### PR TITLE
Make secrets as large as the maximum digest size, which is 48 for SHA384

### DIFF
--- a/t/picotls.c
+++ b/t/picotls.c
@@ -113,7 +113,7 @@ static void test_hkdf(void)
 
 static void test_ciphersuite(ptls_cipher_suite_t *cs1, ptls_cipher_suite_t *cs2)
 {
-    const char *traffic_secret = "01234567890123456789012345678901", *src1 = "hello world", *src2 = "good bye, all";
+    const char *traffic_secret = "012345678901234567890123456789012345678901234567", *src1 = "hello world", *src2 = "good bye, all";
     ptls_aead_context_t *c;
     char enc1[256], enc2[256], dec1[256], dec2[256];
     size_t enc1len, enc2len, dec1len, dec2len;
@@ -152,7 +152,7 @@ static void test_ciphersuite(ptls_cipher_suite_t *cs1, ptls_cipher_suite_t *cs2)
 
 static void test_aad_ciphersuite(ptls_cipher_suite_t *cs1, ptls_cipher_suite_t *cs2)
 {
-    const char *traffic_secret = "01234567890123456789012345678901", *src = "hello world", *aad = "my true aad";
+    const char *traffic_secret = "012345678901234567890123456789012345678901234567", *src = "hello world", *aad = "my true aad";
     ptls_aead_context_t *c;
     char enc[256], dec[256];
     size_t enclen, declen;
@@ -434,7 +434,7 @@ static void test_handshake(ptls_iovec_t ticket, int mode, int expect_ticket, int
         break;
     case TEST_HANDSHAKE_HRR_STATELESS:
         client_hs_prop.client.negotiate_before_key_exchange = 1;
-        server_hs_prop.server.cookie.key = "0123456789abcdef0123456789abcdef";
+        server_hs_prop.server.cookie.key = "0123456789abcdef0123456789abcdef0123456789abcdef";
         server_hs_prop.server.retry_uses_cookie = 1;
         break;
     case TEST_HANDSHAKE_EARLY_DATA:
@@ -831,7 +831,7 @@ static void test_enforce_retry(int use_cookie)
     size_t consumed;
     int ret;
 
-    server_hs_prop.server.cookie.key = "0123456789abcdef0123456789abcdef";
+    server_hs_prop.server.cookie.key = "0123456789abcdef0123456789abcdef0123456789abcdef";
     server_hs_prop.server.cookie.additional_data = ptls_iovec_init("1.2.3.4:1234", 12);
     server_hs_prop.server.enforce_retry = 1;
     server_hs_prop.server.retry_uses_cookie = use_cookie;
@@ -940,7 +940,7 @@ static void test_stateless_hrr_aad_change(void)
     size_t consumed;
     int ret;
 
-    server_hs_prop.server.cookie.key = "0123456789abcdef0123456789abcdef";
+    server_hs_prop.server.cookie.key = "0123456789abcdef0123456789abcdef0123456789abcdef";
     server_hs_prop.server.cookie.additional_data = ptls_iovec_init("1.2.3.4:1234", 12);
     server_hs_prop.server.enforce_retry = 1;
     server_hs_prop.server.retry_uses_cookie = 1;


### PR DESCRIPTION
ASAN finding:

```

=================================================================
==24799==ERROR: AddressSanitizer: global-buffer-overflow on address 0x55841ae13761 at pc 0x55841aced3ec bp 0x7ffca51cae30 sp 0x7ffca51ca5e0
READ of size 48 at 0x55841ae13761 thread T0
    #0 0x55841aced3eb in __asan_memcpy (/home/def/p/floss/picotls/test-openssl.t+0x1603eb)
    #1 0x55841ad882db in ptls_hmac_create /home/def/p/floss/picotls/t/../lib/picotls.c:4680:5
    #2 0x55841ad899e3 in ptls_hkdf_expand /home/def/p/floss/picotls/t/../lib/picotls.c:4709:25
    #3 0x55841ad87dcd in hkdf_expand_label /home/def/p/floss/picotls/t/../lib/picotls.c:4751:11
    #4 0x55841ad8a500 in ptls_hkdf_expand_label /home/def/p/floss/picotls/t/../lib/picotls.c:4764:12
    #5 0x55841ad8a500 in get_traffic_key /home/def/p/floss/picotls/t/../lib/picotls.c:1090
    #6 0x55841ad8a500 in new_aead /home/def/p/floss/picotls/t/../lib/picotls.c:4798
    #7 0x55841add8597 in ptls_aead_new /home/def/p/floss/picotls/t/../lib/picotls.c:4818:12
    #8 0x55841add8597 in test_ciphersuite /home/def/p/floss/picotls/t/picotls.c:122
    #9 0x55841ad9a4ed in test_aes256gcm /home/def/p/floss/picotls/t/picotls.c:241:9
    #10 0x55841ad69d3f in subtest /home/def/p/floss/picotls/deps/picotest/picotest.c:96:5
    #11 0x55841ad99615 in test_picotls /home/def/p/floss/picotls/t/picotls.c:1161:5
    #12 0x55841ad69d3f in subtest /home/def/p/floss/picotls/deps/picotest/picotest.c:96:5
    #13 0x55841ade8e5b in main /home/def/p/floss/picotls/t/openssl.c:277:5
    #14 0x7faf59057222 in __libc_start_main (/usr/lib/libc.so.6+0x24222)
    #15 0x55841ac1b7cd in _start (/home/def/p/floss/picotls/test-openssl.t+0x8e7cd)

0x55841ae13761 is located 63 bytes to the left of global variable '<string literal>' defined in '/home/def/p/floss/picotls/t/picotls.c:116:78' (0x55841ae137a0) of size 12
  '<string literal>' is ascii string 'hello world'
0x55841ae13761 is located 0 bytes to the right of global variable '<string literal>' defined in '/home/def/p/floss/picotls/t/picotls.c:116:34' (0x55841ae13740) of size 33
  '<string literal>' is ascii string '01234567890123456789012345678901'
SUMMARY: AddressSanitizer: global-buffer-overflow (/home/def/p/floss/picotls/test-openssl.t+0x1603eb) in __asan_memcpy
Shadow bytes around the buggy address:
  0x0ab1035ba690: f9 f9 f9 f9 00 06 f9 f9 f9 f9 f9 f9 00 00 05 f9

```