### PR TITLE
add `omit_end_of_early_data` flag

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -467,6 +467,10 @@ struct st_ptls_context_t {
      */
     unsigned require_client_authentication : 1;
     /**
+     * if set, EOED will not be emitted or accepted
+     */
+    unsigned omit_end_of_early_data : 1;
+    /**
      *
      */
     ptls_encrypt_ticket_t *encrypt_ticket;

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -1307,11 +1307,9 @@ static int send_session_ticket(ptls_t *tls, struct st_ptls_message_emitter_t *em
 
     { /* calculate verify-data that will be sent by the client */
         size_t orig_off = emitter->buf->off;
-        if (tls->early_data != NULL) {
-            if (!tls->ctx->omit_end_of_early_data) {
-                assert(tls->state == PTLS_STATE_SERVER_EXPECT_END_OF_EARLY_DATA);
-                buffer_push_handshake_body(emitter->buf, tls->key_schedule, PTLS_HANDSHAKE_TYPE_END_OF_EARLY_DATA, {});
-            }
+        if (tls->early_data != NULL && !tls->ctx->omit_end_of_early_data) {
+            assert(tls->state == PTLS_STATE_SERVER_EXPECT_END_OF_EARLY_DATA);
+            buffer_push_handshake_body(emitter->buf, tls->key_schedule, PTLS_HANDSHAKE_TYPE_END_OF_EARLY_DATA, {});
             emitter->buf->off = orig_off;
         }
         buffer_push_handshake_body(emitter->buf, tls->key_schedule, PTLS_HANDSHAKE_TYPE_FINISHED, {

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -3163,8 +3163,13 @@ static int server_handle_hello(ptls_t *tls, struct st_ptls_message_emitter_t *em
         goto Exit;
 
     if (tls->early_data != NULL) {
-        tls->state =
-            tls->ctx->omit_end_of_early_data ? PTLS_STATE_SERVER_EXPECT_FINISHED : PTLS_STATE_SERVER_EXPECT_END_OF_EARLY_DATA;
+        if (tls->ctx->omit_end_of_early_data) {
+            if ((ret = retire_early_data_secret(tls, 0)) != 0)
+                goto Exit;
+            tls->state = PTLS_STATE_SERVER_EXPECT_FINISHED;
+        } else {
+            tls->state = PTLS_STATE_SERVER_EXPECT_END_OF_EARLY_DATA;
+        }
     } else if (tls->ctx->require_client_authentication) {
         tls->state = PTLS_STATE_SERVER_EXPECT_CERTIFICATE;
     } else {

--- a/t/picotls.c
+++ b/t/picotls.c
@@ -912,8 +912,10 @@ static void test_handshake_api(void)
     int ret;
 
     ctx->update_traffic_key = &update_traffic_key;
+    ctx->omit_end_of_early_data = 1;
     ctx->save_ticket = &save_ticket;
     ctx_peer->update_traffic_key = &update_traffic_key;
+    ctx_peer->omit_end_of_early_data = 1;
     ctx_peer->encrypt_ticket = &encrypt_ticket;
     ctx_peer->ticket_lifetime = 86400;
     ctx_peer->max_early_data_size = 8192;
@@ -1002,8 +1004,10 @@ static void test_handshake_api(void)
     ptls_buffer_dispose(&sbuf);
 
     ctx->update_traffic_key = NULL;
+    ctx->omit_end_of_early_data = 0;
     ctx->save_ticket = NULL;
     ctx_peer->update_traffic_key = NULL;
+    ctx_peer->omit_end_of_early_data = 0;
     ctx_peer->encrypt_ticket = NULL;
     ctx_peer->save_ticket = NULL;
     ctx_peer->ticket_lifetime = 0;


### PR DESCRIPTION
Adds `ptls_context_t::omit_end_of_early_data` flag.

If set, `ptls_handle_message` does not emit an END_OF_EARLY_DATA message nor accepts it.