### PR TITLE
Relax the compiler requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ PROJECT(picotls)
 
 FIND_PACKAGE(PkgConfig REQUIRED)
 
-SET(CMAKE_C_FLAGS "-std=gnu99 -Wall -O2 -g ${CC_WARNING_FLAGS} ${CMAKE_C_FLAGS}")
+SET(CMAKE_C_FLAGS "-std=c99 -Wall -O2 -g ${CC_WARNING_FLAGS} ${CMAKE_C_FLAGS}")
 INCLUDE_DIRECTORIES(${OPENSSL_INCLUDE_DIR} deps/cifra/src/ext deps/cifra/src deps/micro-ecc deps/picotest include)
 SET(MINICRYPTO_LIBRARY_FILES
     deps/micro-ecc/uECC.c

--- a/deps/cifra/src/curve25519.tweetnacl.c
+++ b/deps/cifra/src/curve25519.tweetnacl.c
@@ -38,15 +38,17 @@ static const gf gf0,
 
 static void set25519(gf r, const gf a)
 {
-  for (size_t i = 0; i < 16; i++)
+  size_t i;
+  for (i = 0; i < 16; i++)
     r[i] = a[i];
 }
 
 static void car25519(gf o)
 {
   int64_t c;
+  size_t i;
 
-  for (size_t i = 0; i < 16; i++)
+  for (i = 0; i < 16; i++)
   {
     o[i] += (1LL << 16);
     c = o[i] >> 16;
@@ -58,7 +60,8 @@ static void car25519(gf o)
 static void sel25519(gf p, gf q, int b)
 {
   int64_t tmp, mask = ~(b-1);
-  for (size_t i = 0; i < 16; i++)
+  size_t i;
+  for (i = 0; i < 16; i++)
   {
     tmp = mask & (p[i] ^ q[i]);
     p[i] ^= tmp;
@@ -68,6 +71,7 @@ static void sel25519(gf p, gf q, int b)
 
 static void pack25519(uint8_t out[32], const gf n)
 {
+  size_t i, j;
   int b;
   gf m, t;
   set25519(t, n);
@@ -75,10 +79,10 @@ static void pack25519(uint8_t out[32], const gf n)
   car25519(t);
   car25519(t);
   
-  for(size_t j = 0; j < 2; j++)
+  for(j = 0; j < 2; j++)
   {
     m[0] = t[0] - 0xffed;
-    for (size_t i = 1; i < 15; i++)
+    for (i = 1; i < 15; i++)
     {
       m[i] = t[i] - 0xffff - ((m[i - 1] >> 16) & 1);
       m[i - 1] &= 0xffff;
@@ -89,7 +93,7 @@ static void pack25519(uint8_t out[32], const gf n)
     sel25519(t, m, 1 - b);
   }
 
-  for (size_t i = 0; i < 16; i++)
+  for (i = 0; i < 16; i++)
   {
     out[2 * i] = t[i] & 0xff;
     out[2 * i + 1] = t[i] >> 8;
@@ -100,38 +104,42 @@ static void pack25519(uint8_t out[32], const gf n)
 
 static void unpack25519(gf o, const uint8_t *n)
 {
-  for (size_t i = 0; i < 16; i++)
+  size_t i;
+  for (i = 0; i < 16; i++)
     o[i] = n[2 * i] + ((int64_t) n[2 * i + 1] << 8);
   o[15] &= 0x7fff;
 }
 
 static void add(gf o, const gf a, const gf b)
 {
-  for (size_t i = 0; i < 16; i++)
+  size_t i;
+  for (i = 0; i < 16; i++)
     o[i] = a[i] + b[i];
 }
 
 static void sub(gf o, const gf a, const gf b)
 {
-  for (size_t i = 0; i < 16; i++)
+  size_t i;
+  for (i = 0; i < 16; i++)
     o[i] = a[i] - b[i];
 }
 
 static void mul(gf o, const gf a, const gf b)
 {
   int64_t t[31];
+  size_t i, j;
 
-  for (size_t i = 0; i < 31; i++)
+  for (i = 0; i < 31; i++)
     t[i] = 0;
 
-  for (size_t i = 0; i < 16; i++)
-    for (size_t j = 0; j < 16; j++)
+  for (i = 0; i < 16; i++)
+    for (j = 0; j < 16; j++)
       t[i + j] += a[i] * b[j];
 
-  for (size_t i = 0; i < 15; i++)
+  for (i = 0; i < 15; i++)
     t[i] += 38 * t[i + 16];
 
-  for (size_t i = 0; i < 16; i++)
+  for (i = 0; i < 16; i++)
     o[i] = t[i];
 
   car25519(o);
@@ -146,17 +154,18 @@ static void sqr(gf o, const gf a)
 static void inv25519(gf o, const gf i)
 {
   gf c;
-  for (int a = 0; a < 16; a++)
+  int a;
+  for (a = 0; a < 16; a++)
     c[a] = i[a];
   
-  for (int a = 253; a >= 0; a--)
+  for (a = 253; a >= 0; a--)
   {
     sqr(c, c);
     if(a != 2 && a != 4)
       mul(c, c, i);
   }
 
-  for (int a = 0; a < 16; a++)
+  for (a = 0; a < 16; a++)
     o[a] = c[a];
 }
 
@@ -167,22 +176,26 @@ void cf_curve25519_mul(uint8_t *q, const uint8_t *n, const uint8_t *p)
   gf x;
   gf a, b, c, d, e, f;
 
-  for (size_t i = 0; i < 31; i++)
+  {
+  size_t i;
+  for (i = 0; i < 31; i++)
     z[i] = n[i];
   z[31] = (n[31] & 127) | 64;
   z[0] &= 248;
   
   unpack25519(x, p);
 
-  for(size_t i = 0; i < 16; i++)
+  for(i = 0; i < 16; i++)
   {
     b[i] = x[i];
     d[i] = a[i] = c[i] = 0;
   }
+  }
 
   a[0] = d[0] = 1;
 
-  for (int i = 254; i >= 0; i--)
+  {int i;
+  for (i = 254; i >= 0; i--)
   {
     int64_t r = (z[i >> 3] >> (i & 7)) & 1;
     sel25519(a, b, r);
@@ -207,6 +220,7 @@ void cf_curve25519_mul(uint8_t *q, const uint8_t *n, const uint8_t *p)
     sqr(b, e);
     sel25519(a, b, r);
     sel25519(c, d, r);
+  }
   }
 
   inv25519(c, c);

--- a/deps/cifra/src/ext/handy.h
+++ b/deps/cifra/src/ext/handy.h
@@ -12,28 +12,8 @@
 /* Evaluates to the number of items in array-type variable arr. */
 #define ARRAYCOUNT(arr) (sizeof arr / sizeof arr[0])
 
-/* Normal MIN/MAX macros.  Evaluate argument expressions only once. */
 #ifndef MIN
-  #define MIN(x, y) \
-    ({ typeof (x) __x = (x); \
-       typeof (y) __y = (y); \
-       __x < __y ? __x : __y; })
-#endif
-#ifndef MAX
-  #define MAX(x, y) \
-    ({ typeof (x) __x = (x); \
-       typeof (y) __y = (y); \
-       __x > __y ? __x : __y; })
-#endif
-
-/* Swap two values.  Uses GCC type inference magic. */
-#ifndef SWAP
-  #define SWAP(x, y) \
-    do { \
-      typeof (x) __tmp = (x); \
-      (x) = (y); \
-      (y) = __tmp; \
-    } while (0)
+# define MIN(x, y) ((x) < (y) ? (x) : (y))
 #endif
 
 /** Stringify its argument. */

--- a/lib/cifra.c
+++ b/lib/cifra.c
@@ -19,6 +19,9 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE 700 /* required for glibc to use getaddrinfo, etc. */
+#endif
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>

--- a/t/cli.c
+++ b/t/cli.c
@@ -19,6 +19,9 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE 700 /* required for glibc to use getaddrinfo, etc. */
+#endif
 #include <arpa/inet.h>
 #include <assert.h>
 #include <errno.h>

--- a/t/minicrypto.c
+++ b/t/minicrypto.c
@@ -19,6 +19,9 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE 700 /* required for glibc to use getaddrinfo, etc. */
+#endif
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
Do not use non-standard expressions (e.g. `typeof`), nor use `for (type ...`.