### PR TITLE
Adds `verify_certificate_ctx` argument for the verify certificate callback

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -361,9 +361,9 @@ PTLS_CALLBACK_TYPE(int, sign_certificate, ptls_t *tls, uint16_t *selected_algori
  * callback that should be used for verifying CertificateVerify. If an error occurs between a successful return from this
  * callback to the invocation of the verify_sign callback, verify_sign is called with both data and sign set to an empty buffer.
  * The implementor of the callback should use that as the opportunity to free any temporary data allocated for the verify_sign
- * callback.
+ * callback. The ctx pointer argument equals the ctx argument given to the ptls_new function.
  */
-PTLS_CALLBACK_TYPE(int, verify_certificate, ptls_t *tls,
+PTLS_CALLBACK_TYPE(int, verify_certificate, void *ctx, ptls_t *tls,
                    int (**verify_sign)(void *verify_ctx, ptls_iovec_t data, ptls_iovec_t sign), void **verify_data,
                    ptls_iovec_t *certs, size_t num_certs);
 /**
@@ -691,13 +691,14 @@ int ptls_decode64(uint64_t *value, const uint8_t **src, const uint8_t *end);
 
 /**
  * create a object to handle new TLS connection. Client-side of a TLS connection is created if server_name is non-NULL. Otherwise,
- * a server-side connection is created.
+ * a server-side connection is created. The verify_certificate_ctx will be given to the verify_certificate callback (can be NULL).
  */
-ptls_t *ptls_new(ptls_context_t *ctx, int is_server);
+ptls_t *ptls_new(ptls_context_t *ctx, int is_server, void *verfify_certificate_ctx);
 /**
- * releases all resources associated to the object
+ * releases all resources associated to the object. The free_verify_certificate_ctx function will be used to free the
+ * verify_certificate_ctx (can be NULL).
  */
-void ptls_free(ptls_t *tls);
+void ptls_free(ptls_t *tls, void (*free_verify_certificate_ctx)(void *ctx));
 /**
  * returns address of the crypto callbacks that the connection is using
  */

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -782,7 +782,7 @@ Exit:
     return ret;
 }
 
-static int verify_certificate(ptls_verify_certificate_t *_self, ptls_t *tls, int (**verifier)(void *, ptls_iovec_t, ptls_iovec_t),
+static int verify_certificate(ptls_verify_certificate_t *_self, void* _ctx, ptls_t *tls, int (**verifier)(void *, ptls_iovec_t, ptls_iovec_t),
                               void **verify_data, ptls_iovec_t *certs, size_t num_certs)
 {
     ptls_openssl_verify_certificate_t *self = (ptls_openssl_verify_certificate_t *)_self;

--- a/t/cli.c
+++ b/t/cli.c
@@ -58,7 +58,7 @@ static void shift_buffer(ptls_buffer_t *buf, size_t delta)
 static int handle_connection(int sockfd, ptls_context_t *ctx, const char *server_name, const char *input_file,
                              ptls_handshake_properties_t *hsprop)
 {
-    ptls_t *tls = ptls_new(ctx, server_name == NULL);
+    ptls_t *tls = ptls_new(ctx, server_name == NULL, NULL);
     ptls_buffer_t rbuf, encbuf, ptbuf;
     char bytebuf[16384];
     enum { IN_HANDSHAKE, IN_1RTT, IN_SHUTDOWN } state = IN_HANDSHAKE;
@@ -225,7 +225,7 @@ Exit:
     ptls_buffer_dispose(&rbuf);
     ptls_buffer_dispose(&encbuf);
     ptls_buffer_dispose(&ptbuf);
-    ptls_free(tls);
+    ptls_free(tls, NULL);
     return ret != 0;
 }
 

--- a/t/minicrypto.c
+++ b/t/minicrypto.c
@@ -74,8 +74,8 @@ static void test_hrr(void)
     assert(ctx_peer->key_exchanges[0] != NULL && ctx_peer->key_exchanges[0]->id == PTLS_GROUP_SECP256R1);
     assert(ctx_peer->key_exchanges[1] == NULL);
 
-    client = ptls_new(&client_ctx, 0);
-    server = ptls_new(ctx_peer, 1);
+    client = ptls_new(&client_ctx, 0, NULL);
+    server = ptls_new(ctx_peer, 1, NULL);
     ptls_buffer_init(&cbuf, cbuf_small, sizeof(cbuf_small));
     ptls_buffer_init(&sbuf, sbuf_small, sizeof(sbuf_small));
     ptls_buffer_init(&decbuf, decbuf_small, sizeof(decbuf_small));
@@ -131,8 +131,8 @@ static void test_hrr(void)
     ptls_buffer_dispose(&decbuf);
     ptls_buffer_dispose(&sbuf);
     ptls_buffer_dispose(&cbuf);
-    ptls_free(client);
-    ptls_free(server);
+    ptls_free(client, NULL);
+    ptls_free(server, NULL);
 }
 
 int main(int argc, char **argv)

--- a/t/picotls.c
+++ b/t/picotls.c
@@ -345,8 +345,8 @@ static void test_handshake(ptls_iovec_t ticket, int mode, int check_ch)
     const char *req = "GET / HTTP/1.0\r\n\r\n";
     const char *resp = "HTTP/1.0 200 OK\r\n\r\nhello world\n";
 
-    client = ptls_new(ctx, 0);
-    server = ptls_new(ctx_peer, 1);
+    client = ptls_new(ctx, 0, NULL);
+    server = ptls_new(ctx_peer, 1, NULL);
     ptls_buffer_init(&cbuf, cbuf_small, sizeof(cbuf_small));
     ptls_buffer_init(&sbuf, sbuf_small, sizeof(sbuf_small));
     ptls_buffer_init(&decbuf, decbuf_small, sizeof(decbuf_small));
@@ -386,8 +386,8 @@ static void test_handshake(ptls_iovec_t ticket, int mode, int check_ch)
         ret = ptls_handshake(server, &sbuf, cbuf.base, &consumed, &server_hs_prop);
         if (mode == TEST_HANDSHAKE_HRR_STATELESS) {
             ok(ret == PTLS_ERROR_STATELESS_RETRY);
-            ptls_free(server);
-            server = ptls_new(ctx_peer, 1);
+            ptls_free(server, NULL);
+            server = ptls_new(ctx_peer, 1, NULL);
         } else {
             ok(ret == PTLS_ERROR_IN_PROGRESS);
         }
@@ -505,8 +505,8 @@ static void test_handshake(ptls_iovec_t ticket, int mode, int check_ch)
     ptls_buffer_dispose(&cbuf);
     ptls_buffer_dispose(&sbuf);
     ptls_buffer_dispose(&decbuf);
-    ptls_free(client);
-    ptls_free(server);
+    ptls_free(client, NULL);
+    ptls_free(server, NULL);
 
     if (check_ch)
         ctx_peer->on_client_hello = NULL;
@@ -626,13 +626,13 @@ static void test_enforce_retry(int use_cookie)
     ptls_buffer_init(&sbuf, "", 0);
     ptls_buffer_init(&decbuf, "", 0);
 
-    client = ptls_new(ctx, 0);
+    client = ptls_new(ctx, 0, NULL);
 
     ret = ptls_handshake(client, &cbuf, NULL, NULL, NULL);
     ok(ret == PTLS_ERROR_IN_PROGRESS);
     ok(cbuf.off != 0);
 
-    server = ptls_new(ctx, 1);
+    server = ptls_new(ctx, 1, NULL);
 
     consumed = cbuf.off;
     ret = ptls_handshake(server, &sbuf, cbuf.base, &consumed, &server_hs_prop);
@@ -640,8 +640,8 @@ static void test_enforce_retry(int use_cookie)
 
     if (use_cookie) {
         ok(ret == PTLS_ERROR_STATELESS_RETRY);
-        ptls_free(server);
-        server = ptls_new(ctx, 1);
+        ptls_free(server, NULL);
+        server = ptls_new(ctx, 1, NULL);
     } else {
         ok(ret == PTLS_ERROR_IN_PROGRESS);
     }
@@ -677,8 +677,8 @@ static void test_enforce_retry(int use_cookie)
     ok(memcmp(decbuf.base, "hello world", 11) == 0);
     decbuf.off = 0;
 
-    ptls_free(client);
-    ptls_free(server);
+    ptls_free(client, NULL);
+    ptls_free(server, NULL);
 
     ptls_buffer_dispose(&cbuf);
     ptls_buffer_dispose(&sbuf);
@@ -697,7 +697,7 @@ static void test_enforce_retry_stateless(void)
 
 static ptls_t *stateless_hrr_prepare(ptls_buffer_t *sbuf, ptls_handshake_properties_t *server_hs_prop)
 {
-    ptls_t *client = ptls_new(ctx, 0), *server = ptls_new(ctx_peer, 1);
+    ptls_t *client = ptls_new(ctx, 0, NULL), *server = ptls_new(ctx_peer, 1, NULL);
     ptls_buffer_t cbuf;
     size_t consumed;
     int ret;
@@ -713,7 +713,7 @@ static ptls_t *stateless_hrr_prepare(ptls_buffer_t *sbuf, ptls_handshake_propert
     ok(ret == PTLS_ERROR_STATELESS_RETRY);
 
     ptls_buffer_dispose(&cbuf);
-    ptls_free(server);
+    ptls_free(server, NULL);
 
     return client;
 }
@@ -740,15 +740,15 @@ static void test_stateless_hrr_aad_change(void)
     ok(sbuf.off == consumed);
     sbuf.off = 0;
 
-    server = ptls_new(ctx_peer, 1);
+    server = ptls_new(ctx_peer, 1, NULL);
     server_hs_prop.server.cookie.additional_data = ptls_iovec_init("1.2.3.4:4321", 12);
 
     consumed = cbuf.off;
     ret = ptls_handshake(server, &sbuf, cbuf.base, &consumed, &server_hs_prop);
     ok(ret == PTLS_ALERT_HANDSHAKE_FAILURE);
 
-    ptls_free(client);
-    ptls_free(server);
+    ptls_free(client, NULL);
+    ptls_free(server, NULL);
 
     ptls_buffer_dispose(&cbuf);
     ptls_buffer_dispose(&sbuf);


### PR DESCRIPTION
The ptls context can be used for multiple ptls instances. The verify certificate
context makes the callback unique per ptls instance.

The current implementation uses the context just for the verify certificate context, but if wanted, it could also be extended for other callbacks.