### PR TITLE
no variable declaration in 'for'

### DIFF
--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -536,7 +536,8 @@ static int on_client_hello(ptls_t *tls, uint16_t *sign_algorithm,
         return PTLS_ALERT_HANDSHAKE_FAILURE;
 
     if (server_name.base != NULL) {
-        for (size_t i = 0; i != ctx->servers.count; ++i) {
+        size_t i;
+        for (i = 0; i != ctx->servers.count; ++i) {
             sctx = ctx->servers.entries[i];
             if (ascii_streq_caseless(server_name, sctx->name) &&
                 (*sign_algorithm = select_compatible_signature_algorithm(sctx->sign_ctx, signature_algorithms,


### PR DESCRIPTION
This is same as 7c71ebc3ec81502d1e941f94debb08ad13fdb70e.