### PR TITLE
fix build failure when using libressl

### DIFF
--- a/include/picotls/openssl.h
+++ b/include/picotls/openssl.h
@@ -34,12 +34,15 @@
 
 extern ptls_key_exchange_algorithm_t ptls_openssl_secp256r1;
 #ifdef NID_secp384r1
+#define PTLS_OPENSSL_HAS_SECP384R1 1
 extern ptls_key_exchange_algorithm_t ptls_openssl_secp384r1;
 #endif
 #ifdef NID_secp521r1
+#define PTLS_OPENSSL_HAS_SECP521R1 1
 extern ptls_key_exchange_algorithm_t ptls_openssl_secp521r1;
 #endif
 #ifdef NID_X25519
+#define PTLS_OPENSSL_HAS_X25519 1
 extern ptls_key_exchange_algorithm_t ptls_openssl_x25519;
 #endif
 

--- a/include/picotls/openssl.h
+++ b/include/picotls/openssl.h
@@ -41,7 +41,7 @@ extern ptls_key_exchange_algorithm_t ptls_openssl_secp384r1;
 #define PTLS_OPENSSL_HAS_SECP521R1 1
 extern ptls_key_exchange_algorithm_t ptls_openssl_secp521r1;
 #endif
-#ifdef NID_X25519
+#if defined(NID_X25519) && !defined(LIBRESSL_VERSION_NUMBER)
 #define PTLS_OPENSSL_HAS_X25519 1
 extern ptls_key_exchange_algorithm_t ptls_openssl_x25519;
 #endif

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -331,7 +331,7 @@ static int secp256r1_key_exchange(ptls_iovec_t *pubkey, ptls_iovec_t *secret, pt
     return secp_key_exchange(pubkey, secret, peerkey, NID_X9_62_prime256v1);
 }
 
-#ifdef NID_secp384r1
+#ifdef PTLS_OPENSSL_HAS_SECP384R1
 
 static int secp384r1_create_key_exchange(ptls_key_exchange_context_t **ctx, ptls_iovec_t *pubkey)
 {
@@ -345,7 +345,7 @@ static int secp384r1_key_exchange(ptls_iovec_t *pubkey, ptls_iovec_t *secret, pt
 
 #endif
 
-#ifdef NID_secp521r1
+#ifdef PTLS_OPENSSL_HAS_SECP521R1
 
 static int secp521r1_create_key_exchange(ptls_key_exchange_context_t **ctx, ptls_iovec_t *pubkey)
 {
@@ -359,7 +359,7 @@ static int secp521r1_key_exchange(ptls_iovec_t *pubkey, ptls_iovec_t *secret, pt
 
 #endif
 
-#ifdef NID_X25519
+#ifdef PTLS_OPENSSL_HAS_X25519
 
 struct st_evp_keyex_context_t {
     ptls_key_exchange_context_t super;
@@ -1235,15 +1235,15 @@ Exit:
 
 ptls_key_exchange_algorithm_t ptls_openssl_secp256r1 = {PTLS_GROUP_SECP256R1, secp256r1_create_key_exchange,
                                                         secp256r1_key_exchange};
-#ifdef NID_secp384r1
+#ifdef PTLS_OPENSSL_HAS_SECP384R1
 ptls_key_exchange_algorithm_t ptls_openssl_secp384r1 = {PTLS_GROUP_SECP384R1, secp384r1_create_key_exchange,
                                                         secp384r1_key_exchange};
 #endif
-#ifdef NID_secp521r1
+#ifdef PTLS_OPENSSL_HAS_SECP521R1
 ptls_key_exchange_algorithm_t ptls_openssl_secp521r1 = {PTLS_GROUP_SECP521R1, secp521r1_create_key_exchange,
                                                         secp521r1_key_exchange};
 #endif
-#ifdef NID_X25519
+#ifdef PTLS_OPENSSL_HAS_X25519
 ptls_key_exchange_algorithm_t ptls_openssl_x25519 = {PTLS_GROUP_X25519, x25519_create_key_exchange, x25519_key_exchange};
 #endif
 ptls_key_exchange_algorithm_t *ptls_openssl_key_exchanges[] = {&ptls_openssl_secp256r1, NULL};

--- a/t/cli.c
+++ b/t/cli.c
@@ -300,13 +300,13 @@ static void usage(const char *cmd)
            "  -h                   print this help\n"
            "\n"
            "Supported named groups: secp256r1"
-#ifdef NID_secp384r1
+#ifdef PTLS_OPENSSL_HAS_SECP384R1
     ", secp384r1"
 #endif
-#ifdef NID_secp521r1
+#ifdef PTLS_OPENSSL_HAS_SECP521R1
             ", secp521r1"
 #endif
-#ifdef NID_X25519
+#ifdef PTLS_OPENSSL_HAS_X25519
             ", X25519"
 #endif
            "\n\n",
@@ -381,13 +381,13 @@ int main(int argc, char **argv)
             ptls_key_exchange_algorithm_t *algo = NULL;
 #define MATCH(name) if (algo == NULL && strcasecmp(optarg, #name) == 0) algo = (&ptls_openssl_##name)
             MATCH(secp256r1);
-#ifdef NID_secp384r1
+#ifdef PTLS_OPENSSL_HAS_SECP384R1
             MATCH(secp384r1);
 #endif
-#ifdef NID_secp521r1
+#ifdef PTLS_OPENSSL_HAS_SECP521R1
             MATCH(secp521r1);
 #endif
-#ifdef NID_X25519
+#ifdef PTLS_OPENSSL_HAS_X25519
             MATCH(x25519);
 #endif
 #undef MATCH

--- a/t/openssl.c
+++ b/t/openssl.c
@@ -88,15 +88,15 @@ static void test_key_exchanges(void)
     test_key_exchange(&ptls_openssl_secp256r1, &ptls_minicrypto_secp256r1);
     test_key_exchange(&ptls_minicrypto_secp256r1, &ptls_openssl_secp256r1);
 
-#ifdef NID_secp384r1
+#ifdef PTLS_OPENSSL_HAS_SECP384R1
     test_key_exchange(&ptls_openssl_secp384r1, &ptls_openssl_secp384r1);
 #endif
 
-#ifdef NID_secp521r1
+#ifdef PTLS_OPENSSL_HAS_SECP521R1
     test_key_exchange(&ptls_openssl_secp521r1, &ptls_openssl_secp521r1);
 #endif
 
-#ifdef NID_X25519
+#ifdef PTLS_OPENSSL_HAS_X25519
     test_key_exchange(&ptls_openssl_x25519, &ptls_openssl_x25519);
     test_key_exchange(&ptls_openssl_x25519, &ptls_minicrypto_x25519);
     test_key_exchange(&ptls_minicrypto_x25519, &ptls_openssl_x25519);


### PR DESCRIPTION
We cannot support X25519 with libressl since the necessary functions are not provided.

regression caused by #148.