### PR TITLE
Check the properties pointer before proceeding

### DIFF
--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -2603,7 +2603,7 @@ static int decode_client_hello(ptls_t *tls, struct st_ptls_client_hello_t *ch, c
             });
             break;
         case PTLS_EXTENSION_TYPE_COOKIE:
-            if (properties->server.cookie.key == NULL) {
+            if (properties == NULL || properties->server.cookie.key == NULL) {
                 ret = PTLS_ALERT_ILLEGAL_PARAMETER;
                 goto Exit;
             }


### PR DESCRIPTION
It's currently possible to run the code-path that decodes the cookies extension without providing the optional `ptls_handshake_properties_t` to `ptls_handshake()`, consequently killing the process. This PR adds a check before proceeding with the pointer.

The alert type for this case is: `illegal_parameter`

Thanks to David Wong for reporting the issue.