### PR TITLE
Use EVP_EncryptUpdate for ECB decryption

### DIFF
--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -712,9 +712,10 @@ static void cipher_encrypt(ptls_cipher_context_t *_ctx, void *output, const void
 static void cipher_decrypt(ptls_cipher_context_t *_ctx, void *output, const void *input, size_t _len)
 {
     struct cipher_context_t *ctx = (struct cipher_context_t *)_ctx;
-    int len = (int)_len, ret = EVP_DecryptUpdate(ctx->evp, output, &len, input, len);
+    /* EVP_DecryptUpdate tries to retain the last block, while EncryptUpdate does not */
+    int len = (int)_len, ret = EVP_EncryptUpdate(ctx->evp, output, &len, input, len);
     assert(ret);
-    /* OpenSSL 1.1.0i (or d?) seems to set outlen to zero when passing a 16-byte input to aes128ecb // assert(len == (int)_len); */
+    assert(len == (int)_len);
 }
 
 static int aes128ecb_setup_crypto(ptls_cipher_context_t *ctx, int is_enc, const void *key)

--- a/t/openssl.c
+++ b/t/openssl.c
@@ -91,20 +91,20 @@ static void test_bf(void)
     static const uint8_t key[PTLS_BLOWFISH_KEY_SIZE] = {0},
                          plaintext[PTLS_BLOWFISH_BLOCK_SIZE] = {0x4e, 0xf9, 0x97, 0x45, 0x61, 0x98, 0xdd, 0x78},
                          expected[PTLS_BLOWFISH_BLOCK_SIZE] = {0xe1, 0xc0, 0x30, 0xe7, 0x4c, 0x14, 0xd2, 0x61};
-    uint8_t actual[PTLS_BLOWFISH_BLOCK_SIZE];
+    uint8_t encrypted[PTLS_BLOWFISH_BLOCK_SIZE], decrypted[PTLS_BLOWFISH_BLOCK_SIZE];
 
     /* encrypt */
-    memset(actual, 0, sizeof(actual));
     ptls_cipher_context_t *ctx = ptls_cipher_new(&ptls_openssl_bfecb, 1, key);
-    ptls_cipher_encrypt(ctx, actual, plaintext, sizeof(actual));
+    ptls_cipher_encrypt(ctx, encrypted, plaintext, PTLS_BLOWFISH_BLOCK_SIZE);
     ptls_cipher_free(ctx);
-    ok(memcmp(actual, expected, sizeof(actual)) == 0);
+    ok(memcmp(encrypted, expected, PTLS_BLOWFISH_BLOCK_SIZE) == 0);
 
     /* decrypt */
     ctx = ptls_cipher_new(&ptls_openssl_bfecb, 0, key);
-    ptls_cipher_encrypt(ctx, actual, actual, sizeof(actual));
+    ptls_cipher_encrypt(ctx, decrypted, "deadbeef", PTLS_BLOWFISH_BLOCK_SIZE);
+    ptls_cipher_encrypt(ctx, decrypted, encrypted, PTLS_BLOWFISH_BLOCK_SIZE);
     ptls_cipher_free(ctx);
-    ok(memcmp(actual, plaintext, sizeof(actual)) == 0);
+    ok(memcmp(decrypted, plaintext, PTLS_BLOWFISH_BLOCK_SIZE) == 0);
 #endif
 }
 


### PR DESCRIPTION
Because EVP_DecryptUpdate retains one block, see evp_enc.c.

This has caused incorrect responses in quicly's CID decryption function, leading to packet misrouting.