### PR TITLE
support for precompressed certificates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,22 @@ SET(MINICRYPTO_LIBRARY_FILES
     deps/cifra/src/poly1305.c
     deps/cifra/src/sha256.c
     deps/cifra/src/sha512.c)
+SET(CORE_FILES
+    lib/picotls.c
+    lib/pembase64.c)
 
-ADD_LIBRARY(picotls-core lib/picotls.c lib/pembase64.c)
+PKG_CHECK_MODULES(BROTLI_DEC libbrotlidec)
+PKG_CHECK_MODULES(BROTLI_ENC libbrotlienc)
+IF (BROTLI_DEC_FOUND AND BROTLI_ENC_FOUND)
+    INCLUDE_DIRECTORIES(${BROTLI_DEC_INCLUDE_DIRS} ${BROTLI_ENC_INCLUDE_DIRS})
+    LINK_DIRECTORIES(${BROTLI_DEC_LIBRARY_DIRS} ${BROTLI_ENC_LIBRARY_DIRS})
+    SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DPICOTLS_USE_BROTLI=1")
+    LIST(APPEND CORE_FILES
+        lib/certificate_compression.c)
+    LIST(APPEND CLI_EXTRA_LIBS ${BROTLI_DEC_LIBRARIES} ${BROTLI_ENC_LIBRARIES})
+ENDIF ()
+
+ADD_LIBRARY(picotls-core ${CORE_FILES})
 ADD_LIBRARY(picotls-minicrypto ${MINICRYPTO_LIBRARY_FILES} lib/cifra.c lib/minicrypto-pem.c lib/uecc.c lib/asn1.c)
 ADD_EXECUTABLE(test-minicrypto.t ${MINICRYPTO_LIBRARY_FILES} deps/picotest/picotest.c t/picotls.c t/minicrypto.c lib/asn1.c lib/pembase64.c)
 
@@ -35,7 +49,7 @@ IF (OPENSSL_FOUND AND NOT (OPENSSL_VERSION VERSION_LESS "1.0.1"))
     INCLUDE_DIRECTORIES(${OPENSSL_INCLUDE_DIR})
     ADD_LIBRARY(picotls-openssl lib/openssl.c)
     ADD_EXECUTABLE(cli t/cli.c lib/pembase64.c)
-    TARGET_LINK_LIBRARIES(cli picotls-openssl picotls-core ${OPENSSL_LIBRARIES} ${CMAKE_DL_LIBS})
+    TARGET_LINK_LIBRARIES(cli picotls-openssl picotls-core ${OPENSSL_LIBRARIES} ${CLI_EXTRA_LIBS} ${CMAKE_DL_LIBS})
     ADD_EXECUTABLE(test-openssl.t ${MINICRYPTO_LIBRARY_FILES} lib/cifra.c lib/uecc.c lib/asn1.c lib/pembase64.c deps/picotest/picotest.c t/picotls.c t/openssl.c)
     SET_TARGET_PROPERTIES(test-openssl.t PROPERTIES COMPILE_FLAGS "-DPTLS_MEMORY_DEBUG=1")
     TARGET_LINK_LIBRARIES(test-openssl.t ${OPENSSL_LIBRARIES} ${CMAKE_DL_LIBS})

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -344,6 +344,27 @@ typedef const struct st_ptls_cipher_suite_t {
     } ptls_##name##_t
 
 /**
+ * arguments passsed to the on_client_hello callback
+ */
+typedef struct st_ptls_on_client_hello_parameters_t {
+    /**
+     * SNI value received from the client. The value is {NULL, 0} if the extension was absent.
+     */
+    ptls_iovec_t server_name;
+    /**
+     *
+     */
+    struct {
+        ptls_iovec_t *list;
+        size_t count;
+    } negotiated_protocols;
+    struct {
+        const uint16_t *list;
+        size_t count;
+    } signature_algorithms;
+} ptls_on_client_hello_parameters_t;
+
+/**
  * returns current time in milliseconds (ptls_get_time can be used to return the physical time)
  */
 PTLS_CALLBACK_TYPE0(uint64_t, get_time);
@@ -351,8 +372,7 @@ PTLS_CALLBACK_TYPE0(uint64_t, get_time);
  * after receiving ClientHello, the core calls the optional callback to give a chance to the swap the context depending on the input
  * values. The callback is required to call `ptls_set_server_name` if an SNI extension needs to be sent to the client.
  */
-PTLS_CALLBACK_TYPE(int, on_client_hello, ptls_t *tls, ptls_iovec_t server_name, const ptls_iovec_t *negotiated_protocols,
-                   size_t num_negotiated_protocols, const uint16_t *signature_algorithms, size_t num_signature_algorithms);
+PTLS_CALLBACK_TYPE(int, on_client_hello, ptls_t *tls, ptls_on_client_hello_parameters_t *params);
 /**
  * when generating Certificate, the core calls the callback to obtain the OCSP response for stapling.
  */

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -405,7 +405,8 @@ PTLS_CALLBACK_TYPE(int, on_client_hello, ptls_t *tls, ptls_on_client_hello_param
 /**
  * callback to generate the certificate message. `ptls_context::certificates` are set when the callback is set to NULL.
  */
-PTLS_CALLBACK_TYPE(int, emit_certificate, ptls_t *tls, ptls_iovec_t context, uint8_t *out_type, ptls_buffer_t *outbuf);
+PTLS_CALLBACK_TYPE(int, emit_certificate, ptls_t *tls, ptls_message_emitter_t *emitter, ptls_key_schedule_t *key_sched,
+                   ptls_iovec_t context);
 /**
  * when gerenating CertificateVerify, the core calls the callback to sign the handshake context using the certificate.
  */

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -161,6 +161,7 @@ extern "C" {
 
 typedef struct st_ptls_t ptls_t;
 typedef struct st_ptls_context_t ptls_context_t;
+typedef struct st_ptls_key_schedule_t ptls_key_schedule_t;
 
 /**
  * represents a sequence of octets
@@ -346,6 +347,16 @@ typedef const struct st_ptls_cipher_suite_t {
     ptls_aead_algorithm_t *aead;
     ptls_hash_algorithm_t *hash;
 } ptls_cipher_suite_t;
+
+struct st_ptls_traffic_protection_t;
+
+typedef struct st_ptls_message_emitter_t {
+    ptls_buffer_t *buf;
+    struct st_ptls_traffic_protection_t *enc;
+    size_t record_header_length;
+    int (*begin_message)(struct st_ptls_message_emitter_t *self);
+    int (*commit_message)(struct st_ptls_message_emitter_t *self);
+} ptls_message_emitter_t;
 
 #define PTLS_CALLBACK_TYPE0(ret, name)                                                                                             \
     typedef struct st_ptls_##name##_t {                                                                                            \
@@ -742,6 +753,27 @@ int ptls_buffer_push_asn1_ubigint(ptls_buffer_t *buf, const void *bignum, size_t
         ptls_buffer_push_asn1_block((buf), block);                                                                                 \
     } while (0)
 
+#define ptls_buffer_push_message_body(buf, key_sched, type, block)                                                                 \
+    do {                                                                                                                           \
+        ptls_buffer_t *_buf = (buf);                                                                                               \
+        ptls_key_schedule_t *_key_sched = (key_sched);                                                                             \
+        size_t mess_start = _buf->off;                                                                                             \
+        ptls_buffer_push(_buf, (type));                                                                                            \
+        ptls_buffer_push_block(_buf, 3, block);                                                                                    \
+        if (_key_sched != NULL)                                                                                                    \
+            ptls__key_schedule_update_hash(_key_sched, _buf->base + mess_start, _buf->off - mess_start);                           \
+    } while (0)
+
+#define ptls_push_message(emitter, key_sched, type, block)                                                                         \
+    do {                                                                                                                           \
+        ptls_message_emitter_t *_emitter = (emitter);                                                                              \
+        if ((ret = _emitter->begin_message(_emitter)) != 0)                                                                        \
+            goto Exit;                                                                                                             \
+        ptls_buffer_push_message_body(_emitter->buf, (key_sched), (type), block);                                                  \
+        if ((ret = _emitter->commit_message(_emitter)) != 0)                                                                       \
+            goto Exit;                                                                                                             \
+    } while (0)
+
 int ptls_decode16(uint16_t *value, const uint8_t **src, const uint8_t *end);
 int ptls_decode24(uint32_t *value, const uint8_t **src, const uint8_t *end);
 int ptls_decode32(uint32_t *value, const uint8_t **src, const uint8_t *end);
@@ -990,6 +1022,10 @@ int ptls_handle_message(ptls_t *tls, ptls_buffer_t *sendbuf, size_t epoch_offset
  * internal
  */
 void ptls_aead__build_iv(ptls_aead_context_t *ctx, uint8_t *iv, uint64_t seq);
+/**
+ * internal
+ */
+void ptls__key_schedule_update_hash(ptls_key_schedule_t *sched, const uint8_t *msg, size_t msglen);
 /**
  * clears memory
  */

--- a/include/picotls/certificate_compression.h
+++ b/include/picotls/certificate_compression.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2018 Fastly
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#ifndef picotls_certificate_compression_h
+#define picotls_certificate_compression_h
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "picotls.h"
+
+#define PTLS_CERTIFICATE_COMPRESSION_ALGORITHM_GZIP 1
+#define PTLS_CERTIFICATE_COMPRESSION_ALGORITHM_BROTLI 2
+
+typedef struct st_ptls_emit_compressed_certificate_t {
+    ptls_emit_certificate_t super;
+    uint16_t algo;
+    uint32_t uncompressed_length;
+    ptls_iovec_t buf;
+} ptls_emit_compressed_certificate_t;
+
+extern ptls_decompress_certificate_t ptls_decompress_certificate;
+
+int ptls_init_compressed_certificate(ptls_emit_compressed_certificate_t *ecc, uint16_t algo, ptls_iovec_t *certificates,
+                                     size_t num_certificates, ptls_iovec_t ocsp_status);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/lib/certificate_compression.c
+++ b/lib/certificate_compression.c
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2018 Fastly
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include <assert.h>
+#include <stdlib.h>
+#include "brotli/decode.h"
+#include "brotli/encode.h"
+#include "picotls/certificate_compression.h"
+
+static inline int decompress_certificate(ptls_decompress_certificate_t *self, ptls_t *tls, uint16_t algorithm, ptls_iovec_t output,
+                                         ptls_iovec_t input)
+{
+    if (algorithm != PTLS_CERTIFICATE_COMPRESSION_ALGORITHM_BROTLI)
+        goto Fail;
+
+    size_t decoded_size = output.len;
+    if (BrotliDecoderDecompress(input.len, input.base, &decoded_size, output.base) != BROTLI_DECODER_RESULT_SUCCESS)
+        goto Fail;
+
+    if (decoded_size != output.len)
+        goto Fail;
+
+    return 0;
+Fail:
+    return PTLS_ALERT_BAD_CERTIFICATE;
+}
+
+static const uint16_t algorithms[] = {PTLS_CERTIFICATE_COMPRESSION_ALGORITHM_BROTLI, UINT16_MAX};
+
+ptls_decompress_certificate_t ptls_decompress_certificate = {algorithms, decompress_certificate};
+
+static int emit_compressed_certificate(ptls_emit_certificate_t *_self, ptls_t *tls, ptls_iovec_t context, uint8_t *out_type,
+                                       ptls_buffer_t *outbuf)
+{
+    ptls_emit_compressed_certificate_t *self = (void *)_self;
+    int ret;
+
+    assert(context.len == 0 || !"precompressed mode can only be used for server certificates");
+
+    *out_type = PTLS_HANDSHAKE_TYPE_COMPRESSED_CERTIFICATE;
+
+    ptls_buffer_push16(outbuf, self->algo);
+    ptls_buffer_push24(outbuf, self->uncompressed_length);
+    ptls_buffer_push_block(outbuf, 3, { ptls_buffer_pushv(outbuf, self->buf.base, self->buf.len); });
+
+    ret = 0;
+
+Exit:
+    return ret;
+}
+
+int ptls_init_compressed_certificate(ptls_emit_compressed_certificate_t *self, uint16_t algo, ptls_iovec_t *certificates,
+                                     size_t num_certificates, ptls_iovec_t ocsp_status)
+{
+    ptls_buffer_t uncompressed;
+    int ret;
+
+    *self = (ptls_emit_compressed_certificate_t){{emit_compressed_certificate}, algo};
+
+    ptls_buffer_init(&uncompressed, "", 0);
+
+    /* build uncompressed */
+    if ((ret = ptls_build_certificate_message(&uncompressed, ptls_iovec_init(NULL, 0), certificates, num_certificates,
+                                              ocsp_status)) != 0)
+        goto Exit;
+    self->uncompressed_length = (uint32_t)uncompressed.off;
+
+    /* compress */
+    self->buf.len = uncompressed.off - 1;
+    if ((self->buf.base = malloc(self->buf.len)) == NULL) {
+        ret = PTLS_ERROR_NO_MEMORY;
+        goto Exit;
+    }
+    if (BrotliEncoderCompress(BROTLI_MAX_QUALITY, BROTLI_DEFAULT_WINDOW, BROTLI_MODE_GENERIC, uncompressed.off, uncompressed.base,
+                              &self->buf.len, self->buf.base) != BROTLI_TRUE) {
+        ret = PTLS_ERROR_COMPRESSION_FAILURE;
+        goto Exit;
+    }
+
+    ret = 0;
+
+Exit:
+    if (ret != 0)
+        free(self->buf.base);
+    ptls_buffer_dispose(&uncompressed);
+    return ret;
+}

--- a/lib/certificate_compression.c
+++ b/lib/certificate_compression.c
@@ -47,19 +47,19 @@ static const uint16_t algorithms[] = {PTLS_CERTIFICATE_COMPRESSION_ALGORITHM_BRO
 
 ptls_decompress_certificate_t ptls_decompress_certificate = {algorithms, decompress_certificate};
 
-static int emit_compressed_certificate(ptls_emit_certificate_t *_self, ptls_t *tls, ptls_iovec_t context, uint8_t *out_type,
-                                       ptls_buffer_t *outbuf)
+static int emit_compressed_certificate(ptls_emit_certificate_t *_self, ptls_t *tls, ptls_message_emitter_t *emitter,
+                                       ptls_key_schedule_t *key_sched, ptls_iovec_t context)
 {
     ptls_emit_compressed_certificate_t *self = (void *)_self;
     int ret;
 
     assert(context.len == 0 || !"precompressed mode can only be used for server certificates");
 
-    *out_type = PTLS_HANDSHAKE_TYPE_COMPRESSED_CERTIFICATE;
-
-    ptls_buffer_push16(outbuf, self->algo);
-    ptls_buffer_push24(outbuf, self->uncompressed_length);
-    ptls_buffer_push_block(outbuf, 3, { ptls_buffer_pushv(outbuf, self->buf.base, self->buf.len); });
+    ptls_push_message(emitter, key_sched, PTLS_HANDSHAKE_TYPE_COMPRESSED_CERTIFICATE, {
+        ptls_buffer_push16(emitter->buf, self->algo);
+        ptls_buffer_push24(emitter->buf, self->uncompressed_length);
+        ptls_buffer_push_block(emitter->buf, 3, { ptls_buffer_pushv(emitter->buf, self->buf.base, self->buf.len); });
+    });
 
     ret = 0;
 

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -2860,10 +2860,12 @@ static int server_handle_hello(ptls_t *tls, struct st_ptls_message_emitter_t *em
     /* handle client_random and SNI */
     if (!is_second_flight) {
         memcpy(tls->client_random, ch.random_bytes, sizeof(tls->client_random));
-        if (tls->ctx->on_client_hello != NULL &&
-            (ret = tls->ctx->on_client_hello->cb(tls->ctx->on_client_hello, tls, ch.server_name, ch.alpn.list, ch.alpn.count,
-                                                 ch.signature_algorithms.list, ch.signature_algorithms.count)) != 0)
-            goto Exit;
+        if (tls->ctx->on_client_hello != NULL) {
+            ptls_on_client_hello_parameters_t params = {
+                ch.server_name, {ch.alpn.list, ch.alpn.count}, {ch.signature_algorithms.list, ch.signature_algorithms.count}};
+            if ((ret = tls->ctx->on_client_hello->cb(tls->ctx->on_client_hello, tls, &params)) != 0)
+                goto Exit;
+        }
     } else {
         if (ch.psk.early_data_indication) {
             ret = PTLS_ALERT_DECODE_ERROR;

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -45,18 +45,6 @@
 #define PTLS_CONTENT_TYPE_HANDSHAKE 22
 #define PTLS_CONTENT_TYPE_APPDATA 23
 
-#define PTLS_HANDSHAKE_TYPE_CLIENT_HELLO 1
-#define PTLS_HANDSHAKE_TYPE_SERVER_HELLO 2
-#define PTLS_HANDSHAKE_TYPE_NEW_SESSION_TICKET 4
-#define PTLS_HANDSHAKE_TYPE_END_OF_EARLY_DATA 5
-#define PTLS_HANDSHAKE_TYPE_ENCRYPTED_EXTENSIONS 8
-#define PTLS_HANDSHAKE_TYPE_CERTIFICATE 11
-#define PTLS_HANDSHAKE_TYPE_CERTIFICATE_REQUEST 13
-#define PTLS_HANDSHAKE_TYPE_CERTIFICATE_VERIFY 15
-#define PTLS_HANDSHAKE_TYPE_FINISHED 20
-#define PTLS_HANDSHAKE_TYPE_KEY_UPDATE 24
-#define PTLS_HANDSHAKE_TYPE_MESSAGE_HASH 254
-
 #define PTLS_PSK_KE_MODE_PSK 0
 #define PTLS_PSK_KE_MODE_PSK_DHE 1
 
@@ -67,6 +55,7 @@
 #define PTLS_EXTENSION_TYPE_SUPPORTED_GROUPS 10
 #define PTLS_EXTENSION_TYPE_SIGNATURE_ALGORITHMS 13
 #define PTLS_EXTENSION_TYPE_ALPN 16
+#define PTLS_EXTENSION_TYPE_COMPRESS_CERTIFICATE 27
 #define PTLS_EXTENSION_TYPE_PRE_SHARED_KEY 41
 #define PTLS_EXTENSION_TYPE_EARLY_DATA 42
 #define PTLS_EXTENSION_TYPE_SUPPORTED_VERSIONS 43
@@ -298,6 +287,10 @@ struct st_ptls_client_hello_t {
         ptls_iovec_t list[16];
         size_t count;
     } alpn;
+    struct {
+        uint16_t list[16];
+        size_t count;
+    } cert_compression_algos;
     struct {
         ptls_iovec_t all;
         ptls_iovec_t tbs;
@@ -734,6 +727,15 @@ int ptls_decode16(uint16_t *value, const uint8_t **src, const uint8_t *end)
         return PTLS_ALERT_DECODE_ERROR;
     *value = ntoh16(*src);
     *src += 2;
+    return 0;
+}
+
+int ptls_decode24(uint32_t *value, const uint8_t **src, const uint8_t *end)
+{
+    if (end - *src < 3)
+        return PTLS_ALERT_DECODE_ERROR;
+    *value = ((uint32_t)(*src)[0] << 16) | ((uint32_t)(*src)[1] << 8) | (*src)[2];
+    *src += 3;
     return 0;
 }
 
@@ -1518,6 +1520,16 @@ static int send_client_hello(ptls_t *tls, struct st_ptls_message_emitter_t *emit
                     });
                 });
             }
+            if (tls->ctx->decompress_certificate != NULL) {
+                buffer_push_extension(sendbuf, PTLS_EXTENSION_TYPE_COMPRESS_CERTIFICATE, {
+                    ptls_buffer_push_block(sendbuf, 1, {
+                        const uint16_t *algo = tls->ctx->decompress_certificate->supported_algorithms;
+                        assert(*algo != UINT16_MAX);
+                        for (; *algo != UINT16_MAX; ++algo)
+                            ptls_buffer_push16(sendbuf, *algo);
+                    });
+                });
+            }
             buffer_push_extension(sendbuf, PTLS_EXTENSION_TYPE_SUPPORTED_VERSIONS, {
                 ptls_buffer_push_block(sendbuf, 1, {
                     size_t i;
@@ -2001,10 +2013,47 @@ Exit:
     return ret;
 }
 
+int ptls_build_certificate_message(ptls_buffer_t *buf, ptls_iovec_t context, ptls_iovec_t *certificates, size_t num_certificates,
+                                   ptls_iovec_t ocsp_status)
+{
+    int ret;
+
+    ptls_buffer_push_block(buf, 1, { ptls_buffer_pushv(buf, context.base, context.len); });
+    ptls_buffer_push_block(buf, 3, {
+        size_t i;
+        for (i = 0; i != num_certificates; ++i) {
+            ptls_buffer_push_block(buf, 3, { ptls_buffer_pushv(buf, certificates[i].base, certificates[i].len); });
+            ptls_buffer_push_block(buf, 2, {
+                if (i == 0 && ocsp_status.len != 0) {
+                    buffer_push_extension(buf, PTLS_EXTENSION_TYPE_STATUS_REQUEST, {
+                        ptls_buffer_push(buf, 1); /* status_type == ocsp */
+                        ptls_buffer_push_block(buf, 3, { ptls_buffer_pushv(buf, ocsp_status.base, ocsp_status.len); });
+                    });
+                }
+            });
+        }
+    });
+
+    ret = 0;
+Exit:
+    return ret;
+}
+
+static int default_emit_certificate_cb(ptls_emit_certificate_t *_self, ptls_t *tls, ptls_iovec_t context, uint8_t *type,
+                                       ptls_buffer_t *outbuf)
+{
+    *type = PTLS_HANDSHAKE_TYPE_CERTIFICATE;
+    return ptls_build_certificate_message(outbuf, context, tls->ctx->certificates.list, tls->ctx->certificates.count,
+                                          ptls_iovec_init(NULL, 0));
+}
+
 static int send_certificate_and_certificate_verify(ptls_t *tls, struct st_ptls_message_emitter_t *emitter,
                                                    struct st_ptls_signature_algorithms_t *signature_algorithms,
-                                                   ptls_iovec_t context, const char *context_string, uint8_t push_status_request)
+                                                   ptls_iovec_t context, const char *context_string, int push_status_request)
 {
+    static ptls_emit_certificate_t default_emit_certificate = {default_emit_certificate_cb};
+    ptls_emit_certificate_t *emit_certificate =
+        tls->ctx->emit_certificate != NULL ? tls->ctx->emit_certificate : &default_emit_certificate;
     int ret;
 
     if (signature_algorithms->count == 0) {
@@ -2012,35 +2061,14 @@ static int send_certificate_and_certificate_verify(ptls_t *tls, struct st_ptls_m
         goto Exit;
     }
 
-    /* send Certificate */
+    /* send Certificate (or the equivalent) */
     push_message(emitter, tls->key_schedule, PTLS_HANDSHAKE_TYPE_CERTIFICATE, {
-        ptls_buffer_t *sendbuf = emitter->buf;
-        ptls_buffer_push_block(sendbuf, 1, { ptls_buffer_pushv(sendbuf, context.base, context.len); });
-        ptls_buffer_push_block(sendbuf, 3, {
-            size_t i;
-            for (i = 0; i != tls->ctx->certificates.count; ++i) {
-                ptls_buffer_push_block(sendbuf, 3, {
-                    ptls_buffer_pushv(sendbuf, tls->ctx->certificates.list[i].base, tls->ctx->certificates.list[i].len);
-                });
-                ptls_buffer_push_block(sendbuf, 2, {
-                    /* emit OCSP stapling only when requested and when the callback successfully returns one */
-                    if (push_status_request && i == 0 && tls->ctx->staple_ocsp != NULL) {
-                        size_t reset_off_to = sendbuf->off;
-                        buffer_push_extension(sendbuf, PTLS_EXTENSION_TYPE_STATUS_REQUEST, {
-                            ptls_buffer_push(sendbuf, 1); /* status_type == ocsp */
-                            ptls_buffer_push_block(sendbuf, 3, {
-                                if ((ret = tls->ctx->staple_ocsp->cb(tls->ctx->staple_ocsp, tls, sendbuf, i)) == 0) {
-                                    reset_off_to = 0;
-                                }
-                            });
-                        });
-                        if (reset_off_to != 0) {
-                            sendbuf->off = reset_off_to;
-                        }
-                    }
-                });
-            }
-        });
+        /* emit a custom message by filling in the bytes and then overwriting the message type */
+        size_t start_at = emitter->buf->off;
+        uint8_t type;
+        if ((ret = emit_certificate->cb(emit_certificate, tls, context, &type, emitter->buf)) != 0)
+            goto Exit;
+        emitter->buf->base[start_at - 4] = type;
     });
 
     /* build and send CertificateVerify */
@@ -2086,9 +2114,8 @@ static int client_handle_certificate_request(ptls_t *tls, ptls_iovec_t message, 
     return PTLS_ERROR_IN_PROGRESS;
 }
 
-static int handle_certificate(ptls_t *tls, ptls_iovec_t message, int *got_certs)
+static int handle_certificate(ptls_t *tls, const uint8_t *src, const uint8_t *end, int *got_certs)
 {
-    const uint8_t *src = message.base + PTLS_HANDSHAKE_HEADER_SIZE, *const end = message.base + message.len;
     ptls_iovec_t certs[16];
     size_t num_certs = 0;
     int ret = 0;
@@ -2119,34 +2146,94 @@ static int handle_certificate(ptls_t *tls, ptls_iovec_t message, int *got_certs)
             goto Exit;
     }
 
-    key_schedule_update_hash(tls->key_schedule, message.base, message.len);
     *got_certs = num_certs != 0;
 
 Exit:
     return ret;
 }
 
-static int client_handle_certificate(ptls_t *tls, ptls_iovec_t message)
+static int client_do_handle_certificate(ptls_t *tls, const uint8_t *src, const uint8_t *end)
 {
     int got_certs, ret;
 
-    if ((ret = handle_certificate(tls, message, &got_certs)) != 0)
+    if ((ret = handle_certificate(tls, src, end, &got_certs)) != 0)
         return ret;
     if (!got_certs)
         return PTLS_ALERT_ILLEGAL_PARAMETER;
 
+    return 0;
+}
+
+static int client_handle_certificate(ptls_t *tls, ptls_iovec_t message)
+{
+    int ret;
+
+    if ((ret = client_do_handle_certificate(tls, message.base + PTLS_HANDSHAKE_HEADER_SIZE, message.base + message.len)) != 0)
+        return ret;
+
+    key_schedule_update_hash(tls->key_schedule, message.base, message.len);
+
     tls->state = PTLS_STATE_CLIENT_EXPECT_CERTIFICATE_VERIFY;
     return PTLS_ERROR_IN_PROGRESS;
+}
+
+static int client_handle_compressed_certificate(ptls_t *tls, ptls_iovec_t message)
+{
+    const uint8_t *src = message.base + PTLS_HANDSHAKE_HEADER_SIZE, *const end = message.base + message.len;
+    uint16_t algo;
+    uint32_t uncompressed_size;
+    uint8_t *uncompressed = NULL;
+    int ret;
+
+    if (tls->ctx->decompress_certificate == NULL) {
+        ret = PTLS_ALERT_UNEXPECTED_MESSAGE;
+        goto Exit;
+    }
+
+    /* decode */
+    if ((ret = ptls_decode16(&algo, &src, end)) != 0)
+        goto Exit;
+    if ((ret = ptls_decode24(&uncompressed_size, &src, end)) != 0)
+        goto Exit;
+    if (uncompressed_size > 65536) { /* TODO find a sensible number */
+        ret = PTLS_ALERT_BAD_CERTIFICATE;
+        goto Exit;
+    }
+    if ((uncompressed = malloc(uncompressed_size)) == NULL) {
+        ret = PTLS_ERROR_NO_MEMORY;
+        goto Exit;
+    }
+    ptls_decode_block(src, end, 3, {
+        if ((ret = tls->ctx->decompress_certificate->cb(tls->ctx->decompress_certificate, tls, algo,
+                                                        ptls_iovec_init(uncompressed, uncompressed_size),
+                                                        ptls_iovec_init(src, end - src))) != 0)
+            goto Exit;
+        src = end;
+    });
+
+    /* handle */
+    if ((ret = client_do_handle_certificate(tls, uncompressed, uncompressed + uncompressed_size)) != 0)
+        goto Exit;
+
+    key_schedule_update_hash(tls->key_schedule, message.base, message.len);
+    tls->state = PTLS_STATE_CLIENT_EXPECT_CERTIFICATE_VERIFY;
+    ret = PTLS_ERROR_IN_PROGRESS;
+
+Exit:
+    free(uncompressed);
+    return ret;
 }
 
 static int server_handle_certificate(ptls_t *tls, ptls_iovec_t message)
 {
     int got_certs, ret;
 
-    if ((ret = handle_certificate(tls, message, &got_certs)) != 0)
+    if ((ret = handle_certificate(tls, message.base + PTLS_HANDSHAKE_HEADER_SIZE, message.base + message.len, &got_certs)) != 0)
         return ret;
     if (!got_certs)
         return PTLS_ALERT_CERTIFICATE_REQUIRED;
+
+    key_schedule_update_hash(tls->key_schedule, message.base, message.len);
 
     tls->state = PTLS_STATE_SERVER_EXPECT_CERTIFICATE_VERIFY;
     return PTLS_ERROR_IN_PROGRESS;
@@ -2504,6 +2591,18 @@ static int decode_client_hello(ptls_t *tls, struct st_ptls_client_hello_t *ch, c
                 } while (src != end);
             });
             break;
+        case PTLS_EXTENSION_TYPE_COMPRESS_CERTIFICATE:
+            ptls_decode_block(src, end, 1, {
+                do {
+                    uint16_t id;
+                    if ((ret = ptls_decode16(&id, &src, end)) != 0)
+                        goto Exit;
+                    if (ch->cert_compression_algos.count <
+                        sizeof(ch->cert_compression_algos.list) / sizeof(ch->cert_compression_algos.list[0]))
+                        ch->cert_compression_algos.list[ch->cert_compression_algos.count++] = id;
+                } while (src != end);
+            });
+            break;
         case PTLS_EXTENSION_TYPE_SUPPORTED_GROUPS:
             ch->negotiated_groups = ptls_iovec_init(src, end - src);
             break;
@@ -2838,8 +2937,8 @@ static int server_handle_hello(ptls_t *tls, struct st_ptls_message_emitter_t *em
                           } while (0);                                                                                             \
                       })
 
-    struct st_ptls_client_hello_t ch = {NULL,  {NULL}, {NULL},     0,        {NULL}, {NULL},        {NULL},
-                                        {{0}}, {NULL}, {{{NULL}}}, {{NULL}}, {NULL}, {{UINT16_MAX}}};
+    struct st_ptls_client_hello_t ch = {NULL,  {NULL}, {NULL},     0,     {NULL},   {NULL}, {NULL},
+                                        {{0}}, {NULL}, {{{NULL}}}, {{0}}, {{NULL}}, {NULL}, {{UINT16_MAX}}};
     struct {
         ptls_key_exchange_algorithm_t *algorithm;
         ptls_iovec_t peer_key;
@@ -2861,8 +2960,10 @@ static int server_handle_hello(ptls_t *tls, struct st_ptls_message_emitter_t *em
     if (!is_second_flight) {
         memcpy(tls->client_random, ch.random_bytes, sizeof(tls->client_random));
         if (tls->ctx->on_client_hello != NULL) {
-            ptls_on_client_hello_parameters_t params = {
-                ch.server_name, {ch.alpn.list, ch.alpn.count}, {ch.signature_algorithms.list, ch.signature_algorithms.count}};
+            ptls_on_client_hello_parameters_t params = {ch.server_name,
+                                                        {ch.alpn.list, ch.alpn.count},
+                                                        {ch.signature_algorithms.list, ch.signature_algorithms.count},
+                                                        {ch.cert_compression_algos.list, ch.cert_compression_algos.count}};
             if ((ret = tls->ctx->on_client_hello->cb(tls->ctx->on_client_hello, tls, &params)) != 0)
                 goto Exit;
         }
@@ -3528,23 +3629,22 @@ static int handle_handshake_message(ptls_t *tls, struct st_ptls_message_emitter_
         }
         break;
     case PTLS_STATE_CLIENT_EXPECT_CERTIFICATE_REQUEST_OR_CERTIFICATE:
-        switch (type) {
-        case PTLS_HANDSHAKE_TYPE_CERTIFICATE_REQUEST:
+        if (type == PTLS_HANDSHAKE_TYPE_CERTIFICATE_REQUEST) {
             ret = client_handle_certificate_request(tls, message, properties);
             break;
+        }
+    /* fall through */
+    case PTLS_STATE_CLIENT_EXPECT_CERTIFICATE:
+        switch (type) {
         case PTLS_HANDSHAKE_TYPE_CERTIFICATE:
             ret = client_handle_certificate(tls, message);
+            break;
+        case PTLS_HANDSHAKE_TYPE_COMPRESSED_CERTIFICATE:
+            ret = client_handle_compressed_certificate(tls, message);
             break;
         default:
             ret = PTLS_ALERT_UNEXPECTED_MESSAGE;
             break;
-        }
-        break;
-    case PTLS_STATE_CLIENT_EXPECT_CERTIFICATE:
-        if (type == PTLS_HANDSHAKE_TYPE_CERTIFICATE) {
-            ret = client_handle_certificate(tls, message);
-        } else {
-            ret = PTLS_ALERT_UNEXPECTED_MESSAGE;
         }
         break;
     case PTLS_STATE_CLIENT_EXPECT_CERTIFICATE_VERIFY:

--- a/picotls.xcodeproj/project.pbxproj
+++ b/picotls.xcodeproj/project.pbxproj
@@ -105,6 +105,7 @@
 		E9BC76DF1EF3CCD100EB7A09 /* salsa20.h in Headers */ = {isa = PBXBuildFile; fileRef = E9BC76CC1EF3A31000EB7A09 /* salsa20.h */; };
 		E9BC76E01EF3CCDD00EB7A09 /* poly1305.c in Sources */ = {isa = PBXBuildFile; fileRef = E9BC76D61EF3C1C200EB7A09 /* poly1305.c */; };
 		E9BC76E11EF3CCDE00EB7A09 /* poly1305.c in Sources */ = {isa = PBXBuildFile; fileRef = E9BC76D61EF3C1C200EB7A09 /* poly1305.c */; };
+		E9E4B12B2180530400514B47 /* certificate_compression.c in Sources */ = {isa = PBXBuildFile; fileRef = E9E4B12A2180530400514B47 /* certificate_compression.c */; };
 		E9E865EB203BD46600E2FFCD /* sha512.c in Sources */ = {isa = PBXBuildFile; fileRef = E9E865E9203BD45600E2FFCD /* sha512.c */; };
 		E9E865EC203BD46600E2FFCD /* sha512.c in Sources */ = {isa = PBXBuildFile; fileRef = E9E865E9203BD45600E2FFCD /* sha512.c */; };
 		E9E865ED203BD46700E2FFCD /* sha512.c in Sources */ = {isa = PBXBuildFile; fileRef = E9E865E9203BD45600E2FFCD /* sha512.c */; };
@@ -214,6 +215,9 @@
 		E9BC76D61EF3C1C200EB7A09 /* poly1305.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = poly1305.c; path = src/poly1305.c; sourceTree = "<group>"; };
 		E9BC76D71EF3C1C200EB7A09 /* poly1305.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = poly1305.h; path = src/poly1305.h; sourceTree = "<group>"; };
 		E9E3849C1F0748DD00D50990 /* util.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = util.h; sourceTree = "<group>"; };
+		E9E4B1292180514000514B47 /* certificate_compression.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = certificate_compression.h; sourceTree = "<group>"; };
+		E9E4B12A2180530400514B47 /* certificate_compression.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = certificate_compression.c; sourceTree = "<group>"; };
+		E9E4B12C2181927900514B47 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
 		E9E865E9203BD45600E2FFCD /* sha512.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = sha512.c; path = src/sha512.c; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -315,6 +319,7 @@
 		106530A91D9985E0005B2C60 = {
 			isa = PBXGroup;
 			children = (
+				E9E4B12C2181927900514B47 /* CMakeLists.txt */,
 				106530E11D9B4000005B2C60 /* deps */,
 				106530BC1D998616005B2C60 /* include */,
 				106530BD1D998624005B2C60 /* lib */,
@@ -355,6 +360,7 @@
 				106530BF1D998641005B2C60 /* picotls.c */,
 				105900C51DC9798800FB4085 /* uecc.c */,
 				E949EF272073629300511ECA /* minicrypto-pem.c */,
+				E9E4B12A2180530400514B47 /* certificate_compression.c */,
 			);
 			path = lib;
 			sourceTree = "<group>";
@@ -396,6 +402,7 @@
 			children = (
 				1059004F1DC8D64E00FB4085 /* minicrypto.h */,
 				106530ED1D9CEFF7005B2C60 /* openssl.h */,
+				E9E4B1292180514000514B47 /* certificate_compression.h */,
 			);
 			path = picotls;
 			sourceTree = "<group>";
@@ -677,6 +684,7 @@
 				E99B75E01F5CDDB500CF503E /* asn1.c in Sources */,
 				E99B75E11F5CDDB500CF503E /* pembase64.c in Sources */,
 				106530EB1D9B7C5C005B2C60 /* picotls.c in Sources */,
+				E9E4B12B2180530400514B47 /* certificate_compression.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -811,7 +819,10 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = include;
+				HEADER_SEARCH_PATHS = (
+					include,
+					/usr/local/include,
+				);
 				LIBRARY_SEARCH_PATHS = "";
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -853,7 +864,10 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = include;
+				HEADER_SEARCH_PATHS = (
+					include,
+					/usr/local/include,
+				);
 				LIBRARY_SEARCH_PATHS = "";
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = NO;
@@ -910,12 +924,21 @@
 		106530FA1DAD8985005B2C60 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				GCC_PREPROCESSOR_DEFINITIONS = "PICOTLS_USE_BROTLI=1";
 				HEADER_SEARCH_PATHS = (
-					"/usr/local/openssl-1.1.0/include",
 					include,
+					"/usr/local/openssl-1.1.0/include",
+					/usr/local/include,
 				);
-				LIBRARY_SEARCH_PATHS = "/usr/local/openssl-1.1.0/lib";
-				OTHER_LDFLAGS = "-lcrypto";
+				LIBRARY_SEARCH_PATHS = (
+					"/usr/local/openssl-1.1.0/lib",
+					/usr/local/lib,
+				);
+				OTHER_LDFLAGS = (
+					"-lcrypto",
+					"-lbrotlidec",
+					"-lbrotlienc",
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -923,12 +946,21 @@
 		106530FB1DAD8985005B2C60 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				GCC_PREPROCESSOR_DEFINITIONS = "PICOTLS_USE_BROTLI=1";
 				HEADER_SEARCH_PATHS = (
-					"/usr/local/openssl-1.1.0/include",
 					include,
+					"/usr/local/openssl-1.1.0/include",
+					/usr/local/include,
 				);
-				LIBRARY_SEARCH_PATHS = "/usr/local/openssl-1.1.0/lib";
-				OTHER_LDFLAGS = "-lcrypto";
+				LIBRARY_SEARCH_PATHS = (
+					"/usr/local/openssl-1.1.0/lib",
+					/usr/local/lib,
+				);
+				OTHER_LDFLAGS = (
+					"-lcrypto",
+					"-lbrotlidec",
+					"-lbrotlienc",
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/t/picotls.c
+++ b/t/picotls.c
@@ -368,11 +368,12 @@ static void test_fragmented_message(void)
 #undef SET_RECORD
 }
 
-static int save_client_hello(ptls_on_client_hello_t *self, ptls_t *tls, ptls_iovec_t server_name, const ptls_iovec_t *protocols,
-                             size_t num_protocols, const uint16_t *signature_algorithms, size_t num_signature_algorithms)
+static int save_client_hello(ptls_on_client_hello_t *self, ptls_t *tls, ptls_on_client_hello_parameters_t *params)
 {
-    ptls_set_server_name(tls, (const char *)server_name.base, server_name.len);
-    ptls_set_negotiated_protocol(tls, (const char *)protocols[0].base, protocols[0].len);
+    ptls_set_server_name(tls, (const char *)params->server_name.base, params->server_name.len);
+    if (params->negotiated_protocols.count != 0)
+        ptls_set_negotiated_protocol(tls, (const char *)params->negotiated_protocols.list[0].base,
+                                     params->negotiated_protocols.list[0].len);
     return 0;
 }
 


### PR DESCRIPTION
Implements https://tools.ietf.org/html/draft-ietf-tls-certificate-compression-04.

* as a server:
  * applications can supply their own callback that emits the Certificate message (or the equivalent)
    * the new callback: `emit_certificate` replaces the `staple_ocsp` callback
      * applications that have used the `staple_ocsp` callback needs to have it's own `emit_certificate` callback (example to be provided)
  * `ptls_emit_compressed_certificate_t` is introduced for sending precompressed certificate chain
    * `ptls_init_compressed_certificate` can be called during startup time to build the emit_certificate callback object. The function compresses the supplied certificates and the OCSP response (if provided).
* as a client:
  * `decompress_certificate` can be used to register a decompression callback.
  * a global obcject named `ptls_decompress_certificate` is provided for the purpose
* brotli-support is enabled only when both libbrotlienc and libbrotlidec is installed
* for the `cli` command, `-b` option is added for sending / handling brotli-compressed certificates
