### PR TITLE
move to draft-17

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ picotls
 
 Picotls is a [TLS 1.3](https://tlswg.github.io/tls13-spec/) implementation written in C.
 
-At the moment, the library implements Draft 16 of the specification (1-RTT ECDH + server-certificate + AES128-GCM only).
+At the moment, the library implements Draft 17 of the specification (1-RTT ECDH + server-certificate + AES128-GCM only).
 
 Primary goal of the project is to create a fast, tiny TLS 1.3 implementation that can be used with the HTTP/2 protocol stack and possibly the upcoming QUIC stack of the [H2O HTTP/2 server](https://h2o.examp1e.net).
 

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -76,8 +76,6 @@
 #define PTLS_DEBUGF(...)
 #endif
 
-#define POST16 0
-
 struct st_ptls_protection_context_t {
     uint8_t secret[PTLS_MAX_DIGEST_SIZE];
     ptls_aead_context_t *aead;
@@ -870,10 +868,8 @@ static int client_handle_certificate(ptls_t *tls, ptls_iovec_t message)
                     certs[num_certs++] = ptls_iovec_init(src, end - src);
                 src = end;
             });
-#if POST16
             uint16_t type;
             decode_open_extensions(src, end, &type, { src = end; });
-#endif
         } while (src != end);
     });
 
@@ -1287,9 +1283,7 @@ static int server_handle_hello(ptls_t *tls, ptls_buffer_t *sendbuf, ptls_iovec_t
                 size_t i;
                 for (i = 0; i != num_certs; ++i) {
                     buffer_push_block(sendbuf, 3, { buffer_pushv(sendbuf, certs[i].base, certs[i].len); });
-#if POST16
                     buffer_push_block(sendbuf, 2, {}); /* extensions */
-#endif
                 }
             });
         });

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -60,7 +60,7 @@
 #define PTLS_EXTENSION_TYPE_SUPPORTED_VERSIONS 43
 #define PTLS_EXTENSION_TYPE_COOKIE 44
 
-#define PTLS_PROTOCOL_VERSION_DRAFT16 0x7f10
+#define PTLS_PROTOCOL_VERSION_DRAFT17 0x7f11
 
 #define PTLS_ALERT_LEVEL_WARNING 1
 #define PTLS_ALERT_LEVEL_FATAL 2
@@ -654,7 +654,7 @@ static int send_client_hello(ptls_t *tls, ptls_buffer_t *sendbuf)
         /* extensions */
         buffer_push_block(sendbuf, 2, {
             buffer_push_extension(sendbuf, PTLS_EXTENSION_TYPE_SUPPORTED_VERSIONS,
-                                  { buffer_push_block(sendbuf, 1, { buffer_push16(sendbuf, PTLS_PROTOCOL_VERSION_DRAFT16); }); });
+                                  { buffer_push_block(sendbuf, 1, { buffer_push16(sendbuf, PTLS_PROTOCOL_VERSION_DRAFT17); }); });
             buffer_push_extension(sendbuf, PTLS_EXTENSION_TYPE_SIGNATURE_ALGORITHMS, {
                 buffer_push_block(sendbuf, 2, {
                     buffer_push16(sendbuf, PTLS_SIGNATURE_RSA_PSS_SHA256);
@@ -720,7 +720,7 @@ static int decode_server_hello(ptls_t *tls, struct st_ptls_server_hello_t *sh, c
         uint16_t protver;
         if ((ret = decode16(&protver, &src, end)) != 0)
             goto Exit;
-        if (protver != PTLS_PROTOCOL_VERSION_DRAFT16) {
+        if (protver != PTLS_PROTOCOL_VERSION_DRAFT17) {
             ret = PTLS_ALERT_HANDSHAKE_FAILURE;
             goto Exit;
         }
@@ -1140,7 +1140,7 @@ static int decode_client_hello(ptls_t *tls, struct st_ptls_client_hello_t *ch, c
                     uint16_t v;
                     if ((ret = decode16(&v, &src, end)) != 0)
                         goto Exit;
-                    if (ch->selected_version == 0 && v == PTLS_PROTOCOL_VERSION_DRAFT16)
+                    if (ch->selected_version == 0 && v == PTLS_PROTOCOL_VERSION_DRAFT17)
                         ch->selected_version = v;
                 } while (src != end);
             });
@@ -1159,7 +1159,7 @@ static int decode_client_hello(ptls_t *tls, struct st_ptls_client_hello_t *ch, c
 
     /* check if client hello make sense */
     switch (ch->selected_version) {
-    case PTLS_PROTOCOL_VERSION_DRAFT16:
+    case PTLS_PROTOCOL_VERSION_DRAFT17:
         if (!(ch->compression_methods.count == 1 && ch->compression_methods.ids[0] == 0)) {
             ret = PTLS_ALERT_ILLEGAL_PARAMETER;
             goto Exit;
@@ -1202,7 +1202,7 @@ static int server_handle_hello(ptls_t *tls, ptls_buffer_t *sendbuf, ptls_iovec_t
     if (ch.key_share.algorithm == &key_exchange_no_match) {
         if (ch.negotiated_group != NULL) {
             buffer_push_handshake(sendbuf, NULL, PTLS_HANDSHAKE_TYPE_HELLO_RETRY_REQUEST, {
-                buffer_push16(sendbuf, PTLS_PROTOCOL_VERSION_DRAFT16);
+                buffer_push16(sendbuf, PTLS_PROTOCOL_VERSION_DRAFT17);
                 buffer_push_block(sendbuf, 2, {
                     buffer_push_extension(sendbuf, PTLS_EXTENSION_TYPE_KEY_SHARE,
                                           { buffer_push16(sendbuf, ch.negotiated_group->id); });
@@ -1237,7 +1237,7 @@ static int server_handle_hello(ptls_t *tls, ptls_buffer_t *sendbuf, ptls_iovec_t
 
     /* send ServerHello */
     buffer_push_handshake(sendbuf, tls->key_schedule, PTLS_HANDSHAKE_TYPE_SERVER_HELLO, {
-        buffer_push16(sendbuf, PTLS_PROTOCOL_VERSION_DRAFT16);
+        buffer_push16(sendbuf, PTLS_PROTOCOL_VERSION_DRAFT17);
         if ((ret = ptls_buffer_reserve(sendbuf, PTLS_HELLO_RANDOM_SIZE)) != 0)
             goto Exit;
         tls->crypto->random_bytes(sendbuf->base + sendbuf->off, PTLS_HELLO_RANDOM_SIZE);


### PR DESCRIPTION
Among the wire-level changes, picotls (at the moment) is affected by:
* [x] Remove redundant labels for traffic key derivation
* [x] Move SCT and OCSP into Certificate.extensions

picotls is unaffected by the following changes, since it does not (yet) implement the features being mentioned:

* Remove the 0-RTT Finished, resumption_context, and replace with a psk_binder field in the PSK itself
* Restructure PSK key exchange negotiation modes
* Add max_early_data_size field to TicketEarlyDataInfo
* Add a 0-RTT exporter and change the transcript for the regular exporter
* Merge TicketExtensions and Extensions registry. Changes ticket_early_data_info code point
* Replace Client.key_shares in response to HRR
* Harmonize requirements about cipher suite matching: for resumption you need to match KDF but for 0-RTT you need whole cipher suite. This allows PSKs to actually negotiate cipher suites.