### PR TITLE
New API for early data skipped.

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -875,6 +875,10 @@ int ptls_handshake_is_complete(ptls_t *tls);
  */
 int ptls_is_psk_handshake(ptls_t *tls);
 /**
+ * returns if the server is skipping early data. Only valid on the client.
+ */
+int ptls_is_early_data_skipped(ptls_t *tls);
+/**
  * returns a pointer to user data pointer (client is reponsible for freeing the associated data prior to calling ptls_free)
  */
 void **ptls_get_data_ptr(ptls_t *tls);

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -3575,6 +3575,12 @@ int ptls_is_psk_handshake(ptls_t *tls)
     return tls->is_psk_handshake;
 }
 
+int ptls_is_early_data_skipped(ptls_t *tls)
+{
+    return tls->client.early_data_skipped;
+}
+
+
 void **ptls_get_data_ptr(ptls_t *tls)
 {
     return &tls->data_ptr;


### PR DESCRIPTION
This will be very useful in QUIC, so the client can decide without delay whether the 0-RTT data is lost and maybe needs retransmission.