### PR TITLE
more key exchanges for the OpenSSL backend

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -58,7 +58,10 @@ extern "C" {
 
 /* negotiated_groups */
 #define PTLS_GROUP_SECP256R1 23
+#define PTLS_GROUP_SECP384R1 24
+#define PTLS_GROUP_SECP521R1 25
 #define PTLS_GROUP_X25519 29
+#define PTLS_GROUP_X448 30
 
 /* signature algorithms */
 #define PTLS_SIGNATURE_RSA_PKCS1_SHA1 0x0201

--- a/include/picotls/openssl.h
+++ b/include/picotls/openssl.h
@@ -33,7 +33,18 @@
 #endif
 
 extern ptls_key_exchange_algorithm_t ptls_openssl_secp256r1;
+#ifdef NID_secp384r1
+ptls_key_exchange_algorithm_t ptls_openssl_secp384r1;
+#endif
+#ifdef NID_secp521r1
+ptls_key_exchange_algorithm_t ptls_openssl_secp521r1;
+#endif
+#ifdef NID_X25519
+ptls_key_exchange_algorithm_t ptls_openssl_x25519;
+#endif
+
 extern ptls_key_exchange_algorithm_t *ptls_openssl_key_exchanges[];
+
 extern ptls_cipher_algorithm_t ptls_openssl_aes128ctr;
 extern ptls_aead_algorithm_t ptls_openssl_aes128gcm;
 extern ptls_cipher_algorithm_t ptls_openssl_aes256ctr;

--- a/include/picotls/openssl.h
+++ b/include/picotls/openssl.h
@@ -34,13 +34,13 @@
 
 extern ptls_key_exchange_algorithm_t ptls_openssl_secp256r1;
 #ifdef NID_secp384r1
-ptls_key_exchange_algorithm_t ptls_openssl_secp384r1;
+extern ptls_key_exchange_algorithm_t ptls_openssl_secp384r1;
 #endif
 #ifdef NID_secp521r1
-ptls_key_exchange_algorithm_t ptls_openssl_secp521r1;
+extern ptls_key_exchange_algorithm_t ptls_openssl_secp521r1;
 #endif
 #ifdef NID_X25519
-ptls_key_exchange_algorithm_t ptls_openssl_x25519;
+extern ptls_key_exchange_algorithm_t ptls_openssl_x25519;
 #endif
 
 extern ptls_key_exchange_algorithm_t *ptls_openssl_key_exchanges[];

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -420,7 +420,6 @@ static int evp_keyex_on_exchange(ptls_key_exchange_context_t **_ctx, ptls_iovec_
         goto Exit;
     }
     if (EVP_PKEY_derive_set_peer(evpctx, evppeer) <= 0) {
-        ERR_print_errors_fp(stderr);
         ret = PTLS_ERROR_LIBRARY;
         goto Exit;
     }

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -522,7 +522,7 @@ Exit:
     if (ctx != NULL)
         evp_keyex_on_exchange(&ctx, NULL, ptls_iovec_init(NULL, 0));
     if (ret != 0)
-        free(outpubkey);
+        free(outpubkey->base);
     return ret;
 }
 

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -536,19 +536,6 @@ static int x25519_key_exchange(ptls_iovec_t *pubkey, ptls_iovec_t *secret, ptls_
     return evp_keyex_exchange(pubkey, secret, peerkey, NID_X25519);
 }
 
-#ifdef NID_X448
-
-static int x448_create_key_exchange(ptls_key_exchange_context_t **ctx, ptls_iovec_t *pubkey)
-{
-    return evp_keyex_create(ctx, pubkey, NID_X448);
-}
-
-static int x448_key_exchange(ptls_iovec_t *pubkey, ptls_iovec_t *secret, ptls_iovec_t peerkey)
-{
-    return evp_keyex_exchange(pubkey, secret, peerkey, NID_X448);
-}
-
-#endif
 #endif
 
 static int do_sign(EVP_PKEY *key, ptls_buffer_t *outbuf, ptls_iovec_t input, const EVP_MD *md)
@@ -1258,9 +1245,6 @@ ptls_key_exchange_algorithm_t ptls_openssl_secp521r1 = {PTLS_GROUP_SECP521R1, se
 #endif
 #ifdef NID_X25519
 ptls_key_exchange_algorithm_t ptls_openssl_x25519 = {PTLS_GROUP_X25519, x25519_create_key_exchange, x25519_key_exchange};
-#endif
-#ifdef NID_X448
-ptls_key_exchange_algorithm_t ptls_openssl_x448 = {PTLS_GROUP_X25519, x448_create_key_exchange, x448_key_exchange};
 #endif
 ptls_key_exchange_algorithm_t *ptls_openssl_key_exchanges[] = {&ptls_openssl_secp256r1, NULL};
 ptls_cipher_algorithm_t ptls_openssl_aes128ctr = {"AES128-CTR", PTLS_AES128_KEY_SIZE, PTLS_AES_IV_SIZE,

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -326,6 +326,34 @@ static int secp256r1_key_exchange(ptls_iovec_t *pubkey, ptls_iovec_t *secret, pt
     return secp_key_exchange(pubkey, secret, peerkey, NID_X9_62_prime256v1);
 }
 
+#ifdef NID_secp384r1
+
+static int secp384r1_create_key_exchange(ptls_key_exchange_context_t **ctx, ptls_iovec_t *pubkey)
+{
+    return x9_62_create_key_exchange(ctx, pubkey, NID_secp384r1);
+}
+
+static int secp384r1_key_exchange(ptls_iovec_t *pubkey, ptls_iovec_t *secret, ptls_iovec_t peerkey)
+{
+    return secp_key_exchange(pubkey, secret, peerkey, NID_secp384r1);
+}
+
+#endif
+
+#ifdef NID_secp521r1
+
+static int secp521r1_create_key_exchange(ptls_key_exchange_context_t **ctx, ptls_iovec_t *pubkey)
+{
+    return x9_62_create_key_exchange(ctx, pubkey, NID_secp521r1);
+}
+
+static int secp521r1_key_exchange(ptls_iovec_t *pubkey, ptls_iovec_t *secret, ptls_iovec_t peerkey)
+{
+    return secp_key_exchange(pubkey, secret, peerkey, NID_secp521r1);
+}
+
+#endif
+
 #ifdef NID_X25519
 
 struct st_evp_keyex_context_t {
@@ -1216,6 +1244,14 @@ Exit:
 
 ptls_key_exchange_algorithm_t ptls_openssl_secp256r1 = {PTLS_GROUP_SECP256R1, secp256r1_create_key_exchange,
                                                         secp256r1_key_exchange};
+#ifdef NID_secp384r1
+ptls_key_exchange_algorithm_t ptls_openssl_secp384r1 = {PTLS_GROUP_SECP384R1, secp384r1_create_key_exchange,
+                                                        secp384r1_key_exchange};
+#endif
+#ifdef NID_secp521r1
+ptls_key_exchange_algorithm_t ptls_openssl_secp521r1 = {PTLS_GROUP_SECP521R1, secp521r1_create_key_exchange,
+                                                        secp521r1_key_exchange};
+#endif
 #ifdef NID_X25519
 ptls_key_exchange_algorithm_t ptls_openssl_x25519 = {PTLS_GROUP_X25519, x25519_create_key_exchange, x25519_key_exchange};
 #endif

--- a/picotls.xcodeproj/project.pbxproj
+++ b/picotls.xcodeproj/project.pbxproj
@@ -911,10 +911,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-					"/usr/local/openssl-1.0.2/include",
+					"/usr/local/openssl-1.1.0/include",
 					include,
 				);
-				LIBRARY_SEARCH_PATHS = "/usr/local/openssl-1.0.2/lib";
+				LIBRARY_SEARCH_PATHS = "/usr/local/openssl-1.1.0/lib";
 				OTHER_LDFLAGS = "-lcrypto";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -924,10 +924,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-					"/usr/local/openssl-1.0.2/include",
+					"/usr/local/openssl-1.1.0/include",
 					include,
 				);
-				LIBRARY_SEARCH_PATHS = "/usr/local/openssl-1.0.2/lib";
+				LIBRARY_SEARCH_PATHS = "/usr/local/openssl-1.1.0/lib";
 				OTHER_LDFLAGS = "-lcrypto";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};

--- a/picotls.xcodeproj/project.pbxproj
+++ b/picotls.xcodeproj/project.pbxproj
@@ -751,10 +751,10 @@
 			buildSettings = {
 				EXECUTABLE_PREFIX = lib;
 				HEADER_SEARCH_PATHS = (
-					"/usr/local/openssl-1.0.2/include",
+					"/usr/local/openssl-1.1.0/include",
 					include,
 				);
-				LIBRARY_SEARCH_PATHS = "/usr/local/openssl-1.0.2/lib";
+				LIBRARY_SEARCH_PATHS = "/usr/local/openssl-1.1.0/lib";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -764,10 +764,10 @@
 			buildSettings = {
 				EXECUTABLE_PREFIX = lib;
 				HEADER_SEARCH_PATHS = (
-					"/usr/local/openssl-1.0.2/include",
+					"/usr/local/openssl-1.1.0/include",
 					include,
 				);
-				LIBRARY_SEARCH_PATHS = "/usr/local/openssl-1.0.2/lib";
+				LIBRARY_SEARCH_PATHS = "/usr/local/openssl-1.1.0/lib";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -866,10 +866,10 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "";
 				HEADER_SEARCH_PATHS = (
-					"/usr/local/openssl-1.0.2/include",
+					"/usr/local/openssl-1.1.0/include",
 					include,
 				);
-				LIBRARY_SEARCH_PATHS = "/usr/local/openssl-1.0.2/lib";
+				LIBRARY_SEARCH_PATHS = "/usr/local/openssl-1.1.0/lib";
 				OTHER_LDFLAGS = "-lcrypto";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -880,10 +880,10 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "";
 				HEADER_SEARCH_PATHS = (
-					"/usr/local/openssl-1.0.2/include",
+					"/usr/local/openssl-1.1.0/include",
 					include,
 				);
-				LIBRARY_SEARCH_PATHS = "/usr/local/openssl-1.0.2/lib";
+				LIBRARY_SEARCH_PATHS = "/usr/local/openssl-1.1.0/lib";
 				OTHER_LDFLAGS = "-lcrypto";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};

--- a/t/openssl.c
+++ b/t/openssl.c
@@ -87,6 +87,20 @@ static void test_key_exchanges(void)
     test_key_exchange(&ptls_openssl_secp256r1, &ptls_openssl_secp256r1);
     test_key_exchange(&ptls_openssl_secp256r1, &ptls_minicrypto_secp256r1);
     test_key_exchange(&ptls_minicrypto_secp256r1, &ptls_openssl_secp256r1);
+
+#ifdef NID_secp384r1
+    test_key_exchange(&ptls_openssl_secp384r1, &ptls_openssl_secp384r1);
+#endif
+
+#ifdef NID_secp521r1
+    test_key_exchange(&ptls_openssl_secp521r1, &ptls_openssl_secp521r1);
+#endif
+
+#ifdef NID_X25519
+    test_key_exchange(&ptls_openssl_x25519, &ptls_openssl_x25519);
+    test_key_exchange(&ptls_openssl_x25519, &ptls_minicrypto_x25519);
+    test_key_exchange(&ptls_minicrypto_x25519, &ptls_openssl_x25519);
+#endif
 }
 
 static void test_rsa_sign(void)


### PR DESCRIPTION
Adds secp384r1, secp521r1, X25519.

X448 is not implemented (since OpenSSL 1.1.0 does not support it; it is likely that 1.1.1 will have support). But the code is generic enough that it would be easy to add support for X448.

ToDo:
* [x] test interop with other implementations
* [ ] create a something like `ptls_openssl_key_exchanges_all`, that holds all the supported algorithms?