### PR TITLE
whether retry should be performed and whether it should be stateless are orthogonal issues

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -472,7 +472,7 @@ typedef struct st_ptls_handshake_properties_t {
              */
             unsigned enforce_retry : 1;
             /**
-             * if retry should be stateless
+             * if retry should be stateless (cookie.key MUST be set when this option is used)
              */
             unsigned retry_uses_cookie : 1;
         } server;

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -334,15 +334,6 @@ PTLS_CALLBACK_TYPE(void, log_secret, ptls_t *tls, const char *label, ptls_iovec_
 PTLS_CALLBACK_TYPE(void, update_open_count, ssize_t delta);
 
 /**
- * when a HRR with cookie should be sent
- */
-typedef enum en_ptls_cookie_send_mode_t {
-    PTLS_COOKIE_SEND_NEVER = 0,
-    PTLS_COOKIE_SEND_ON_HRR,
-    PTLS_COOKIE_SEND_ALWAYS
-} ptls_cookie_send_mode_t;
-
-/**
  * the configuration
  */
 struct st_ptls_context_t {
@@ -475,11 +466,15 @@ typedef struct st_ptls_handshake_properties_t {
                  * additional data to be used for verifying the cookie
                  */
                 ptls_iovec_t additional_data;
-                /**
-                 * when HRR with cookie should be sent
-                 */
-                ptls_cookie_send_mode_t send_mode;
             } cookie;
+            /**
+             * if HRR should always be sent
+             */
+            unsigned enforce_retry : 1;
+            /**
+             * if retry should be stateless
+             */
+            unsigned retry_uses_cookie : 1;
         } server;
     };
     /**

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -2401,7 +2401,6 @@ static int server_handle_hello(ptls_t *tls, ptls_buffer_t *sendbuf, ptls_iovec_t
         goto Exit;
 
     if (!is_second_flight) {
-        ptls_cookie_send_mode_t cookie_mode = properties != NULL ? properties->server.cookie.send_mode : PTLS_COOKIE_SEND_NEVER;
         if (ch.cookie.all.len != 0 && key_share.algorithm != NULL) {
 
             /* use cookie to check the integrity of the handshake, and update the context */
@@ -2426,7 +2425,8 @@ static int server_handle_hello(ptls_t *tls, ptls_buffer_t *sendbuf, ptls_iovec_t
             sendbuf->off = hrr_start;
             is_second_flight = 1;
 
-        } else if ((key_share.algorithm == NULL && ch.psk.identities.count == 0) || cookie_mode == PTLS_COOKIE_SEND_ALWAYS) {
+        } else if ((key_share.algorithm == NULL && ch.psk.identities.count == 0) ||
+                   (properties != NULL && properties->server.enforce_retry)) {
 
             /* send HelloRetryRequest  */
             if (ch.negotiated_groups.base == NULL) {
@@ -2439,56 +2439,51 @@ static int server_handle_hello(ptls_t *tls, ptls_buffer_t *sendbuf, ptls_iovec_t
                 goto Exit;
             key_schedule_update_hash(tls->key_schedule, message.base, message.len);
             assert(tls->key_schedule->generation == 0);
-            /* roll the key schedule if performing a statefull retry */
-            if (cookie_mode == PTLS_COOKIE_SEND_NEVER) {
-                key_schedule_transform_post_ch1hash(tls->key_schedule);
-                key_schedule_extract(tls->key_schedule, ptls_iovec_init(NULL, 0));
-            }
-            /* emit HelloRetryRequest */
-            EMIT_HELLO_RETRY_REQUEST(
-                cookie_mode != PTLS_COOKIE_SEND_NEVER ? NULL : tls->key_schedule,
-                key_share.algorithm != NULL ? NULL : negotiated_group, {
-                    if (cookie_mode != PTLS_COOKIE_SEND_NEVER) {
-                        buffer_push_extension(sendbuf, PTLS_EXTENSION_TYPE_COOKIE, {
+            if (properties != NULL && properties->server.retry_uses_cookie) {
+                /* emit HRR with cookie */
+                EMIT_HELLO_RETRY_REQUEST(NULL, key_share.algorithm != NULL ? NULL : negotiated_group, {
+                    buffer_push_extension(sendbuf, PTLS_EXTENSION_TYPE_COOKIE, {
+                        ptls_buffer_push_block(sendbuf, 2, {
+                            /* push to-be-signed data */
+                            size_t tbs_start = sendbuf->off;
                             ptls_buffer_push_block(sendbuf, 2, {
-                                /* push to-be-signed data */
-                                size_t tbs_start = sendbuf->off;
-                                ptls_buffer_push_block(sendbuf, 2, {
-                                    /* first block of the cookie data is the hash(ch1) */
-                                    ptls_buffer_push_block(sendbuf, 1, {
-                                        size_t sz = tls->cipher_suite->hash->digest_size;
-                                        if ((ret = ptls_buffer_reserve(sendbuf, sz)) != 0)
-                                            goto Exit;
-                                        key_schedule_extract_ch1hash(tls->key_schedule, sendbuf->base + sendbuf->off);
-                                        sendbuf->off += sz;
-                                    });
-                                    /* second is if we have sent key_share extension */
-                                    ptls_buffer_push(sendbuf, key_share.algorithm == NULL);
-                                    /* we can add more data here */
-                                });
-                                size_t tbs_len = sendbuf->off - tbs_start;
-                                /* push the signature */
+                                /* first block of the cookie data is the hash(ch1) */
                                 ptls_buffer_push_block(sendbuf, 1, {
-                                    size_t sz = tls->ctx->cipher_suites[0]->hash->digest_size;
+                                    size_t sz = tls->cipher_suite->hash->digest_size;
                                     if ((ret = ptls_buffer_reserve(sendbuf, sz)) != 0)
                                         goto Exit;
-                                    if ((ret = calc_cookie_signature(tls, properties, negotiated_group,
-                                                                     ptls_iovec_init(sendbuf->base + tbs_start, tbs_len),
-                                                                     sendbuf->base + sendbuf->off)) != 0)
-                                        goto Exit;
+                                    key_schedule_extract_ch1hash(tls->key_schedule, sendbuf->base + sendbuf->off);
                                     sendbuf->off += sz;
                                 });
+                                /* second is if we have sent key_share extension */
+                                ptls_buffer_push(sendbuf, key_share.algorithm == NULL);
+                                /* we can add more data here */
+                            });
+                            size_t tbs_len = sendbuf->off - tbs_start;
+                            /* push the signature */
+                            ptls_buffer_push_block(sendbuf, 1, {
+                                size_t sz = tls->ctx->cipher_suites[0]->hash->digest_size;
+                                if ((ret = ptls_buffer_reserve(sendbuf, sz)) != 0)
+                                    goto Exit;
+                                if ((ret = calc_cookie_signature(tls, properties, negotiated_group,
+                                                                 ptls_iovec_init(sendbuf->base + tbs_start, tbs_len),
+                                                                 sendbuf->base + sendbuf->off)) != 0)
+                                    goto Exit;
+                                sendbuf->off += sz;
                             });
                         });
-                    }
+                    });
                 });
-            if (cookie_mode == PTLS_COOKIE_SEND_NEVER) {
+                ret = PTLS_ERROR_STATELESS_RETRY;
+            } else {
+                /* invoking stateful retry; roll the key schedule and emit HRR */
+                key_schedule_transform_post_ch1hash(tls->key_schedule);
+                key_schedule_extract(tls->key_schedule, ptls_iovec_init(NULL, 0));
+                EMIT_HELLO_RETRY_REQUEST(tls->key_schedule, key_share.algorithm != NULL ? NULL : negotiated_group, {});
                 tls->state = PTLS_STATE_SERVER_EXPECT_SECOND_CLIENT_HELLO;
                 if (ch.psk.early_data_indication)
                     tls->skip_early_data = 1;
                 ret = PTLS_ERROR_IN_PROGRESS;
-            } else {
-                ret = PTLS_ERROR_STATELESS_RETRY;
             }
             goto Exit;
         }

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -2440,7 +2440,7 @@ static int server_handle_hello(ptls_t *tls, ptls_buffer_t *sendbuf, ptls_iovec_t
             key_schedule_update_hash(tls->key_schedule, message.base, message.len);
             assert(tls->key_schedule->generation == 0);
             if (properties != NULL && properties->server.retry_uses_cookie) {
-                /* emit HRR with cookie */
+                /* emit HRR with cookie (note: we MUST omit KeyShare if the client has specified the correct one; see 46554f0) */
                 EMIT_HELLO_RETRY_REQUEST(NULL, key_share.algorithm != NULL ? NULL : negotiated_group, {
                     buffer_push_extension(sendbuf, PTLS_EXTENSION_TYPE_COOKIE, {
                         ptls_buffer_push_block(sendbuf, 2, {

--- a/t/picotls.c
+++ b/t/picotls.c
@@ -530,7 +530,8 @@ static void test_stateless_hrr(void)
 
     server_hs_prop.server.cookie.key = "0123456789abcdef0123456789abcdef";
     server_hs_prop.server.cookie.additional_data = ptls_iovec_init("1.2.3.4:1234", 12);
-    server_hs_prop.server.cookie.send_mode = PTLS_COOKIE_SEND_ALWAYS;
+    server_hs_prop.server.enforce_retry = 1;
+    server_hs_prop.server.retry_uses_cookie = 1;
 
     ptls_buffer_init(&cbuf, "", 0);
     ptls_buffer_init(&sbuf, "", 0);
@@ -624,7 +625,8 @@ static void test_stateless_hrr_aad_change(void)
 
     server_hs_prop.server.cookie.key = "0123456789abcdef0123456789abcdef";
     server_hs_prop.server.cookie.additional_data = ptls_iovec_init("1.2.3.4:1234", 12);
-    server_hs_prop.server.cookie.send_mode = PTLS_COOKIE_SEND_ALWAYS;
+    server_hs_prop.server.enforce_retry = 1;
+    server_hs_prop.server.retry_uses_cookie = 1;
 
     client = stateless_hrr_prepare(&sbuf, &server_hs_prop);
     ptls_buffer_init(&cbuf, "", 0);


### PR DESCRIPTION
In #102, retry and its statefulness became a tri-state option as shown below.
```
/**
 * when a HRR with cookie should be sent
 */
typedef enum en_ptls_cookie_send_mode_t {
    PTLS_COOKIE_SEND_NEVER = 0,
    PTLS_COOKIE_SEND_ON_HRR,
    PTLS_COOKIE_SEND_ALWAYS
} ptls_cookie_send_mode_t;
```

However in hindsight the design is wrong in sense that it does not provide an option to always send a stateful HRR.

The PR address the issue by turning the option into two booleans: `enforce_retry` and `retry_uses_cookie`.

Lastly, the PR updates the tests to cover the matrix of `enforce_retry` x `retry_uses_cookie`.