### PR TITLE
refactor AEAD API following changes in QUIC draft-11

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -804,11 +804,6 @@ int ptls_hkdf_extract(ptls_hash_algorithm_t *hash, void *output, ptls_iovec_t sa
  */
 int ptls_hkdf_expand(ptls_hash_algorithm_t *hash, void *output, size_t outlen, ptls_iovec_t prk, ptls_iovec_t info);
 /**
- *
- */
-int ptls_hkdf_expand_label(ptls_hash_algorithm_t *algo, void *output, size_t outlen, ptls_iovec_t secret, const char *label,
-                           ptls_iovec_t hash_value, const char *base_label);
-/**
  * instantiates a symmetric cipher
  */
 ptls_cipher_context_t *ptls_cipher_new(ptls_cipher_algorithm_t *algo, int is_enc, const void *key);
@@ -825,15 +820,13 @@ static void ptls_cipher_init(ptls_cipher_context_t *ctx, const void *iv);
  */
 static void ptls_cipher_encrypt(ptls_cipher_context_t *ctx, void *output, const void *input, size_t len);
 /**
- * instantiates an AEAD cipher given a secret, which is expanded using hkdf to a set of key and iv
- * @param aead
- * @param hash
+ * instantiates an AEAD cipher given a key. `static_iv` field must be set up after calling this function.
+ * @param aead AEAD algorithm
  * @param is_enc 1 if creating a context for encryption, 0 if creating a context for decryption
- * @param secret the secret. The size must be the digest length of the hash algorithm
+ * @param key encryption key
  * @return pointer to an AEAD context if successful, otherwise NULL
  */
-ptls_aead_context_t *ptls_aead_new(ptls_aead_algorithm_t *aead, ptls_hash_algorithm_t *hash, int is_enc, const void *secret,
-                                   const char *base_label);
+ptls_aead_context_t *ptls_aead_new(ptls_aead_algorithm_t *aead, int is_enc, const void *key);
 /**
  * destroys an AEAD cipher context
  */

--- a/t/picotls.c
+++ b/t/picotls.c
@@ -107,7 +107,7 @@ static void test_ciphersuite(ptls_cipher_suite_t *cs1, ptls_cipher_suite_t *cs2)
     size_t enc1len, enc2len, dec1len, dec2len;
 
     /* encrypt */
-    c = ptls_aead_new(cs1->aead, cs1->hash, 1, traffic_secret, NULL);
+    c = new_aead(cs1->aead, cs1->hash, 1, traffic_secret);
     assert(c != NULL);
     ptls_aead_encrypt_init(c, 0, NULL, 0);
     enc1len = ptls_aead_encrypt_update(c, enc1, src1, strlen(src1));
@@ -117,7 +117,7 @@ static void test_ciphersuite(ptls_cipher_suite_t *cs1, ptls_cipher_suite_t *cs2)
     enc2len += ptls_aead_encrypt_final(c, enc2 + enc2len);
     ptls_aead_free(c);
 
-    c = ptls_aead_new(cs2->aead, cs2->hash, 0, traffic_secret, NULL);
+    c = new_aead(cs2->aead, cs2->hash, 0, traffic_secret);
     assert(c != NULL);
 
     /* decrypt and compare */
@@ -146,7 +146,7 @@ static void test_aad_ciphersuite(ptls_cipher_suite_t *cs1, ptls_cipher_suite_t *
     size_t enclen, declen;
 
     /* encrypt */
-    c = ptls_aead_new(cs1->aead, cs1->hash, 1, traffic_secret, NULL);
+    c = new_aead(cs1->aead, cs1->hash, 1, traffic_secret);
     assert(c != NULL);
     ptls_aead_encrypt_init(c, 123, aad, strlen(aad));
     enclen = ptls_aead_encrypt_update(c, enc, src, strlen(src));
@@ -154,7 +154,7 @@ static void test_aad_ciphersuite(ptls_cipher_suite_t *cs1, ptls_cipher_suite_t *
     ptls_aead_free(c);
 
     /* decrypt */
-    c = ptls_aead_new(cs2->aead, cs2->hash, 0, traffic_secret, NULL);
+    c = new_aead(cs2->aead, cs2->hash, 0, traffic_secret);
     assert(c != NULL);
     declen = ptls_aead_decrypt(c, dec, enc, enclen, 123, aad, strlen(aad));
     ok(declen == strlen(src));


### PR DESCRIPTION
The AEAD API of picotls has been designed in hope that the only difference between the traffic key derivation functions of TLS 1.3 and QUIC will be the value of the base_label.

However, the function definition of QUIC has been changed recently, and draft-11 has shipped without reverting the change (see https://github.com/quicwg/base-drafts/issues/1255).

This PR changes the AEAD API of picotls so that it would be easier for the users to implement draft-11-style AEAD, as well as removing the abstraction that is no longer necessary.


https://gist.github.com/kazuho/6ace6cb277e977b89f283be7631b977f contains a code snippet that can be used to create an AEAD context for QUIC draft-11.