### PR TITLE
expose the list of the ciphers offered by the client

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -441,7 +441,7 @@ typedef struct st_ptls_on_client_hello_parameters_t {
     struct {
         const uint16_t *list;
         size_t count;
-    } client_ciphers;
+    } cipher_suites;
     /**
      * if ESNI was used
      */

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -438,6 +438,10 @@ typedef struct st_ptls_on_client_hello_parameters_t {
         const uint16_t *list;
         size_t count;
     } certificate_compression_algorithms;
+    struct {
+        const uint16_t *list;
+        size_t count;
+    } client_ciphers;
     /**
      * if ESNI was used
      */

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -3010,8 +3010,10 @@ static int decode_client_hello(ptls_t *tls, struct st_ptls_client_hello_t *ch, c
                 goto Exit;
             id++;
             ch->client_ciphers.count++;
-            if (id >= ch->client_ciphers.list + MAX_CLIENT_CIPHERS)
+            if (id >= ch->client_ciphers.list + MAX_CLIENT_CIPHERS) {
+                src = end;
                 break;
+            }
         } while (src != end);
     });
 


### PR DESCRIPTION
This PR exposes the raw cipher list offered by the client to the client hello callback via `ptls_on_client_hello_parameters_t`.

Alternatively, could also keep it as an iovec and decode within the callback or right before calling it, but  this way the decoding is kept within `decode_client_hello`.

thanks!