### PR TITLE
Fix heap-buffer-overflow READ

### DIFF
--- a/lib/minicrypto-pem.c
+++ b/lib/minicrypto-pem.c
@@ -105,29 +105,30 @@ size_t ptls_minicrypto_asn1_decode_private_key(ptls_asn1_pkcs8_private_key_t *pk
             byte_index += oid_length;
         }
     }
-
-    if (*decode_error == 0 && last_byte1 < byte_index) {
-        byte_index = ptls_asn1_error_message("Length larger than message", bytes_max, byte_index, 0, log_ctx);
-        *decode_error = PTLS_ERROR_BER_EXCESSIVE_LENGTH;
-    }
+  
     if (*decode_error == 0) {
         /* get parameters, ANY */
         if (log_ctx != NULL) {
             log_ctx->fn(log_ctx->ctx, "      Parameters:\n");
         }
+      
+        if (last_byte1 <= byte_index) {
+            pkey->parameters_index = 0;
+            pkey->parameters_length = 0;
+        } else {
+            pkey->parameters_index = byte_index;
 
-        pkey->parameters_index = byte_index;
-
-        pkey->parameters_length =
-            (uint32_t)ptls_asn1_validation_recursive(bytes + byte_index, last_byte1 - byte_index, decode_error, 2, log_ctx);
-
-        byte_index += pkey->parameters_length;
-
+            pkey->parameters_length =
+                (uint32_t)ptls_asn1_validation_recursive(bytes + byte_index, last_byte1 - byte_index, decode_error, 2, log_ctx);
+            if (*decode_error == 0) {
+                byte_index += pkey->parameters_length;
+            }
+        }
         if (log_ctx != NULL) {
             log_ctx->fn(log_ctx->ctx, "\n");
         }
         /* close sequence */
-        if (byte_index != last_byte1) {
+        if (*decode_error == 0 && byte_index != last_byte1) {
             byte_index = ptls_asn1_error_message("Length larger than element", bytes_max, byte_index, 2, log_ctx);
             *decode_error = PTLS_ERROR_BER_ELEMENT_TOO_SHORT;
         }

--- a/lib/minicrypto-pem.c
+++ b/lib/minicrypto-pem.c
@@ -106,7 +106,7 @@ size_t ptls_minicrypto_asn1_decode_private_key(ptls_asn1_pkcs8_private_key_t *pk
         }
     }
 
-    if (last_byte1 < byte_index) {
+    if (*decode_error == 0 && last_byte1 < byte_index) {
         byte_index = ptls_asn1_error_message("Length larger than message", bytes_max, byte_index, 0, log_ctx);
         *decode_error = PTLS_ERROR_BER_EXCESSIVE_LENGTH;
     }

--- a/lib/minicrypto-pem.c
+++ b/lib/minicrypto-pem.c
@@ -106,6 +106,10 @@ size_t ptls_minicrypto_asn1_decode_private_key(ptls_asn1_pkcs8_private_key_t *pk
         }
     }
 
+    if (last_byte1 < byte_index) {
+        byte_index = ptls_asn1_error_message("Length larger than message", bytes_max, byte_index, 0, log_ctx);
+        *decode_error = PTLS_ERROR_BER_EXCESSIVE_LENGTH;
+    }
     if (*decode_error == 0) {
         /* get parameters, ANY */
         if (log_ctx != NULL) {


### PR DESCRIPTION
It's possible that byte_index goes past last_byte1 after we read the
OID. Add a check for that.

Credit to OSS-Fuzz