### PR TITLE
Suppress warnings in curve25519.tweetnacl.c

### DIFF
--- a/deps/cifra/src/curve25519.tweetnacl.c
+++ b/deps/cifra/src/curve25519.tweetnacl.c
@@ -57,7 +57,7 @@ static void car25519(gf o)
   }
 }
 
-static void sel25519(gf p, gf q, int b)
+static void sel25519(gf p, gf q, int64_t b)
 {
   int64_t tmp, mask = ~(b-1);
   size_t i;
@@ -96,7 +96,7 @@ static void pack25519(uint8_t out[32], const gf n)
   for (i = 0; i < 16; i++)
   {
     out[2 * i] = t[i] & 0xff;
-    out[2 * i + 1] = t[i] >> 8;
+    out[2 * i + 1] = (uint8_t) (t[i] >> 8);
   }
 }
 


### PR DESCRIPTION
The changes ought to be pretty small. There does not appear to be any effect on test. But look at the change in the function sel2119. It was previously:

> static void sel25519(gf p, gf q, int b)
> {
>    int64_t tmp, mask = ~(b-1);

That is, the argument "b" was declared as int and used as int64. This cannot be right, since the definition of int can vary with the machine architecture. I changed that to:

> static void sel25519(gf p, gf q, int64_t b)
> {
>    int64_t tmp, mask = ~(b-1);

This suppresses the warning. I hope that it respects the original intent.