### PR TITLE
Fix memleak and potential crash in cli

### DIFF
--- a/include/picotls/pembase64.h
+++ b/include/picotls/pembase64.h
@@ -39,6 +39,6 @@ size_t ptls_base64_howlong(size_t data_length);
 void ptls_base64_decode_init(ptls_base64_decode_state_t *state);
 int ptls_base64_decode(const char *base64_text, ptls_base64_decode_state_t *state, ptls_buffer_t *buf);
 
-int ptls_load_pem_objects(char const *pem_fname, const char *label, ptls_iovec_t **list, size_t list_max, size_t *nb_objects);
+int ptls_load_pem_objects(char const *pem_fname, const char *label, ptls_iovec_t *list, size_t list_max, size_t *nb_objects);
 
 #endif /* PTLS_PEMBASE64_H */

--- a/lib/pembase64.c
+++ b/lib/pembase64.c
@@ -299,7 +299,7 @@ static int ptls_get_pem_object(FILE *F, const char *label, ptls_buffer_t *buf)
     return ret;
 }
 
-int ptls_load_pem_objects(char const *pem_fname, const char *label, ptls_iovec_t **list, size_t list_max, size_t *nb_objects)
+int ptls_load_pem_objects(char const *pem_fname, const char *label, ptls_iovec_t *list, size_t list_max, size_t *nb_objects)
 {
     FILE *F;
     int ret = 0;
@@ -328,8 +328,8 @@ int ptls_load_pem_objects(char const *pem_fname, const char *label, ptls_iovec_t
 
             if (ret == 0) {
                 if (buf.off > 0 && buf.is_allocated) {
-                    list[count]->base = buf.base;
-                    list[count]->len = buf.off;
+                    list[count].base = buf.base;
+                    list[count].len = buf.off;
                     count++;
                 } else {
                     ptls_buffer_dispose(&buf);

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -3561,7 +3561,7 @@ int ptls_load_certificates(ptls_context_t *ctx, char *cert_pem_file)
     if (ctx->certificates.list == NULL) {
         ret = PTLS_ERROR_NO_MEMORY;
     } else {
-        ret = ptls_load_pem_objects(cert_pem_file, "CERTIFICATE", &ctx->certificates.list, PTLS_MAX_CERTS_IN_CONTEXT,
+        ret = ptls_load_pem_objects(cert_pem_file, "CERTIFICATE", ctx->certificates.list, PTLS_MAX_CERTS_IN_CONTEXT,
                                     &ctx->certificates.count);
     }
 

--- a/lib/uecc.c
+++ b/lib/uecc.c
@@ -322,8 +322,7 @@ static int ptls_pem_parse_private_key(char const *pem_fname, ptls_asn1_pkcs8_pri
                                       ptls_minicrypto_log_ctx_t *log_ctx)
 {
     size_t nb_keys = 0;
-    ptls_iovec_t *list = &pkey->vec;
-    int ret = ptls_load_pem_objects(pem_fname, "PRIVATE KEY", &list, 1, &nb_keys);
+    int ret = ptls_load_pem_objects(pem_fname, "PRIVATE KEY", &pkey->vec, 1, &nb_keys);
 
     if (ret == 0) {
         if (nb_keys != 1) {

--- a/picotlsvs/picotlsvs/picotlsvs.c
+++ b/picotlsvs/picotlsvs/picotlsvs.c
@@ -34,7 +34,6 @@ size_t ptls_minicrypto_asn1_decode_private_key(
 int openPemTest(char const * filename)
 {
 	ptls_iovec_t buf = { 0 };
-	ptls_iovec_t * list = &buf;
 	size_t count = 1;
 	size_t fuzz_index = 0;
 	uint8_t original_byte = 0;
@@ -42,7 +41,7 @@ int openPemTest(char const * filename)
 	size_t byte_index = 0;
 	int decode_error;
 
-	int ret = ptls_load_pem_objects(filename, "PRIVATE KEY", &list, 1, &count);
+	int ret = ptls_load_pem_objects(filename, "PRIVATE KEY", &buf, 1, &count);
 
 
 	if (ret == 0)

--- a/t/util.h
+++ b/t/util.h
@@ -39,28 +39,10 @@
 
 static inline void load_certificate_chain(ptls_context_t *ctx, const char *fn)
 {
-    static ptls_iovec_t certs[16];
-    FILE *fp;
-    size_t n = 0;
-    X509 *cert;
-
-    if ((fp = fopen(fn, "rb")) == NULL) {
-        fprintf(stderr, "failed to open file:%s:%s\n", fn, strerror(errno));
+    if (ptls_load_certificates(ctx, (char *)fn) != 0) {
+        fprintf(stderr, "failed to load certificate:%s:%s\n", fn, strerror(errno));
         exit(1);
     }
-    while ((cert = PEM_read_X509(fp, NULL, NULL, NULL)) != NULL) {
-        ptls_iovec_t *dst = certs + n++;
-        dst->len = i2d_X509(cert, &dst->base);
-    }
-    fclose(fp);
-
-    if (n == 0) {
-        fprintf(stderr, "failed to read certificates from file:%s\n", fn);
-        exit(1);
-    }
-
-    ctx->certificates.list = certs;
-    ctx->certificates.count = n;
 }
 
 static inline void load_private_key(ptls_context_t *ctx, const char *fn)


### PR DESCRIPTION
Fix for memleak issue reported in #85 as well as a related issue I found while testing with a certificate which contains multiple entries.