### PR TITLE
retain early-exporter-master-secret after handshake

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -710,7 +710,7 @@ int ptls_send_alert(ptls_t *tls, ptls_buffer_t *sendbuf, uint8_t level, uint8_t 
 /**
  *
  */
-int ptls_export_secret(ptls_t *tls, void *output, size_t outlen, const char *label, ptls_iovec_t context_value);
+int ptls_export_secret(ptls_t *tls, void *output, size_t outlen, const char *label, ptls_iovec_t context_value, int is_early);
 /**
  *
  */


### PR DESCRIPTION
and adds `is_early` argument to ptls_exporter_secret so that the value can be used.

fixes #95