### PR TITLE
Allow the status_request ext to appear in the certificate_request HS message

### DIFF
--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -386,6 +386,7 @@ static inline void init_extension_bitmap(struct st_ptls_extension_bitmap_t *bitm
     EXT(STATUS_REQUEST, {
         ALLOW(CLIENT_HELLO);
         ALLOW(CERTIFICATE);
+        ALLOW(CERTIFICATE_REQUEST);
     });
     EXT(SUPPORTED_GROUPS, {
         ALLOW(CLIENT_HELLO);


### PR DESCRIPTION
## Objective

[Section 4.2](https://tools.ietf.org/html/rfc8446#section-4.2) states that a `status_request` extension may appear in the `certificate_request` handshake. Hence, tweak `init_extension_bitmap` to reflect the spec.

```
| status_request [RFC6066]                         |  CH, CR, CT |
```

Reported by David Wong

## Discussion

Quick glance at the extensions table in the spec and the bitmap initializer gives an impression that picotls is conflating `HelloRetryRequest` (HRR) and `ServerHello` (SH) for `key_share`, `cookie` and `supported_versions` extensions.

On one hand, Section 4.2 gives an impression that HRR and SR are technically the same:

> As discussed in Section 4.1.3, the HelloRetryRequest has the same format as a ServerHello message, and the legacy_version, legacy_session_id_echo, cipher_suite, and legacy_compression_method fields have the same meaning.  However, for convenience we discuss “HelloRetryRequest” throughout this document as if it were a distinct message.

OTOH, it's technically possible to treat them distinctively via the random field:

> For reasons of backward compatibility with middleboxes (see Appendix D.4), the HelloRetryRequest message uses the same structure as the ServerHello, but with Random set to the special value of the SHA-256 of "HelloRetryRequest":
>
>     CF 21 AD 74 E5 9A 61 11 BE 1D 8C 02 1E 65 B8 91
>     C2 A2 11 16 7A BB 8C 5E 07 9E 09 E2 C8 A8 33 9C

Even though the HandshakeType for HRR is only reserved, it feels like we should treat them distinctively in the bitmap. The `cookie` extension is a good one to reason about.

Spec:

```
| cookie (RFC 8446)                                |     CH, HRR |
```

Implementation:

```
417 EXT(COOKIE, {
418     ALLOW(CLIENT_HELLO);
419     ALLOW(SERVER_HELLO);
420 });
```

It sounds reasonable for the client to abort the handshake if a cookie extension is present in the `ServerHello`.

> Implementations MUST NOT send extension responses if the remote endpoint did not send the corresponding extension requests, with the exception of the "cookie" extension in the HelloRetryRequest.  Upon receiving such an extension, an endpoint MUST abort the handshake with an "unsupported_extension" alert.

Question: Shall we consider treating HRR and SH distinctively in the bitmap?