### PR TITLE
Instrument dependencies in fuzz builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,8 +87,6 @@ IF (BUILD_FUZZER)
     IF (OSS_FUZZ)
         # Use https://github.com/google/oss-fuzz compatible options
         SET(LIB_FUZZER FuzzingEngine)
-        SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-omit-frame-pointer")
-        SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c-fno-omit-frame-pointer")
         SET_TARGET_PROPERTIES(fuzz-asn1-validation
             fuzz-asn1-type-and-length
             fuzz-server-hello
@@ -96,6 +94,8 @@ IF (BUILD_FUZZER)
             PROPERTIES
             LINKER_LANGUAGE CXX)
     ELSE()
+        SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=fuzzer-no-link")
+        SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=fuzzer-no-link")
         SET_TARGET_PROPERTIES(fuzz-asn1-validation
             fuzz-asn1-type-and-length
             fuzz-server-hello


### PR DESCRIPTION
As part of debugging the google/oss-fuzz integration I noticed that the `BUILD_FUZZER` build does not correctly instrument static libraries for coverage/feedback outside of `OSS_FUZZ` builds. This PR addresses that issue.

Here is coverage before (8 counters):

```
$ ./fuzz-server-hello -runs=4
INFO: Seed: 91409740
INFO: Loaded 1 modules   (8 inline 8-bit counters): 8 [0x6a0248, 0x6a0250),
INFO: Loaded 1 PC tables (8 PCs): 8 [0x48d1c0,0x48d240),
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
INFO: A corpus is not provided, starting from an empty corpus
#2  INITED cov: 4 ft: 4 corp: 1/1b exec/s: 0 rss: 32Mb
#4  DONE   cov: 4 ft: 4 corp: 1/1b exec/s: 0 rss: 32Mb
Done 4 runs in 0 second(s)
```

And after (3444 counters):

```
$ ./fuzz-server-hello -runs=4
INFO: Seed: 163370380
INFO: Loaded 1 modules   (3444 inline 8-bit counters): 3444 [0x6c07f0, 0x6c1564),
INFO: Loaded 1 PC tables (3444 PCs): 3444 [0x49f400,0x4acb40),
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
INFO: A corpus is not provided, starting from an empty corpus
#2  INITED cov: 141 ft: 142 corp: 1/1b exec/s: 0 rss: 32Mb
#4  DONE   cov: 141 ft: 142 corp: 1/1b exec/s: 0 rss: 32Mb
Done 4 runs in 0 second(s)
```

This PR also removes `OSS_FUZZ` build cruft that @omasanori [identified](https://github.com/h2o/picotls/pull/219#discussion_r264039169). I smoke-tested this branch against oss-fuzz locally to help ensure it will not cause problems there.