### PR TITLE
accept base-label as an argument

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -727,7 +727,7 @@ int ptls_hkdf_expand(ptls_hash_algorithm_t *hash, void *output, size_t outlen, p
  *
  */
 int ptls_hkdf_expand_label(ptls_hash_algorithm_t *algo, void *output, size_t outlen, ptls_iovec_t secret, const char *label,
-                           ptls_iovec_t hash_value);
+                           ptls_iovec_t hash_value, const char *base_label);
 /**
  * instantiates an AEAD cipher given a secret, which is expanded using hkdf to a set of key and iv
  * @param aead
@@ -736,7 +736,8 @@ int ptls_hkdf_expand_label(ptls_hash_algorithm_t *algo, void *output, size_t out
  * @param secret the secret. The size must be the digest length of the hash algorithm
  * @return pointer to an AEAD context if successful, otherwise NULL
  */
-ptls_aead_context_t *ptls_aead_new(ptls_aead_algorithm_t *aead, ptls_hash_algorithm_t *hash, int is_enc, const void *secret);
+ptls_aead_context_t *ptls_aead_new(ptls_aead_algorithm_t *aead, ptls_hash_algorithm_t *hash, int is_enc, const void *secret,
+                                   const char *base_label);
 /**
  * destroys an AEAD cipher context
  */

--- a/t/picotls.c
+++ b/t/picotls.c
@@ -95,7 +95,7 @@ static void test_ciphersuite(ptls_cipher_suite_t *cs1, ptls_cipher_suite_t *cs2)
     size_t enc1len, enc2len, dec1len, dec2len;
 
     /* encrypt */
-    c = ptls_aead_new(cs1->aead, cs1->hash, 1, traffic_secret);
+    c = ptls_aead_new(cs1->aead, cs1->hash, 1, traffic_secret, NULL);
     assert(c != NULL);
     ptls_aead_encrypt_init(c, 0, NULL, 0);
     enc1len = ptls_aead_encrypt_update(c, enc1, src1, strlen(src1));
@@ -105,7 +105,7 @@ static void test_ciphersuite(ptls_cipher_suite_t *cs1, ptls_cipher_suite_t *cs2)
     enc2len += ptls_aead_encrypt_final(c, enc2 + enc2len);
     ptls_aead_free(c);
 
-    c = ptls_aead_new(cs2->aead, cs2->hash, 0, traffic_secret);
+    c = ptls_aead_new(cs2->aead, cs2->hash, 0, traffic_secret, NULL);
     assert(c != NULL);
 
     /* decrypt and compare */
@@ -134,7 +134,7 @@ static void test_aad_ciphersuite(ptls_cipher_suite_t *cs1, ptls_cipher_suite_t *
     size_t enclen, declen;
 
     /* encrypt */
-    c = ptls_aead_new(cs1->aead, cs1->hash, 1, traffic_secret);
+    c = ptls_aead_new(cs1->aead, cs1->hash, 1, traffic_secret, NULL);
     assert(c != NULL);
     ptls_aead_encrypt_init(c, 123, aad, strlen(aad));
     enclen = ptls_aead_encrypt_update(c, enc, src, strlen(src));
@@ -142,7 +142,7 @@ static void test_aad_ciphersuite(ptls_cipher_suite_t *cs1, ptls_cipher_suite_t *
     ptls_aead_free(c);
 
     /* decrypt */
-    c = ptls_aead_new(cs2->aead, cs2->hash, 0, traffic_secret);
+    c = ptls_aead_new(cs2->aead, cs2->hash, 0, traffic_secret, NULL);
     assert(c != NULL);
     declen = ptls_aead_decrypt(c, dec, enc, enclen, 123, aad, strlen(aad));
     ok(declen == strlen(src));


### PR DESCRIPTION
Add `base_label` as an optional argument to hkdf wrappers, so that QUIC implementations can specify `QUIC ` as a prefix as opposed to `tls13 `.