### PR TITLE
use callback for getting time

### DIFF
--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -2787,6 +2787,8 @@ ptls_t *ptls_new(ptls_context_t *ctx, int is_server)
 {
     ptls_t *tls;
 
+    assert(ctx->get_time != NULL && "please set ctx->get_time to `&ptls_get_time`; see #92");
+
     if ((tls = malloc(sizeof(*tls))) == NULL)
         return NULL;
 

--- a/t/cli.c
+++ b/t/cli.c
@@ -309,7 +309,7 @@ int main(int argc, char **argv)
     ENGINE_register_all_digests();
 #endif
 
-    ptls_context_t ctx = {ptls_openssl_random_bytes, ptls_openssl_key_exchanges, ptls_openssl_cipher_suites};
+    ptls_context_t ctx = {ptls_openssl_random_bytes, &ptls_get_time, ptls_openssl_key_exchanges, ptls_openssl_cipher_suites};
     ptls_handshake_properties_t hsprop = {{{{NULL}}}};
     const char *host, *port, *file = NULL;
     int use_early_data = 0, ch;

--- a/t/minicrypto.c
+++ b/t/minicrypto.c
@@ -64,7 +64,7 @@ static void test_secp256r1_sign(void)
 static void test_hrr(void)
 {
     ptls_key_exchange_algorithm_t *client_keyex[] = {&ptls_minicrypto_x25519, &ptls_minicrypto_secp256r1, NULL};
-    ptls_context_t client_ctx = {ptls_minicrypto_random_bytes, client_keyex, ptls_minicrypto_cipher_suites};
+    ptls_context_t client_ctx = {ptls_minicrypto_random_bytes, &ptls_get_time, client_keyex, ptls_minicrypto_cipher_suites};
     ptls_t *client, *server;
     ptls_buffer_t cbuf, sbuf, decbuf;
     uint8_t cbuf_small[16384], sbuf_small[16384], decbuf_small[16384];
@@ -147,9 +147,14 @@ int main(int argc, char **argv)
     ptls_minicrypto_init_secp256r1sha256_sign_certificate(&sign_certificate,
                                                           ptls_iovec_init(SECP256R1_PRIVATE_KEY, SECP256R1_PRIVATE_KEY_SIZE));
 
-    ptls_context_t ctxbuf = {
-        ptls_minicrypto_random_bytes, ptls_minicrypto_key_exchanges, ptls_minicrypto_cipher_suites, {&cert, 1}, NULL, NULL,
-        &sign_certificate.super};
+    ptls_context_t ctxbuf = {ptls_minicrypto_random_bytes,
+                             &ptls_get_time,
+                             ptls_minicrypto_key_exchanges,
+                             ptls_minicrypto_cipher_suites,
+                             {&cert, 1},
+                             NULL,
+                             NULL,
+                             &sign_certificate.super};
     ctx = ctx_peer = &ctxbuf;
 
     subtest("picotls", test_picotls);

--- a/t/openssl.c
+++ b/t/openssl.c
@@ -171,9 +171,15 @@ int main(int argc, char **argv)
     setup_certificate(&cert);
     setup_sign_certificate(&openssl_sign_certificate);
     ptls_openssl_init_verify_certificate(&openssl_verify_certificate, NULL);
-    ptls_context_t openssl_ctx = {
-        ptls_openssl_random_bytes,       ptls_openssl_key_exchanges,       ptls_openssl_cipher_suites, {&cert, 1}, NULL, NULL,
-        &openssl_sign_certificate.super, &openssl_verify_certificate.super};
+    ptls_context_t openssl_ctx = {ptls_openssl_random_bytes,
+                                  &ptls_get_time,
+                                  ptls_openssl_key_exchanges,
+                                  ptls_openssl_cipher_suites,
+                                  {&cert, 1},
+                                  NULL,
+                                  NULL,
+                                  &openssl_sign_certificate.super,
+                                  &openssl_verify_certificate.super};
     ctx = ctx_peer = &openssl_ctx;
 
     subtest("ecdh-key-exchange", test_ecdh_key_exchange);
@@ -186,6 +192,7 @@ int main(int argc, char **argv)
     ptls_minicrypto_init_secp256r1sha256_sign_certificate(
         &minicrypto_sign_certificate, ptls_iovec_init(SECP256R1_PRIVATE_KEY, sizeof(SECP256R1_PRIVATE_KEY) - 1));
     ptls_context_t minicrypto_ctx = {ptls_minicrypto_random_bytes,
+                                     &ptls_get_time,
                                      ptls_minicrypto_key_exchanges,
                                      ptls_minicrypto_cipher_suites,
                                      {&minicrypto_certificate, 1},


### PR DESCRIPTION
Helps testing and also might help portability.

Considering the fact that `random_bytes` is a callback, it makes sense to have `get_time` defined as a callback as well.

Note that this is a compatibility-breaking change. Users would need to adjust how they setup `ptls_context_t`.