### PR TITLE
Travis : enhance macos job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,12 @@ matrix:
       compiler: clang
     - name: macOS (Xcode)
       os: osx
+      env:
+          - CMAKE_OPTS=" -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl/"
 
 before_install:
 
 script:
-  - cmake .
+  - cmake ${CMAKE_OPTS} .
   - make all
   - make check

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,11 @@ matrix:
       os: osx
       env:
           - CMAKE_OPTS=" -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl/"
+    - name: macOS (Xcode 10.1/clang-10)
+      os: osx
+      osx_image: xcode10.1
+      env:
+          - CMAKE_OPTS=" -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl/"
 
 before_install:
 


### PR DESCRIPTION
Fix openssl path for build with macOS Builder (and avoid message build without openssl)

add new job with Xcode 10.1 (and clang-10)