### PR TITLE
Add a -i option to cli

### DIFF
--- a/t/cli.c
+++ b/t/cli.c
@@ -26,12 +26,14 @@
 #include <arpa/inet.h>
 #include <assert.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <getopt.h>
 #include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/select.h>
 #include <sys/socket.h>
+#include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
 #include <openssl/err.h>
@@ -137,21 +139,28 @@ Exit:
     return ret;
 }
 
-static int handle_connection(int fd, ptls_context_t *ctx, const char *server_name, ptls_handshake_properties_t *hsprop)
+static int handle_connection(int fd, ptls_context_t *ctx, const char *server_name,
+                             const char *input_file, ptls_handshake_properties_t *hsprop)
 {
     ptls_t *tls = ptls_new(ctx, server_name == NULL);
     uint8_t rbuf[1024], wbuf_small[1024], early_data[1024];
     ptls_buffer_t wbuf;
-    int stdin_closed = 0, ret;
+    int input_closed = 0, ret;
     size_t early_data_size = 0, roff;
     ssize_t rret;
+    int inputfd = 0, maxfd = fd + 1;
+
+    if (input_file != NULL) {
+      inputfd = open(input_file, O_RDONLY);
+      if (inputfd >= maxfd) maxfd = inputfd + 1;
+    }
 
     if (server_name != NULL)
         ptls_set_server_name(tls, server_name, 0);
 
     if (server_name != NULL && hsprop->client.max_early_data_size != NULL) {
         /* using early data */
-        if ((rret = read(0, early_data, sizeof(early_data))) > 0)
+        if ((rret = read(inputfd, early_data, sizeof(early_data))) > 0)
             early_data_size = rret;
     }
 
@@ -183,19 +192,24 @@ static int handle_connection(int fd, ptls_context_t *ctx, const char *server_nam
 
         /* wait for either of STDIN or read-side of the socket to become available */
         fd_set readfds;
+        fd_set exceptfds;
         FD_ZERO(&readfds);
-        if (!stdin_closed)
-            FD_SET(0, &readfds);
+        FD_ZERO(&exceptfds);
+        if (!input_closed) {
+            FD_SET(inputfd, &readfds);
+            FD_SET(inputfd, &exceptfds);
+        }
         FD_SET(fd, &readfds);
-        if (select(fd + 1, &readfds, NULL, NULL, NULL) <= 0)
+        FD_SET(fd, &exceptfds);
+        if (select(maxfd, &readfds, NULL, &exceptfds, NULL) <= 0)
             continue;
 
-        if (FD_ISSET(0, &readfds)) {
+        if (FD_ISSET(inputfd, &readfds) || FD_ISSET(inputfd, &exceptfds)) {
             /* read from stdin, encrypt and send */
-            while ((rret = read(0, rbuf, sizeof(rbuf))) == -1 && errno == EINTR)
+            while ((rret = read(inputfd, rbuf, sizeof(rbuf))) == -1 && errno == EINTR)
                 ;
             if (rret == 0)
-                stdin_closed = 1;
+                input_closed = 1;
             if ((ret = ptls_send(tls, &wbuf, rbuf, rret)) != 0) {
                 fprintf(stderr, "ptls_send:%d\n", ret);
                 goto Exit;
@@ -205,7 +219,7 @@ static int handle_connection(int fd, ptls_context_t *ctx, const char *server_nam
             wbuf.off = 0;
         }
 
-        if (FD_ISSET(fd, &readfds)) {
+        if (FD_ISSET(fd, &readfds) || FD_ISSET(fd, &exceptfds)) {
             /* read from socket, decrypt and print */
             while ((rret = read(fd, rbuf, sizeof(rbuf))) == -1 && errno == EINTR)
                 ;
@@ -222,7 +236,8 @@ Exit:
     return 0;
 }
 
-static int run_server(struct sockaddr *sa, socklen_t salen, ptls_context_t *ctx, ptls_handshake_properties_t *hsprop)
+static int run_server(struct sockaddr *sa, socklen_t salen, ptls_context_t *ctx,
+                      const char *input_file, ptls_handshake_properties_t *hsprop)
 {
     int listen_fd, conn_fd, on = 1;
 
@@ -245,7 +260,7 @@ static int run_server(struct sockaddr *sa, socklen_t salen, ptls_context_t *ctx,
 
     while (1) {
         if ((conn_fd = accept(listen_fd, NULL, 0)) != -1) {
-            handle_connection(conn_fd, ctx, NULL, hsprop);
+            handle_connection(conn_fd, ctx, NULL, input_file, hsprop);
             close(conn_fd);
         }
     }
@@ -254,7 +269,7 @@ static int run_server(struct sockaddr *sa, socklen_t salen, ptls_context_t *ctx,
 }
 
 static int run_client(struct sockaddr *sa, socklen_t salen, ptls_context_t *ctx, const char *server_name,
-                      ptls_handshake_properties_t *hsprop)
+                      const char *input_file, ptls_handshake_properties_t *hsprop)
 {
     int fd;
 
@@ -267,7 +282,7 @@ static int run_client(struct sockaddr *sa, socklen_t salen, ptls_context_t *ctx,
         return 1;
     }
 
-    return handle_connection(fd, ctx, server_name, hsprop);
+    return handle_connection(fd, ctx, server_name, input_file, hsprop);
 }
 
 static void usage(const char *cmd)
@@ -278,6 +293,7 @@ static void usage(const char *cmd)
            "  -4                   force IPv4\n"
            "  -6                   force IPv6\n"
            "  -c certificate-file\n"
+           "  -i file              a file to read from and send to the peer (default: stdin)\n"
            "  -k key-file          specifies the credentials to be used for running the\n"
            "                       server. If omitted, the command runs as a client.\n"
            "  -l log-file          file to log traffic secrets\n"
@@ -304,13 +320,13 @@ int main(int argc, char **argv)
 
     ptls_context_t ctx = {ptls_openssl_random_bytes, ptls_openssl_key_exchanges, ptls_openssl_cipher_suites};
     ptls_handshake_properties_t hsprop = {{{{NULL}}}};
-    const char *host, *port;
+    const char *host, *port, *file = NULL;
     int use_early_data = 0, ch;
     struct sockaddr_storage sa;
     socklen_t salen;
     int family = 0;
 
-    while ((ch = getopt(argc, argv, "46c:k:nes:l:vh")) != -1) {
+    while ((ch = getopt(argc, argv, "46c:i:k:nes:l:vh")) != -1) {
         switch (ch) {
         case '4':
             family = AF_INET;
@@ -320,6 +336,9 @@ int main(int argc, char **argv)
             break;
         case 'c':
             load_certificate_chain(&ctx, optarg);
+            break;
+        case 'i':
+            file = optarg;
             break;
         case 'k':
             load_private_key(&ctx, optarg);
@@ -371,8 +390,8 @@ int main(int argc, char **argv)
         exit(1);
 
     if (ctx.certificates.count != 0) {
-        return run_server((struct sockaddr *)&sa, salen, &ctx, &hsprop);
+        return run_server((struct sockaddr *)&sa, salen, &ctx, file, &hsprop);
     } else {
-        return run_client((struct sockaddr *)&sa, salen, &ctx, host, &hsprop);
+        return run_client((struct sockaddr *)&sa, salen, &ctx, host, file, &hsprop);
     }
 }


### PR DESCRIPTION
This causes cli to read from a file rather than stdin.  In a loop (which is often the case for a server), this allows it to generate the same response multiple times.