### PR TITLE
Ignore build tool artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@ x64
 */*.dll
 */*.xbf
 */*.ilk
+cmake_install.cmake
+CMakeCache.txt
+CMakeFiles/
+Makefile
 deps/picotest
 /picotlsvs/cifra/cifra.vcxproj.user
 /picotlsvs/testopenssl/testopenssl.vcxproj.user


### PR DESCRIPTION
It'd be wonderful if we could ignore CMake artifacts. They can be a little distracting when working on multiple branches. Thanks!