### PR TITLE
automagically update the traffic key, unless `update_traffic_key` callback is used

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -115,7 +115,6 @@ extern "C" {
 #define PTLS_ERROR_SESSION_NOT_FOUND (PTLS_ERROR_CLASS_INTERNAL + 5)
 #define PTLS_ERROR_STATELESS_RETRY (PTLS_ERROR_CLASS_INTERNAL + 6)
 #define PTLS_ERROR_NOT_AVAILABLE (PTLS_ERROR_CLASS_INTERNAL + 7)
-#define PTLS_ERROR_KEY_UPDATE_REQUESTED (PTLS_ERROR_CLASS_INTERNAL + 8)
 
 #define PTLS_ERROR_INCORRECT_BASE64 (PTLS_ERROR_CLASS_INTERNAL + 50)
 #define PTLS_ERROR_PEM_LABEL_NOT_FOUND (PTLS_ERROR_CLASS_INTERNAL + 51)
@@ -803,7 +802,7 @@ int ptls_send(ptls_t *tls, ptls_buffer_t *sendbuf, const void *input, size_t inl
 /**
  * updates the send traffic key (as well as asks the peer to update)
  */
-int ptls_update_key(ptls_t *tls, ptls_buffer_t *sendbuf, int request_update);
+int ptls_update_key(ptls_t *tls, int request_update);
 /**
  * Returns if the context is a server context.
  */

--- a/t/cli.c
+++ b/t/cli.c
@@ -131,12 +131,8 @@ static int handle_connection(int sockfd, ptls_context_t *ctx, const char *server
                         /* release data sent as early-data, if server accepted it */
                         if (hsprop->client.early_data_accepted_by_peer)
                             shift_buffer(&ptbuf, early_bytes_sent);
-                        if (request_key_update) {
-                            if ((ret = ptls_update_key(tls, &encbuf, 1)) != 0) {
-                                fprintf(stderr, "ptls_update_key(update_requested):%d\n", ret);
-                                goto Exit;
-                            }
-                        }
+                        if (request_key_update)
+                            ptls_update_key(tls, 1);
                         if (ptbuf.off != 0) {
                             if ((ret = ptls_send(tls, &encbuf, ptbuf.base, ptbuf.off)) != 0) {
                                 fprintf(stderr, "ptls_send(1rtt):%d\n", ret);
@@ -160,11 +156,6 @@ static int handle_connection(int sockfd, ptls_context_t *ctx, const char *server
                         }
                     } else if (ret == PTLS_ERROR_IN_PROGRESS) {
                         /* ok */
-                    } else if (ret == PTLS_ERROR_KEY_UPDATE_REQUESTED) {
-                        if ((ret = ptls_update_key(tls, &encbuf, 0)) != 0) {
-                            fprintf(stderr, "ptls_update_key(update_not_requested):%d\n", ret);
-                            goto Exit;
-                        }
                     } else {
                         fprintf(stderr, "ptls_receive:%d\n", ret);
                         goto Exit;


### PR DESCRIPTION
Picotls now handles key updates by itself. Specifically:
* `ptls_receive` never returns `PTLS_ERROR_KEY_UPDATE_REQUESTED`
* ciphertext returned from `ptls_send` may include a Key Update handshake message at any time

amends #183