### PR TITLE
QUIC draft-17 support

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -513,9 +513,10 @@ struct st_ptls_context_t {
      */
     uint32_t max_early_data_size;
     /**
-     * the label prefix used in hkdf-expand-label (if NULL, uses "tls13 ")
+     * the field is obsolete; should be set to NULL for QUIC draft-17.  Note also that even though everybody did, it was incorrect
+     * to set the value to "quic " in the earlier versions of the draft.
      */
-    const char *hkdf_label_prefix;
+    const char *hkdf_label_prefix__obsolete;
     /**
      * if set, psk handshakes use (ec)dhe
      */

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -83,6 +83,9 @@ extern "C" {
 #define PTLS_ALERT_TO_PEER_ERROR(e) ((e) + PTLS_ERROR_CLASS_PEER_ALERT)
 #define PTLS_ERROR_TO_ALERT(e) ((e)&0xff)
 
+/* the HKDF prefix */
+#define PTLS_HKDF_EXPAND_LABEL_PREFIX "tls13 "
+
 /* alerts */
 #define PTLS_ALERT_LEVEL_WARNING 1
 #define PTLS_ALERT_LEVEL_FATAL 2

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -77,8 +77,6 @@
 
 #define PTLS_EARLY_DATA_MAX_DELAY 10000 /* max. RTT (in msec) to permit early data */
 
-#define PTLS_HKDF_EXPAND_LABEL_PREFIX "tls13 "
-
 #ifndef PTLS_MAX_EARLY_DATA_SKIP_SIZE
 #define PTLS_MAX_EARLY_DATA_SKIP_SIZE 65536
 #endif

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -1086,7 +1086,7 @@ static int setup_traffic_protection(ptls_t *tls, int is_enc, const char *secret_
     if (ctx->aead != NULL)
         ptls_aead_free(ctx->aead);
     if ((ctx->aead = ptls_aead_new(tls->cipher_suite->aead, tls->cipher_suite->hash, is_enc, ctx->secret,
-                                   tls->ctx->hkdf_label_prefix)) == NULL)
+                                   tls->ctx->hkdf_label_prefix__obsolete)) == NULL)
         return PTLS_ERROR_NO_MEMORY; /* TODO obtain error from ptls_aead_new */
     ctx->seq = 0;
 
@@ -1441,7 +1441,7 @@ static int send_client_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptls_
         tls->key_share = tls->ctx->key_exchanges[0];
 
     if (!is_second_flight) {
-        tls->key_schedule = key_schedule_new(tls->cipher_suite, tls->ctx->cipher_suites, tls->ctx->hkdf_label_prefix);
+        tls->key_schedule = key_schedule_new(tls->cipher_suite, tls->ctx->cipher_suites, tls->ctx->hkdf_label_prefix__obsolete);
         if ((ret = key_schedule_extract(tls->key_schedule, resumption_secret)) != 0)
             goto Exit;
     }
@@ -2966,7 +2966,7 @@ static int server_handle_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptl
             goto Exit;
         if (!is_second_flight) {
             tls->cipher_suite = cs;
-            tls->key_schedule = key_schedule_new(cs, NULL, tls->ctx->hkdf_label_prefix);
+            tls->key_schedule = key_schedule_new(cs, NULL, tls->ctx->hkdf_label_prefix__obsolete);
         } else {
             if (tls->cipher_suite != cs) {
                 ret = PTLS_ALERT_HANDSHAKE_FAILURE;


### PR DESCRIPTION
__tl;dr see the impact section__

Prefix of the labels being passed to HKDF functions are going to change in QUIC draft-17. The following table illustrates the changes (as well as clarifying what has been written in spec since -12 and what we have actually implemented).

||prefix for deriving handshake secrets|prefix for deriving traffic keys|
|:---:|:---:|:---:|
|**draft-16 (spec)**|"tls13 "|"quic "|
|**draft-16 (interop)**|"quic "|"quic "|
|**draft-17**|"tls13 "|"tls13 quic "|
|**configuration knob in picotls**|ptls_context_t::hkdf_label_prefix|label_prefix argument of ptls_hkdf_expand_label, ptls_aead_new|

The intent behind the changes in draft-17 are:
* to always use the "tls13 " prefix (to ensure that we would be deriving different traffic keys when using a future version of TLS)<sup>[1]</sup>
* to use " quic " as part of the label used to derive traffic keys, to guarantee that TLS over TCP and TLS over QUIC would have different traffic keys

__The impact to the QUIC stacks using picotls are__:
* Stop setting `ptls_context_t::hkdf_label_prefix`.
  * This PR renames the field to `hkdf_label_prefix__obsolete` so that people would not miss this.
* Change the prefix supplied when calling `ptls_hkdf_expand_label` or `ptls_aead_new` from "quic " to  "tls13 quic ".
  * This PR introduces a macro called `PTLS_HKDF_EXPAND_LABEL_PREFIX` that expands to "tls13 ". Stacks can specify the prefix as `PTLS_HKDF_EXPAND_LABEL_PREFIX "quic "` to avoid hard-coding the prefix defined in TLS.

See also: https://github.com/quicwg/base-drafts/issues/1971, https://github.com/quicwg/base-drafts/pull/1991, https://github.com/quicwg/base-drafts/pull/2046

[1] Future versions of TLS are expected to provide a different KDF (or define a prefix other than "tls13 "). Picotls might provide a new API that exposes the KDF function in a TLS-version-independent way.