### PR TITLE
`verify_sign` should free the key

### DIFF
--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -607,6 +607,7 @@ static int verify_sign(void *verify_ctx, ptls_iovec_t data, ptls_iovec_t signatu
 Exit:
     if (ctx != NULL)
         EVP_MD_CTX_destroy(ctx);
+    EVP_PKEY_free(key);
     return ret;
 }
 

--- a/t/openssl.c
+++ b/t/openssl.c
@@ -94,6 +94,7 @@ static void test_rsa_sign(void)
 
     ptls_buffer_init(&sigbuf, sigbuf_small, sizeof(sigbuf_small));
     ok(do_sign(sc->key, &sigbuf, ptls_iovec_init(message, strlen(message)), EVP_sha256()) == 0);
+    EVP_PKEY_up_ref(sc->key);
     ok(verify_sign(sc->key, ptls_iovec_init(message, strlen(message)), ptls_iovec_init(sigbuf.base, sigbuf.off)) == 0);
 
     ptls_buffer_dispose(&sigbuf);
@@ -117,6 +118,7 @@ static void test_ecdsa_sign(void)
 
     ptls_buffer_init(&sigbuf, sigbuf_small, sizeof(sigbuf_small));
     ok(do_sign(pkey, &sigbuf, ptls_iovec_init(message, strlen(message)), EVP_sha256()) == 0);
+    EVP_PKEY_up_ref(pkey);
     ok(verify_sign(pkey, ptls_iovec_init(message, strlen(message)), ptls_iovec_init(sigbuf.base, sigbuf.off)) == 0);
 
     ptls_buffer_dispose(&sigbuf);


### PR DESCRIPTION
 as specified in the doc-comment of verify_certificate