### PR TITLE
Add supporting LibreSSL 2.7

### DIFF
--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -42,13 +42,15 @@
 #include "picotls.h"
 #include "picotls/openssl.h"
 
-#if (OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER))
-#define OPENSSL_1_0_API 1
+#if !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000L
+#define OPENSSL_1_1_API 1
+#elif defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x2070000fL
+#define OPENSSL_1_1_API 1
 #else
-#define OPENSSL_1_0_API 0
+#define OPENSSL_1_1_API 0
 #endif
 
-#if OPENSSL_1_0_API
+#if !OPENSSL_1_1_API
 
 #define EVP_PKEY_up_ref(p) CRYPTO_add(&(p)->references, 1, CRYPTO_LOCK_EVP_PKEY)
 #define X509_STORE_up_ref(p) CRYPTO_add(&(p)->references, 1, CRYPTO_LOCK_X509_STORE)


### PR DESCRIPTION
LibreSSL 2.7 adds OpenSSL-compat APIs.
We can compile picotls with LibreSSL 2.7 after apply this patch.
If not, we get error messages like "HMAC_CTX_new already defined."

https://github.com/h2o/h2o/issues/1706#issuecomment-375651422

Tested with LibreSSL 2.7.0, LibreSSL 2.6.4, OpenSSL 1.0.2k (CentOS 7's) and OpenSSL 1.1.0g