### PR TITLE
Fixing the cookies decoding issue in HRR parsing.

### DIFF
--- a/deps/cifra/src/curve25519.tweetnacl.c
+++ b/deps/cifra/src/curve25519.tweetnacl.c
@@ -57,7 +57,7 @@ static void car25519(gf o)
   }
 }
 
-static void sel25519(gf p, gf q, int b)
+static void sel25519(gf p, gf q, int64_t b)
 {
   int64_t tmp, mask = ~(b-1);
   size_t i;
@@ -96,7 +96,7 @@ static void pack25519(uint8_t out[32], const gf n)
   for (i = 0; i < 16; i++)
   {
     out[2 * i] = t[i] & 0xff;
-    out[2 * i + 1] = t[i] >> 8;
+    out[2 * i + 1] = (uint8_t) (t[i] >> 8);
   }
 }
 

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -1334,7 +1334,7 @@ static int client_handle_hello_retry_request(ptls_t *tls, ptls_buffer_t *sendbuf
         case PTLS_EXTENSION_TYPE_COOKIE:
             ptls_decode_block(src, end, 2, {
                 if (src == end) {
-					ret = PTLS_ALERT_DECODE_ERROR;
+                    ret = PTLS_ALERT_DECODE_ERROR;
                     goto Exit;
                 }
                 cookie = ptls_iovec_init(src, end - src);

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -1334,7 +1334,7 @@ static int client_handle_hello_retry_request(ptls_t *tls, ptls_buffer_t *sendbuf
         case PTLS_EXTENSION_TYPE_COOKIE:
             ptls_decode_block(src, end, 2, {
                 if (src == end) {
-                    ret = PTLS_ALERT_DECODE_ERROR;
+					ret = PTLS_ALERT_DECODE_ERROR;
                     goto Exit;
                 }
                 cookie = ptls_iovec_init(src, end - src);

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -1338,7 +1338,7 @@ static int client_handle_hello_retry_request(ptls_t *tls, ptls_buffer_t *sendbuf
                     goto Exit;
                 }
                 cookie = ptls_iovec_init(src, end - src);
-                end = src;
+                src = end;
             });
             break;
         }


### PR DESCRIPTION
There was a typo. A silly typo. "end = src" instead of "src = end". But the macro expansion thing is really confusing, and it took me some time to find it.