### PR TITLE
implement key update

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -472,10 +472,6 @@ struct st_ptls_context_t {
      */
     unsigned omit_end_of_early_data : 1;
     /**
-     * if set, key update is disabled and there will be no KeyUpdate post-handshake exchanges
-     */
-    unsigned disable_key_update : 1;
-    /**
      *
      */
     ptls_encrypt_ticket_t *encrypt_ticket;

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -115,6 +115,7 @@ extern "C" {
 #define PTLS_ERROR_SESSION_NOT_FOUND (PTLS_ERROR_CLASS_INTERNAL + 5)
 #define PTLS_ERROR_STATELESS_RETRY (PTLS_ERROR_CLASS_INTERNAL + 6)
 #define PTLS_ERROR_NOT_AVAILABLE (PTLS_ERROR_CLASS_INTERNAL + 7)
+#define PTLS_ERROR_KEY_UPDATE_REQUESTED (PTLS_ERROR_CLASS_INTERNAL + 8)
 
 #define PTLS_ERROR_INCORRECT_BASE64 (PTLS_ERROR_CLASS_INTERNAL + 50)
 #define PTLS_ERROR_PEM_LABEL_NOT_FOUND (PTLS_ERROR_CLASS_INTERNAL + 51)
@@ -803,6 +804,10 @@ int ptls_receive(ptls_t *tls, ptls_buffer_t *plaintextbuf, const void *input, si
  * encrypts given buffer into multiple TLS records
  */
 int ptls_send(ptls_t *tls, ptls_buffer_t *sendbuf, const void *input, size_t inlen);
+/**
+ * updates the send traffic key (as well as asks the peer to update)
+ */
+int ptls_update_key(ptls_t *tls, ptls_buffer_t *sendbuf, int request_update);
 /**
  * Returns if the context is a server context.
  */

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -3247,10 +3247,13 @@ static int update_traffic_key(ptls_t *tls, int is_enc)
     ptls_hash_algorithm_t *hash = tls->key_schedule->hashes[0].algo;
     if ((ret = hkdf_expand_label(hash, secret, hash->digest_size, ptls_iovec_init(tp->secret, hash->digest_size), "traffic upd",
                                  ptls_iovec_init(NULL, 0), tls->key_schedule->hkdf_label_prefix)) != 0)
-        return ret;
-
+        goto Exit;
     memcpy(tp->secret, secret, sizeof(secret));
-    return setup_traffic_protection(tls, is_enc, NULL, 3, 1);
+    ret = setup_traffic_protection(tls, is_enc, NULL, 3, 1);
+
+Exit:
+    ptls_clear_memory(secret, sizeof(secret));
+    return ret;
 }
 
 static int handle_key_update(ptls_t *tls, struct st_ptls_message_emitter_t *emitter, ptls_iovec_t message)

--- a/t/cli.c
+++ b/t/cli.c
@@ -57,7 +57,7 @@ static void shift_buffer(ptls_buffer_t *buf, size_t delta)
 }
 
 static int handle_connection(int sockfd, ptls_context_t *ctx, const char *server_name, const char *input_file,
-                             ptls_handshake_properties_t *hsprop)
+                             ptls_handshake_properties_t *hsprop, int request_key_update)
 {
     ptls_t *tls = ptls_new(ctx, server_name == NULL);
     ptls_buffer_t rbuf, encbuf, ptbuf;
@@ -131,6 +131,12 @@ static int handle_connection(int sockfd, ptls_context_t *ctx, const char *server
                         /* release data sent as early-data, if server accepted it */
                         if (hsprop->client.early_data_accepted_by_peer)
                             shift_buffer(&ptbuf, early_bytes_sent);
+                        if (request_key_update) {
+                            if ((ret = ptls_update_key(tls, &encbuf, 1)) != 0) {
+                                fprintf(stderr, "ptls_update_key(update_requested):%d\n", ret);
+                                goto Exit;
+                            }
+                        }
                         if (ptbuf.off != 0) {
                             if ((ret = ptls_send(tls, &encbuf, ptbuf.base, ptbuf.off)) != 0) {
                                 fprintf(stderr, "ptls_send(1rtt):%d\n", ret);
@@ -154,6 +160,11 @@ static int handle_connection(int sockfd, ptls_context_t *ctx, const char *server
                         }
                     } else if (ret == PTLS_ERROR_IN_PROGRESS) {
                         /* ok */
+                    } else if (ret == PTLS_ERROR_KEY_UPDATE_REQUESTED) {
+                        if ((ret = ptls_update_key(tls, &encbuf, 0)) != 0) {
+                            fprintf(stderr, "ptls_update_key(update_not_requested):%d\n", ret);
+                            goto Exit;
+                        }
                     } else {
                         fprintf(stderr, "ptls_receive:%d\n", ret);
                         goto Exit;
@@ -233,7 +244,7 @@ Exit:
 }
 
 static int run_server(struct sockaddr *sa, socklen_t salen, ptls_context_t *ctx, const char *input_file,
-                      ptls_handshake_properties_t *hsprop)
+                      ptls_handshake_properties_t *hsprop, int request_key_update)
 {
     int listen_fd, conn_fd, on = 1;
 
@@ -256,14 +267,14 @@ static int run_server(struct sockaddr *sa, socklen_t salen, ptls_context_t *ctx,
 
     while (1) {
         if ((conn_fd = accept(listen_fd, NULL, 0)) != -1)
-            handle_connection(conn_fd, ctx, NULL, input_file, hsprop);
+            handle_connection(conn_fd, ctx, NULL, input_file, hsprop, request_key_update);
     }
 
     return 0;
 }
 
 static int run_client(struct sockaddr *sa, socklen_t salen, ptls_context_t *ctx, const char *server_name, const char *input_file,
-                      ptls_handshake_properties_t *hsprop)
+                      ptls_handshake_properties_t *hsprop, int request_key_update)
 {
     int fd;
 
@@ -276,7 +287,7 @@ static int run_client(struct sockaddr *sa, socklen_t salen, ptls_context_t *ctx,
         return 1;
     }
 
-    return handle_connection(fd, ctx, server_name, input_file, hsprop);
+    return handle_connection(fd, ctx, server_name, input_file, hsprop, request_key_update);
 }
 
 static void usage(const char *cmd)
@@ -298,6 +309,7 @@ static void usage(const char *cmd)
            "  -S                   require public key exchange when resuming a session\n"
            "  -e                   when resuming a session, send first 8,192 bytes of input\n"
            "                       as early data\n"
+           "  -u                   update the traffic key when handshake is complete\n"
            "  -v                   verify peer using the default certificates\n"
            "  -h                   print this help\n"
            "\n"
@@ -330,12 +342,12 @@ int main(int argc, char **argv)
     ptls_context_t ctx = {ptls_openssl_random_bytes, &ptls_get_time, key_exchanges, ptls_openssl_cipher_suites};
     ptls_handshake_properties_t hsprop = {{{{NULL}}}};
     const char *host, *port, *file = NULL;
-    int is_server = 0, use_early_data = 0, ch;
+    int is_server = 0, use_early_data = 0, request_key_update = 0, ch;
     struct sockaddr_storage sa;
     socklen_t salen;
     int family = 0;
 
-    while ((ch = getopt(argc, argv, "46aC:c:i:k:nN:es:Sl:vh")) != -1) {
+    while ((ch = getopt(argc, argv, "46aC:c:i:k:nN:es:Sl:uvh")) != -1) {
         switch (ch) {
         case '4':
             family = AF_INET;
@@ -404,6 +416,9 @@ int main(int argc, char **argv)
                 ;
             key_exchanges[i++] = algo;
         } break;
+        case 'u':
+            request_key_update = 1;
+            break;
         default:
             usage(argv[0]);
             exit(1);
@@ -441,8 +456,8 @@ int main(int argc, char **argv)
         exit(1);
 
     if (is_server) {
-        return run_server((struct sockaddr *)&sa, salen, &ctx, file, &hsprop);
+        return run_server((struct sockaddr *)&sa, salen, &ctx, file, &hsprop, request_key_update);
     } else {
-        return run_client((struct sockaddr *)&sa, salen, &ctx, host, file, &hsprop);
+        return run_client((struct sockaddr *)&sa, salen, &ctx, host, file, &hsprop, request_key_update);
     }
 }


### PR DESCRIPTION
The API changes are:
* `ptls_receive` returns `PTLS_ERROR_KEY_UPDATE_REQUESTED` when the peer requests a key update
* `ptls_key_update` should be called in response to peer requesting a key update, or when you want to initiate a key update

Such design has been chosen due to the fact that we cannot send a handshake message in `ptls_send` (because it is assumed that the output size does not increase except for the overhead of the record that carries application data).