### PR TITLE
Check the return value of critical OpenSSL functions

### DIFF
--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -1219,8 +1219,10 @@ int ptls_openssl_encrypt_ticket(ptls_buffer_t *buf, ptls_iovec_t src,
     ret = 0;
 
 Exit:
-    if (cctx != NULL)
-        EVP_CIPHER_CTX_cleanup(cctx);
+    if (cctx != NULL) {
+        int ret = EVP_CIPHER_CTX_cleanup(cctx);
+        assert(ret);
+    }
     if (hctx != NULL)
         HMAC_CTX_free(hctx);
     return ret;
@@ -1289,8 +1291,10 @@ int ptls_openssl_decrypt_ticket(ptls_buffer_t *buf, ptls_iovec_t src,
     ret = 0;
 
 Exit:
-    if (cctx != NULL)
-        EVP_CIPHER_CTX_cleanup(cctx);
+    if (cctx != NULL) {
+        int ret = EVP_CIPHER_CTX_cleanup(cctx);
+        assert(ret);
+    }
     if (hctx != NULL)
         HMAC_CTX_free(hctx);
     return ret;

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -79,7 +79,8 @@ static void HMAC_CTX_free(HMAC_CTX *ctx)
 
 void ptls_openssl_random_bytes(void *buf, size_t len)
 {
-    RAND_bytes(buf, (int)len);
+    int ret = RAND_bytes(buf, (int)len);
+    assert(ret);
 }
 
 static EC_KEY *ecdh_gerenate_key(EC_GROUP *group)


### PR DESCRIPTION
## Objective

~Assert that `RAND_bytes()` and `EVP_CIPHER_CTX_cleanup()` were called successfully.~

Abort if `RAND_bytes()` and `EVP_CIPHER_CTX_cleanup()` ever fails.

## Why

`RAND_bytes()` is a fundamental cryptographic building block of the library, hence we should not assume that it will always succeed. Ditto for cleaning up the cipher context.

## Define Success

Here's an except From the OpenSSL documentation.

> RAND_bytes() and RAND_priv_bytes() return 1 on success, -1 if not supported by the current RAND method, or 0 on other failure.

> EVP_CIPHER_CTX_cleanup() returns 1 for success and 0 for failure.

Thanks to David Wong for reporting the concern.