### PR TITLE
base64 decoder returns success even the input is invalid on platforms that have unsigned char types

### DIFF
--- a/lib/pembase64.c
+++ b/lib/pembase64.c
@@ -143,7 +143,7 @@ int ptls_base64_decode(const char *text, ptls_base64_decode_state_t *state, ptls
         c = text[text_index++];
 
         vc = 0 < c && c < 0x7f ? ptls_base64_values[c] : -1;
-        if (vc == -1) {
+        if (vc == (char)-1) {
             if (state->nbc == 2 && c == '=' && text[text_index] == '=') {
                 state->nbc = 4;
                 text_index++;


### PR DESCRIPTION
This PR fixes the base64 decoder returning success even when the input is invalid, on platforms that define `char` as an unsigned type (e.g. macOS).

I _think_ this is the only occasion we promote the `char` for comparison (and hence ends up in error), but we might want to stop assigning `-1` for `char` at all.

@huitema What do you think?