### PR TITLE
Avoid arithmetic operator for void pointer

### DIFF
--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -413,7 +413,7 @@ static int aead_do_decrypt(ptls_aead_context_t *ctx, void *_output, size_t *outl
         return PTLS_ERROR_LIBRARY;
     *outlen += blocklen;
     if (!EVP_CIPHER_CTX_ctrl(crypto_ctx->ctx, EVP_CTRL_GCM_SET_TAG, (int)crypto_ctx->tag_size,
-                             (void *)(input + inlen - crypto_ctx->tag_size)))
+                             (void *)((uint8_t *)input + inlen - crypto_ctx->tag_size)))
         return PTLS_ERROR_LIBRARY;
     if (!EVP_DecryptFinal_ex(crypto_ctx->ctx, output + *outlen, &blocklen))
         return PTLS_ALERT_BAD_RECORD_MAC;

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -1599,7 +1599,7 @@ int ptls_hkdf_expand(ptls_hash_algorithm_t *algo, void *output, size_t outlen, p
         size_t off_start = i * algo->digest_size, off_end = off_start + algo->digest_size;
         if (off_end > outlen)
             off_end = outlen;
-        memcpy(output + off_start, digest, off_end - off_start);
+        memcpy((uint8_t *)output + off_start, digest, off_end - off_start);
     }
 
     if (hmac != NULL)


### PR DESCRIPTION
Some compile(ex Visual Studio C++ compiler) does not allow it.