### PR TITLE
Fix windows build after Client Hello Callback update

### DIFF
--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -836,7 +836,7 @@ Found:
 static X509 *to_x509(ptls_iovec_t vec)
 {
     const uint8_t *p = vec.base;
-    return d2i_X509(NULL, &p, vec.len);
+    return d2i_X509(NULL, &p, (long) vec.len);
 }
 
 static int verify_sign(void *verify_ctx, ptls_iovec_t data, ptls_iovec_t signature)

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -19,7 +19,6 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-#include <arpa/inet.h>
 #include <assert.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -28,6 +27,7 @@
 #ifdef _WINDOWS
 #include "wincompat.h"
 #else
+#include <arpa/inet.h>
 #include <sys/time.h>
 #endif
 #include "picotls.h"
@@ -653,8 +653,8 @@ static int commit_record_message(ptls_message_emitter_t *_self)
         /* TODO allow CH,SH,HRR above 16KB */
         size_t sz = self->super.buf->off - self->rec_start - 5;
         assert(sz <= PTLS_MAX_PLAINTEXT_RECORD_SIZE);
-        self->super.buf->base[self->rec_start + 3] = sz >> 8;
-        self->super.buf->base[self->rec_start + 4] = sz;
+        self->super.buf->base[self->rec_start + 3] = (uint8_t)(sz >> 8);
+        self->super.buf->base[self->rec_start + 4] = (uint8_t)(sz);
         ret = 0;
     }
 
@@ -3865,7 +3865,7 @@ NextRecord:
     return ret;
 
 ServerSkipEarlyData:
-    tls->server.early_data_skipped_bytes += rec.length;
+    tls->server.early_data_skipped_bytes += (uint32_t)rec.length;
     if (tls->server.early_data_skipped_bytes > PTLS_MAX_EARLY_DATA_SKIP_SIZE)
         return PTLS_ALERT_HANDSHAKE_FAILURE;
     ret = PTLS_ERROR_IN_PROGRESS;

--- a/picotlsvs/picotls/wincompat.h
+++ b/picotlsvs/picotls/wincompat.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #define ssize_t int
 #include <Winsock2.h>
+#include <ws2tcpip.h>
 
 #ifndef gettimeofday
 #define gettimeofday wintimeofday

--- a/picotlsvs/picotlsvs/picotlsvs.c
+++ b/picotlsvs/picotlsvs/picotlsvs.c
@@ -414,14 +414,16 @@ int collected_test_extensions(ptls_t *tls, ptls_handshake_properties_t *properti
 	return 0;
 }
 
-int client_hello_call_back(ptls_on_client_hello_t * on_hello_cb_ctx,
-	ptls_t *tls, ptls_iovec_t server_name, const ptls_iovec_t *negotiated_protocols,
-	size_t num_negotiated_protocols, const uint16_t *signature_algorithms, size_t num_signature_algorithms)
+int client_hello_call_back(ptls_on_client_hello_t *on_hello_cb_ctx, ptls_t *tls,
+                           ptls_on_client_hello_parameters_t *params)
 {
-	for (size_t i = 0; i < num_negotiated_protocols; i++)
+    /* Save the server name */
+    ptls_set_server_name(tls, (const char *)params->server_name.base, params->server_name.len);
+    /* Check the ALPN */
+	for (size_t i = 0; i < params->negotiated_protocols.count; i++)
 	{
-		if (negotiated_protocols[i].len == sizeof(test_alpn) - 1 &&
-			memcmp(negotiated_protocols[i].base, test_alpn, sizeof(test_alpn) - 1) == 0)
+		if (params->negotiated_protocols.list[i].len == sizeof(test_alpn) - 1 &&
+                memcmp(params->negotiated_protocols.list[i].base, test_alpn, sizeof(test_alpn) - 1) == 0)
 		{
 			ptls_set_negotiated_protocol(tls, test_alpn, sizeof(test_alpn) - 1);
 			break;

--- a/picotlsvs/picotlsvs/picotlsvs.vcxproj
+++ b/picotlsvs/picotlsvs/picotlsvs.vcxproj
@@ -93,7 +93,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <AdditionalLibraryDirectories>$(OPENSSLDIR);$(OutDir)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>picotls.lib;libcrypto.lib;libssl.lib;microecc.lib;cifra.lib;bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>picotls.lib;libcrypto.lib;libssl.lib;microecc.lib;cifra.lib;bcrypt.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -107,7 +107,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <AdditionalLibraryDirectories>$(OPENSSL64DIR);$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>picotls.lib;cifra.lib;microecc.lib;libcrypto.lib;bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>picotls.lib;cifra.lib;microecc.lib;libcrypto.lib;bcrypt.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -125,7 +125,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>$(OPENSSLDIR);$(OutDir)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>picotls.lib;cifra.lib;microecc.lib;libcrypto.lib;bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>picotls.lib;cifra.lib;microecc.lib;libcrypto.lib;bcrypt.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -143,7 +143,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>$(OPENSSL64DIR);$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>picotls.lib;cifra.lib;microecc.lib;libcrypto.lib;bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>picotls.lib;cifra.lib;microecc.lib;libcrypto.lib;bcrypt.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/picotlsvs/testopenssl/testopenssl.vcxproj
+++ b/picotlsvs/testopenssl/testopenssl.vcxproj
@@ -94,7 +94,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <AdditionalLibraryDirectories>$(OPENSSLDIR);$(OutDir)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>picotls.lib;cifra.lib;microecc.lib;libcrypto.lib;bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>picotls.lib;cifra.lib;microecc.lib;libcrypto.lib;bcrypt.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -109,7 +109,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <AdditionalLibraryDirectories>$(OPENSSL64DIR);$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>picotls.lib;cifra.lib;microecc.lib;libcrypto.lib;bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>picotls.lib;cifra.lib;microecc.lib;libcrypto.lib;bcrypt.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -128,7 +128,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>$(OPENSSLDIR);$(OutDir)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>picotls.lib;cifra.lib;microecc.lib;libcrypto.lib;bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>picotls.lib;cifra.lib;microecc.lib;libcrypto.lib;bcrypt.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -147,7 +147,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>$(OPENSSL64DIR);$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>picotls.lib;cifra.lib;microecc.lib;libcrypto.lib;bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>picotls.lib;cifra.lib;microecc.lib;libcrypto.lib;bcrypt.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/t/openssl.c
+++ b/t/openssl.c
@@ -198,7 +198,7 @@ static void setup_certificate(ptls_iovec_t *dst)
 
 static void setup_sign_certificate(ptls_openssl_sign_certificate_t *sc)
 {
-    BIO *bio = BIO_new_mem_buf(RSA_PRIVATE_KEY, strlen(RSA_PRIVATE_KEY));
+    BIO *bio = BIO_new_mem_buf(RSA_PRIVATE_KEY, (int)strlen(RSA_PRIVATE_KEY));
     EVP_PKEY *pkey = PEM_read_bio_PrivateKey(bio, NULL, NULL, NULL);
     assert(pkey != NULL || !"failed to load private key");
     BIO_free(bio);


### PR DESCRIPTION
Also fix a missing reference to ws3_32.lib when building the test clients, and make sure that the calls to inet_pton are working correctly on Windows.

The tests work on windows, but the windows test app appears to only work in debug mode.