### PR TITLE
Expose handshake write key when receiving ServerHello

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -636,6 +636,12 @@ typedef struct st_ptls_raw_extension_t {
     ptls_iovec_t data;
 } ptls_raw_extension_t;
 
+typedef enum en_ptls_early_data_acceptance_t {
+    PTLS_EARLY_DATA_ACCEPTANCE_UNKNOWN = 0,
+    PTLS_EARLY_DATA_REJECTED,
+    PTLS_EARLY_DATA_ACCEPTED
+} ptls_early_data_acceptance_t;
+
 /**
  * optional arguments to client-driven handshake
  */
@@ -665,10 +671,11 @@ typedef struct st_ptls_handshake_properties_t {
              */
             size_t *max_early_data_size;
             /**
-             * if early-data has been accepted by peer. For clients using `update_traffic_key` callback, the flag is set when the
-             * callback is called with (is_enc, epoch) set to (1, 2).
+             * if early-data has been accepted by peer. The state changes anytime after handshake keys become available.
+             * Applications can peek the tri-state variable every time it calls `ptls_hanshake` or `ptls_handle_message` to
+             * determine the result at the earliest moment.
              */
-            unsigned early_data_accepted_by_peer : 1;
+            ptls_early_data_acceptance_t early_data_acceptance;
             /**
              * negotiate the key exchange method before sending key_share
              */

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -671,9 +671,9 @@ typedef struct st_ptls_handshake_properties_t {
              */
             size_t *max_early_data_size;
             /**
-             * if early-data has been accepted by peer. The state changes anytime after handshake keys become available.
-             * Applications can peek the tri-state variable every time it calls `ptls_hanshake` or `ptls_handle_message` to
-             * determine the result at the earliest moment.
+             * If early-data has been accepted by peer, or if the state is still unknown. The state changes anytime after handshake
+             * keys become available. Applications can peek the tri-state variable every time it calls `ptls_hanshake` or
+             * `ptls_handle_message` to determine the result at the earliest moment. This is an output parameter.
              */
             ptls_early_data_acceptance_t early_data_acceptance;
             /**

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -114,10 +114,6 @@ struct st_ptls_record_message_emitter_t {
     size_t rec_start;
 };
 
-struct st_ptls_early_data_t {
-    uint8_t next_secret[PTLS_MAX_DIGEST_SIZE];
-};
-
 struct st_ptls_signature_algorithms_t {
     uint16_t list[16]; /* expand? */
     size_t count;
@@ -237,6 +233,7 @@ struct st_ptls_t {
             uint8_t legacy_session_id[32];
             ptls_key_exchange_context_t *key_share_ctx;
             unsigned offered_psk : 1;
+            unsigned using_early_data : 1;
             unsigned early_data_skipped : 1;
             struct st_ptls_certificate_request_t certificate_request;
         } client;
@@ -254,10 +251,9 @@ struct st_ptls_t {
         void *verify_ctx;
     } certificate_verify;
     /**
-     * the value contains the traffic secret to be commisioned after END_OF_EARLY_DATA
-     * END_OF_EARLY_DATA
+     * handshake traffic secret to be commisioned (an array of `uint8_t [PTLS_MAX_DIGEST_SIZE]` or NULL)
      */
-    struct st_ptls_early_data_t *early_data;
+    uint8_t *pending_handshake_secret;
     /**
      * user data
      */
@@ -1157,14 +1153,16 @@ static int setup_traffic_protection(ptls_t *tls, int is_enc, const char *secret_
     return 0;
 }
 
-static int retire_early_data_secret(ptls_t *tls, int is_enc)
+static int commission_handshake_secret(ptls_t *tls)
 {
-    assert(tls->early_data != NULL);
-    memcpy((is_enc ? &tls->traffic_protection.enc : &tls->traffic_protection.dec)->secret, tls->early_data->next_secret,
+    int is_enc = !ptls_is_server(tls);
+
+    assert(tls->pending_handshake_secret != NULL);
+    memcpy((is_enc ? &tls->traffic_protection.enc : &tls->traffic_protection.dec)->secret, tls->pending_handshake_secret,
            PTLS_MAX_DIGEST_SIZE);
-    ptls_clear_memory(tls->early_data, sizeof(*tls->early_data));
-    free(tls->early_data);
-    tls->early_data = NULL;
+    ptls_clear_memory(tls->pending_handshake_secret, PTLS_MAX_DIGEST_SIZE);
+    free(tls->pending_handshake_secret);
+    tls->pending_handshake_secret = NULL;
 
     return setup_traffic_protection(tls, is_enc, NULL, 2, 1);
 }
@@ -1343,7 +1341,7 @@ static int send_session_ticket(ptls_t *tls, ptls_message_emitter_t *emitter)
 
     { /* calculate verify-data that will be sent by the client */
         size_t orig_off = emitter->buf->off;
-        if (tls->early_data != NULL && !tls->ctx->omit_end_of_early_data) {
+        if (tls->pending_handshake_secret != NULL && !tls->ctx->omit_end_of_early_data) {
             assert(tls->state == PTLS_STATE_SERVER_EXPECT_END_OF_EARLY_DATA);
             ptls_buffer_push_message_body(emitter->buf, tls->key_schedule, PTLS_HANDSHAKE_TYPE_END_OF_EARLY_DATA, {});
             emitter->buf->off = orig_off;
@@ -1352,8 +1350,8 @@ static int send_session_ticket(ptls_t *tls, ptls_message_emitter_t *emitter)
             if ((ret = ptls_buffer_reserve(emitter->buf, tls->key_schedule->hashes[0].algo->digest_size)) != 0)
                 goto Exit;
             if ((ret = calc_verify_data(emitter->buf->base + emitter->buf->off, tls->key_schedule,
-                                        tls->early_data != NULL ? tls->early_data->next_secret
-                                                                : tls->traffic_protection.dec.secret)) != 0)
+                                        tls->pending_handshake_secret != NULL ? tls->pending_handshake_secret
+                                                                              : tls->traffic_protection.dec.secret)) != 0)
                 goto Exit;
             emitter->buf->off += tls->key_schedule->hashes[0].algo->digest_size;
         });
@@ -1830,17 +1828,14 @@ static int send_client_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptls_
                 tls->key_share = key_share;
                 tls->cipher_suite = cipher_suite;
                 if (!is_second_flight && max_early_data_size != 0 && properties->client.max_early_data_size != NULL) {
+                    tls->client.using_early_data = 1;
                     *properties->client.max_early_data_size = max_early_data_size;
-                    if ((tls->early_data = malloc(sizeof(*tls->early_data))) == NULL) {
-                        ret = PTLS_ERROR_NO_MEMORY;
-                        goto Exit;
-                    }
                 }
             } else {
                 resumption_secret = ptls_iovec_init(NULL, 0);
             }
         }
-        if (properties->client.max_early_data_size != NULL && tls->early_data == NULL)
+        if (properties->client.max_early_data_size != NULL && !tls->client.using_early_data)
             *properties->client.max_early_data_size = 0;
     }
 
@@ -1961,7 +1956,7 @@ static int send_client_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptls_
                     });
                 });
                 if (resumption_secret.base != NULL) {
-                    if (tls->early_data != NULL && !is_second_flight)
+                    if (tls->client.using_early_data && !is_second_flight)
                         buffer_push_extension(sendbuf, PTLS_EXTENSION_TYPE_EARLY_DATA, {});
                     /* pre-shared key "MUST be the last extension in the ClientHello" (draft-17 section 4.2.6) */
                     buffer_push_extension(sendbuf, PTLS_EXTENSION_TYPE_PRE_SHARED_KEY, {
@@ -1996,7 +1991,7 @@ static int send_client_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptls_
     }
     ptls__key_schedule_update_hash(tls->key_schedule, emitter->buf->base + msghash_off, emitter->buf->off - msghash_off);
 
-    if (tls->early_data != NULL) {
+    if (tls->client.using_early_data) {
         if ((ret = setup_traffic_protection(tls, 1, "c e traffic", 1, 0)) != 0)
             goto Exit;
         if ((ret = push_change_cipher_spec(tls, emitter->buf)) != 0)
@@ -2315,7 +2310,7 @@ static int client_handle_encrypted_extensions(ptls_t *tls, ptls_iovec_t message,
             });
             break;
         case PTLS_EXTENSION_TYPE_EARLY_DATA:
-            if (tls->early_data == NULL) {
+            if (!tls->client.using_early_data) {
                 ret = PTLS_ALERT_ILLEGAL_PARAMETER;
                 goto Exit;
             }
@@ -2341,14 +2336,18 @@ static int client_handle_encrypted_extensions(ptls_t *tls, ptls_iovec_t message,
         }
     }
 
-    if (tls->early_data != NULL) {
+    if (tls->client.using_early_data) {
         tls->client.early_data_skipped = skip_early_data;
         if (properties != NULL && !skip_early_data)
             properties->client.early_data_accepted_by_peer = 1;
-        if ((ret = derive_secret(tls->key_schedule, tls->early_data->next_secret, "c hs traffic")) != 0)
+        if ((tls->pending_handshake_secret = malloc(PTLS_MAX_DIGEST_SIZE)) == NULL) {
+            ret = PTLS_ERROR_NO_MEMORY;
+            goto Exit;
+        }
+        if ((ret = derive_secret(tls->key_schedule, tls->pending_handshake_secret, "c hs traffic")) != 0)
             goto Exit;
         if (tls->ctx->update_traffic_key != NULL &&
-            (ret = tls->ctx->update_traffic_key->cb(tls->ctx->update_traffic_key, tls, 1, 2, tls->early_data->next_secret)) != 0)
+            (ret = tls->ctx->update_traffic_key->cb(tls->ctx->update_traffic_key, tls, 1, 2, tls->pending_handshake_secret)) != 0)
             goto Exit;
     } else {
         if ((ret = setup_traffic_protection(tls, 1, "c hs traffic", 2, 0)) != 0)
@@ -2725,11 +2724,11 @@ static int client_handle_finished(ptls_t *tls, ptls_message_emitter_t *emitter, 
         goto Exit;
 
     /* if sending early data, emit EOED and commision the client handshake traffic secret */
-    if (tls->early_data != NULL) {
+    if (tls->pending_handshake_secret != NULL) {
         assert(tls->traffic_protection.enc.aead != NULL || tls->ctx->update_traffic_key != NULL);
         if (!tls->client.early_data_skipped && !tls->ctx->omit_end_of_early_data)
             ptls_push_message(emitter, tls->key_schedule, PTLS_HANDSHAKE_TYPE_END_OF_EARLY_DATA, {});
-        if ((ret = retire_early_data_secret(tls, 1)) != 0)
+        if ((ret = commission_handshake_secret(tls)) != 0)
             goto Exit;
     }
 
@@ -3677,7 +3676,7 @@ static int server_handle_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptl
     }
 
     if (accept_early_data && tls->ctx->max_early_data_size != 0 && psk_index == 0) {
-        if ((tls->early_data = malloc(sizeof(*tls->early_data))) == NULL) {
+        if ((tls->pending_handshake_secret = malloc(PTLS_MAX_DIGEST_SIZE)) == NULL) {
             ret = PTLS_ERROR_NO_MEMORY;
             goto Exit;
         }
@@ -3722,11 +3721,11 @@ static int server_handle_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptl
     key_schedule_extract(tls->key_schedule, ecdh_secret);
     if ((ret = setup_traffic_protection(tls, 1, "s hs traffic", 2, 0)) != 0)
         goto Exit;
-    if (tls->early_data != NULL) {
-        if ((ret = derive_secret(tls->key_schedule, tls->early_data->next_secret, "c hs traffic")) != 0)
+    if (tls->pending_handshake_secret != NULL) {
+        if ((ret = derive_secret(tls->key_schedule, tls->pending_handshake_secret, "c hs traffic")) != 0)
             goto Exit;
         if (tls->ctx->update_traffic_key != NULL &&
-            (ret = tls->ctx->update_traffic_key->cb(tls->ctx->update_traffic_key, tls, 0, 2, tls->early_data->next_secret)) != 0)
+            (ret = tls->ctx->update_traffic_key->cb(tls->ctx->update_traffic_key, tls, 0, 2, tls->pending_handshake_secret)) != 0)
             goto Exit;
     } else {
         if ((ret = setup_traffic_protection(tls, 0, "c hs traffic", 2, 0)) != 0)
@@ -3759,7 +3758,7 @@ static int server_handle_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptl
                     });
                 });
             }
-            if (tls->early_data != NULL)
+            if (tls->pending_handshake_secret != NULL)
                 buffer_push_extension(sendbuf, PTLS_EXTENSION_TYPE_EARLY_DATA, {});
             if ((ret = push_additional_extensions(properties, sendbuf)) != 0)
                 goto Exit;
@@ -3809,9 +3808,9 @@ static int server_handle_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptl
     if ((ret = derive_exporter_secret(tls, 0)) != 0)
         goto Exit;
 
-    if (tls->early_data != NULL) {
+    if (tls->pending_handshake_secret != NULL) {
         if (tls->ctx->omit_end_of_early_data) {
-            if ((ret = retire_early_data_secret(tls, 0)) != 0)
+            if ((ret = commission_handshake_secret(tls)) != 0)
                 goto Exit;
             tls->state = PTLS_STATE_SERVER_EXPECT_FINISHED;
         } else {
@@ -3849,7 +3848,7 @@ static int server_handle_end_of_early_data(ptls_t *tls, ptls_iovec_t message)
 {
     int ret;
 
-    if ((ret = retire_early_data_secret(tls, 0)) != 0)
+    if ((ret = commission_handshake_secret(tls)) != 0)
         goto Exit;
 
     ptls__key_schedule_update_hash(tls->key_schedule, message.base, message.len);
@@ -4049,9 +4048,9 @@ void ptls_free(ptls_t *tls)
     if (tls->certificate_verify.cb != NULL) {
         tls->certificate_verify.cb(tls->certificate_verify.verify_ctx, ptls_iovec_init(NULL, 0), ptls_iovec_init(NULL, 0));
     }
-    if (tls->early_data != NULL) {
-        ptls_clear_memory(tls->early_data, sizeof(*tls->early_data));
-        free(tls->early_data);
+    if (tls->pending_handshake_secret != NULL) {
+        ptls_clear_memory(tls->pending_handshake_secret, PTLS_MAX_DIGEST_SIZE);
+        free(tls->pending_handshake_secret);
     }
     update_open_count(tls->ctx, -1);
     ptls_clear_memory(tls, sizeof(*tls));

--- a/t/cli.c
+++ b/t/cli.c
@@ -135,8 +135,9 @@ static int handle_connection(int sockfd, ptls_context_t *ctx, const char *server
                 if (state == IN_HANDSHAKE) {
                     if ((ret = ptls_handshake(tls, &encbuf, bytebuf + off, &leftlen, hsprop)) == 0) {
                         state = IN_1RTT;
+                        assert(ptls_is_server(tls) || hsprop->client.early_data_acceptance != PTLS_EARLY_DATA_ACCEPTANCE_UNKNOWN);
                         /* release data sent as early-data, if server accepted it */
-                        if (hsprop->client.early_data_accepted_by_peer)
+                        if (hsprop->client.early_data_acceptance == PTLS_EARLY_DATA_ACCEPTED)
                             shift_buffer(&ptbuf, early_bytes_sent);
                         if (request_key_update)
                             ptls_update_key(tls, 1);


### PR DESCRIPTION
For some historical reasons, when running as a client, picotls calculates the handshake write key when it receives EncryptedExtensions - the first handshake message protected by the handshake key  (FWIW, it made sense to do so a long time ago, when we used to send EOED and commission the handshake write key at this moment. We are now doing that at a later moment so that we could could continue sending early data until becoming possible to send 1-RTT data).

That does not work well with QUIC, a protocol that requires the TLS stack to provide handshake write key as soon as possible (consider the case of SH and EE being delivered as separate UDP datagrams).

This PR address the issue by moving the calculation of handshake write key to the earliest possible moment.

The unfortunate side-effect of the PR is the API change.

Previously, we have advised QUIC stacks to consult the value of `ptls_handshake_properties_t::early_data_accepted_by_peer` when the handshake write key is provided to the `update_traffic_key` callback. Obviously, that becomes impossible by the change. Therefore, the PR replaces the variable with `ptls_handshake_properties_t::early_data_acceptance` which is a tri-state variable taking one of _UNKNOWN_, _ACCEPTED_, _REJECTED_. QUIC stacks should check the variable each time it calls `ptls_handle_message` to see if 0-RTT has been accepted or rejected.