### PR TITLE
verify certificate using IP address

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -918,9 +918,9 @@ extern void (*volatile ptls_clear_memory)(void *p, size_t len);
  */
 static ptls_iovec_t ptls_iovec_init(const void *p, size_t len);
 /**
- * checks if a server name is one that can be sent using ServerNameIndication.HostName.
+ * checks if a server name is an IP address.
  */
-int ptls_server_name_is_host_name(const char *name);
+int ptls_server_name_is_ipaddr(const char *name);
 
 /* inline functions */
 inline ptls_iovec_t ptls_iovec_init(const void *p, size_t len)

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -751,9 +751,11 @@ ptls_cipher_suite_t *ptls_get_cipher(ptls_t *tls);
  */
 const char *ptls_get_server_name(ptls_t *tls);
 /**
- * sets the server-name (for client the value sent in SNI). If server_name_len is zero, then strlen(server_name) is called to
- * determine
- * the length of the name.
+ * sets the server-name associated to the TLS connection. If server_name_len is zero, then strlen(server_name) is called to
+ * determine the length of the name.
+ * On the client-side, the value is used for certificate validation. The value will be also sent as an SNI extension, if it looks
+ * like a DNS name.
+ * On the server-side, it can be called from on_client_hello to indicate the acceptance of the SNI extension to the client.
  */
 int ptls_set_server_name(ptls_t *tls, const char *server_name, size_t server_name_len);
 /**
@@ -915,6 +917,10 @@ extern void (*volatile ptls_clear_memory)(void *p, size_t len);
  *
  */
 static ptls_iovec_t ptls_iovec_init(const void *p, size_t len);
+/**
+ * checks if a server name is one that can be sent using ServerNameIndication.HostName.
+ */
+int ptls_server_name_is_host_name(const char *name);
 
 /* inline functions */
 inline ptls_iovec_t ptls_iovec_init(const void *p, size_t len)

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -1049,7 +1049,12 @@ static int verify_cert_chain(X509_STORE *store, X509 *cert, STACK_OF(X509) * cha
 #ifdef X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS
     /* verify CN */
     if (server_name != NULL) {
-        if ((ret = X509_check_host(cert, server_name, strlen(server_name), X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS, NULL)) != 1) {
+        if (ptls_server_name_is_host_name(server_name)) {
+            ret = X509_check_host(cert, server_name, strlen(server_name), X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS, NULL);
+        } else {
+            ret = X509_check_ip_asc(cert, server_name, 0);
+        }
+        if (ret != 1) {
             if (ret == 0) { /* failed match */
                 ret = PTLS_ALERT_BAD_CERTIFICATE;
             } else {

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -1049,10 +1049,10 @@ static int verify_cert_chain(X509_STORE *store, X509 *cert, STACK_OF(X509) * cha
 #ifdef X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS
     /* verify CN */
     if (server_name != NULL) {
-        if (ptls_server_name_is_host_name(server_name)) {
-            ret = X509_check_host(cert, server_name, strlen(server_name), X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS, NULL);
-        } else {
+        if (ptls_server_name_is_ipaddr(server_name)) {
             ret = X509_check_ip_asc(cert, server_name, 0);
+        } else {
+            ret = X509_check_host(cert, server_name, strlen(server_name), X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS, NULL);
         }
         if (ret != 1) {
             if (ret == 0) { /* failed match */

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -19,6 +19,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
+#include <arpa/inet.h>
 #include <assert.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -1487,7 +1488,7 @@ static int send_client_hello(ptls_t *tls, struct st_ptls_message_emitter_t *emit
         ptls_buffer_push_block(sendbuf, 1, { ptls_buffer_push(sendbuf, 0); });
         /* extensions */
         ptls_buffer_push_block(sendbuf, 2, {
-            if (tls->server_name != NULL && ptls_server_name_is_host_name(tls->server_name)) {
+            if (tls->server_name != NULL && !ptls_server_name_is_ipaddr(tls->server_name)) {
                 buffer_push_extension(sendbuf, PTLS_EXTENSION_TYPE_SERVER_NAME, {
                     ptls_buffer_push_block(sendbuf, 2, {
                         ptls_buffer_push(sendbuf, PTLS_SERVER_NAME_TYPE_HOSTNAME);
@@ -1893,7 +1894,7 @@ static int client_handle_encrypted_extensions(ptls_t *tls, ptls_iovec_t message,
                 ret = PTLS_ALERT_DECODE_ERROR;
                 goto Exit;
             }
-            if (!(tls->server_name != NULL && ptls_server_name_is_host_name(tls->server_name))) {
+            if (!(tls->server_name != NULL && !ptls_server_name_is_ipaddr(tls->server_name))) {
                 ret = PTLS_ALERT_ILLEGAL_PARAMETER;
                 goto Exit;
             }
@@ -4245,35 +4246,19 @@ int ptls_handle_message(ptls_t *tls, ptls_buffer_t *sendbuf, size_t epoch_offset
 }
 
 /**
- * checks if given name is a DNS name that can be sent as an argument of SNI
+ * checks if given name looks like an IP address
  */
-int ptls_server_name_is_host_name(const char *name)
+int ptls_server_name_is_ipaddr(const char *name)
 {
-#define IS_ALPHA(c) (('A' <= (c) && (c) <= 'Z') || ('a' <= (c) && (c) <= 'z'))
-#define IS_DIGIT(c) ('0' <= (c) && (c) <= '9')
-
-    const char *p = name;
-    int is_first_ch = 1;
-
-    if (*p == '\0')
-        return 0;
-    for (; *p != '\0'; ++p) {
-        if (*p == '.') {
-            if (is_first_ch)
-                return 0;
-            is_first_ch = 1;
-        } else if (is_first_ch) {
-            if (!IS_ALPHA(*p))
-                return 0;
-            is_first_ch = 0;
-        } else {
-            if (!(IS_ALPHA(*p) || IS_DIGIT(*p) || *p == '-'))
-                return 0;
-        }
-    }
-
-    return 1;
-
-#undef IS_ALPHA
-#undef IS_DIGIT
+#ifdef AF_INET
+    struct sockaddr_in sin;
+    if (inet_pton(AF_INET, name, &sin) == 1)
+        return 1;
+#endif
+#ifdef AF_INET6
+    struct sockaddr_in6 sin6;
+    if (inet_pton(AF_INET6, name, &sin6) == 1)
+        return 1;
+#endif
+    return 0;
 }

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -1487,7 +1487,7 @@ static int send_client_hello(ptls_t *tls, struct st_ptls_message_emitter_t *emit
         ptls_buffer_push_block(sendbuf, 1, { ptls_buffer_push(sendbuf, 0); });
         /* extensions */
         ptls_buffer_push_block(sendbuf, 2, {
-            if (tls->server_name != NULL) {
+            if (tls->server_name != NULL && ptls_server_name_is_host_name(tls->server_name)) {
                 buffer_push_extension(sendbuf, PTLS_EXTENSION_TYPE_SERVER_NAME, {
                     ptls_buffer_push_block(sendbuf, 2, {
                         ptls_buffer_push(sendbuf, PTLS_SERVER_NAME_TYPE_HOSTNAME);
@@ -1893,7 +1893,7 @@ static int client_handle_encrypted_extensions(ptls_t *tls, ptls_iovec_t message,
                 ret = PTLS_ALERT_DECODE_ERROR;
                 goto Exit;
             }
-            if (tls->server_name == NULL) {
+            if (!(tls->server_name != NULL && ptls_server_name_is_host_name(tls->server_name))) {
                 ret = PTLS_ALERT_ILLEGAL_PARAMETER;
                 goto Exit;
             }
@@ -4242,4 +4242,38 @@ int ptls_handle_message(ptls_t *tls, ptls_buffer_t *sendbuf, size_t epoch_offset
         return PTLS_ALERT_UNEXPECTED_MESSAGE;
 
     return handle_handshake_record(tls, handle_handshake_message, &emitter.super, &rec, properties);
+}
+
+/**
+ * checks if given name is a DNS name that can be sent as an argument of SNI
+ */
+int ptls_server_name_is_host_name(const char *name)
+{
+#define IS_ALPHA(c) (('A' <= (c) && (c) <= 'Z') || ('a' <= (c) && (c) <= 'z'))
+#define IS_DIGIT(c) ('0' <= (c) && (c) <= '9')
+
+    const char *p = name;
+    int is_first_ch = 1;
+
+    if (*p == '\0')
+        return 0;
+    for (; *p != '\0'; ++p) {
+        if (*p == '.') {
+            if (is_first_ch)
+                return 0;
+            is_first_ch = 1;
+        } else if (is_first_ch) {
+            if (!IS_ALPHA(*p))
+                return 0;
+            is_first_ch = 0;
+        } else {
+            if (!(IS_ALPHA(*p) || IS_DIGIT(*p) || *p == '-'))
+                return 0;
+        }
+    }
+
+    return 1;
+
+#undef IS_ALPHA
+#undef IS_DIGIT
 }

--- a/t/picotls.c
+++ b/t/picotls.c
@@ -31,15 +31,15 @@
 #include "../lib/picotls.c"
 #include "test.h"
 
-static void test_is_hostname(void)
+static void test_is_ipaddr(void)
 {
-    ok(ptls_server_name_is_host_name("www.google.com"));
-    ok(ptls_server_name_is_host_name("www.google.com."));
-    ok(ptls_server_name_is_host_name("www"));
-    ok(!ptls_server_name_is_host_name(""));
-    ok(!ptls_server_name_is_host_name("123"));
-    ok(!ptls_server_name_is_host_name("1.1.1.1"));
-    ok(!ptls_server_name_is_host_name("2001:db8::2:1"));
+    ok(!ptls_server_name_is_ipaddr("www.google.com"));
+    ok(!ptls_server_name_is_ipaddr("www.google.com."));
+    ok(!ptls_server_name_is_ipaddr("www"));
+    ok(!ptls_server_name_is_ipaddr(""));
+    ok(!ptls_server_name_is_ipaddr("123"));
+    ok(ptls_server_name_is_ipaddr("1.1.1.1"));
+    ok(ptls_server_name_is_ipaddr("2001:db8::2:1"));
 }
 
 ptls_context_t *ctx, *ctx_peer;
@@ -1023,7 +1023,7 @@ static void test_handshake_api(void)
 
 void test_picotls(void)
 {
-    subtest("is_hostname", test_is_hostname);
+    subtest("is_ipaddr", test_is_ipaddr);
     subtest("sha256", test_sha256);
     subtest("sha384", test_sha384);
     subtest("hmac-sha256", test_hmac_sha256);

--- a/t/picotls.c
+++ b/t/picotls.c
@@ -31,6 +31,17 @@
 #include "../lib/picotls.c"
 #include "test.h"
 
+static void test_is_hostname(void)
+{
+    ok(ptls_server_name_is_host_name("www.google.com"));
+    ok(ptls_server_name_is_host_name("www.google.com."));
+    ok(ptls_server_name_is_host_name("www"));
+    ok(!ptls_server_name_is_host_name(""));
+    ok(!ptls_server_name_is_host_name("123"));
+    ok(!ptls_server_name_is_host_name("1.1.1.1"));
+    ok(!ptls_server_name_is_host_name("2001:db8::2:1"));
+}
+
 ptls_context_t *ctx, *ctx_peer;
 ptls_verify_certificate_t *verify_certificate;
 
@@ -1012,6 +1023,7 @@ static void test_handshake_api(void)
 
 void test_picotls(void)
 {
+    subtest("is_hostname", test_is_hostname);
     subtest("sha256", test_sha256);
     subtest("sha384", test_sha384);
     subtest("hmac-sha256", test_hmac_sha256);


### PR DESCRIPTION
Some TLS hosts (e.g. 1.1.1.1) are identified by their IP addresses rather than the hostnames.

This PR implements validation for such hosts, specifically by making following changes:
* allow a string representing an IP address to be passed as an argument to `ptls_set_server_name`
  * SNI extension is only sent if the supplied name is a DNS name
* call the appropriate function to verify a certificate based on IP address