### PR TITLE
Only include status extension (OCSP) when requested

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -442,7 +442,7 @@ PTLS_CALLBACK_TYPE(int, on_client_hello, ptls_t *tls, ptls_on_client_hello_param
  * callback to generate the certificate message. `ptls_context::certificates` are set when the callback is set to NULL.
  */
 PTLS_CALLBACK_TYPE(int, emit_certificate, ptls_t *tls, ptls_message_emitter_t *emitter, ptls_key_schedule_t *key_sched,
-                   ptls_iovec_t context);
+                   ptls_iovec_t context, int push_status_request);
 /**
  * when gerenating CertificateVerify, the core calls the callback to sign the handshake context using the certificate.
  */

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -2403,7 +2403,7 @@ Exit:
 }
 
 static int default_emit_certificate_cb(ptls_emit_certificate_t *_self, ptls_t *tls, ptls_message_emitter_t *emitter,
-                                       ptls_key_schedule_t *key_sched, ptls_iovec_t context)
+                                       ptls_key_schedule_t *key_sched, ptls_iovec_t context, int push_status_request)
 {
     int ret;
 
@@ -2433,7 +2433,7 @@ static int send_certificate_and_certificate_verify(ptls_t *tls, ptls_message_emi
     }
 
     /* send Certificate (or the equivalent) */
-    if ((ret = emit_certificate->cb(emit_certificate, tls, emitter, tls->key_schedule, context)) != 0)
+    if ((ret = emit_certificate->cb(emit_certificate, tls, emitter, tls->key_schedule, context, push_status_request)) != 0)
         goto Exit;
 
     /* build and send CertificateVerify */


### PR DESCRIPTION
pass the flag that indicates a status request was received or not to the cert emit callback. 

The server should not include the extension `PTLS_EXTENSION_TYPE_STATUS_REQUEST`, nor should it staple if the request wasn't received.

Without this change openssl-1.1.1 s_client produces the following error:
```
140737354049280:error:141B30D9:SSL routines:tls_collect_extensions:unsolicited extension:ssl/statem/extensions.c:628:
```

alternatively we can pass the flag all the way to `ptls_build_certificate_message` instead of relying on the ocsp_status iovec.
