### PR TITLE
EOED is not part of the context when calculating traffic secret

### DIFF
--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -2649,9 +2649,9 @@ static int server_handle_hello(ptls_t *tls, ptls_buffer_t *sendbuf, ptls_iovec_t
 
     assert(tls->key_schedule->generation == 2);
     if ((ret = key_schedule_extract(tls->key_schedule, ptls_iovec_init(NULL, 0))) != 0)
-        return ret;
+        goto Exit;
     if ((ret = setup_traffic_protection(tls, tls->cipher_suite, 1, "s ap traffic", "SERVER_TRAFFIC_SECRET_0")) != 0)
-        return ret;
+        goto Exit;
     if ((ret = derive_exporter_secret(tls, 0)) != 0)
         goto Exit;
     if ((ret = derive_secret(tls->key_schedule, tls->server.pending_traffic_secret, "c ap traffic")) != 0)

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -1740,9 +1740,9 @@ static int client_handle_finished(ptls_t *tls, ptls_buffer_t *sendbuf, ptls_iove
         goto Exit;
     if ((ret = setup_traffic_protection(tls, tls->cipher_suite, 0, "s ap traffic", "SERVER_TRAFFIC_SECRET_0")) != 0)
         goto Exit;
-    if ((ret = derive_exporter_secret(tls, 0)) != 0)
-        goto Exit;
     if ((ret = derive_secret(tls->key_schedule, send_secret, "c ap traffic")) != 0)
+        goto Exit;
+    if ((ret = derive_exporter_secret(tls, 0)) != 0)
         goto Exit;
 
     /* if sending early data, emit EOED and commision the client handshake traffic secret */
@@ -2652,9 +2652,9 @@ static int server_handle_hello(ptls_t *tls, ptls_buffer_t *sendbuf, ptls_iovec_t
         goto Exit;
     if ((ret = setup_traffic_protection(tls, tls->cipher_suite, 1, "s ap traffic", "SERVER_TRAFFIC_SECRET_0")) != 0)
         goto Exit;
-    if ((ret = derive_exporter_secret(tls, 0)) != 0)
-        goto Exit;
     if ((ret = derive_secret(tls->key_schedule, tls->server.pending_traffic_secret, "c ap traffic")) != 0)
+        goto Exit;
+    if ((ret = derive_exporter_secret(tls, 0)) != 0)
         goto Exit;
 
     tls->state = tls->early_data != NULL ? PTLS_STATE_SERVER_EXPECT_END_OF_EARLY_DATA : PTLS_STATE_SERVER_EXPECT_FINISHED;

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -722,6 +722,8 @@ static int derive_secret(struct st_ptls_key_schedule_t *sched, void *secret, con
                                      ptls_iovec_init(sched->secret, sched->algo->digest_size), label,
                                      ptls_iovec_init(hash_value, sched->algo->digest_size));
 
+    PTLS_DEBUGF("%s: (label=%s, hash=%02x%02x) => %02x%02x\n", __FUNCTION__, label, hash_value[0], hash_value[1],
+                ((uint8_t *)secret)[0], ((uint8_t *)secret)[1]);
     ptls_clear_memory(hash_value, sizeof(hash_value));
     return ret;
 }
@@ -870,7 +872,7 @@ static int setup_traffic_protection(ptls_t *tls, ptls_cipher_suite_t *cs, int is
     if (tls->ctx->log_secret != NULL)
         tls->ctx->log_secret->cb(tls->ctx->log_secret, tls, log_label,
                                  ptls_iovec_init(ctx->secret, tls->key_schedule->algo->digest_size));
-    PTLS_DEBUGF("[%s] %02x%02x,%02x%02x\n", secret_label, (unsigned)ctx->secret[0], (unsigned)ctx->secret[1],
+    PTLS_DEBUGF("[%s] %02x%02x,%02x%02x\n", log_label, (unsigned)ctx->secret[0], (unsigned)ctx->secret[1],
                 (unsigned)ctx->aead->static_iv[0], (unsigned)ctx->aead->static_iv[1]);
 
     return 0;


### PR DESCRIPTION
On server-side, picotls has been calculating the client application traffic secret when it receives ClientFinished. This has worked fine until draft-18.

However, in draft-21, EOED became a handshake message. Therefore the secret needs to be calculated before updating the hash with the received EOED.

This PR moves the calculation to when the server application traffic secret is calculated, achieving symmetry with the client-side code that also calculate the two secrets at the same time.