### PR TITLE
fix client-side bugs when receiving HRR in response to a 0-RTT resumption attempt

### DIFF
--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -1827,7 +1827,9 @@ static int send_client_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptls_
                                              &resumption_ticket, &max_early_data_size, properties->client.session_ticket.base,
                                              properties->client.session_ticket.base + properties->client.session_ticket.len) == 0) {
                 tls->client.offered_psk = 1;
-                tls->key_share = key_share;
+                /* key-share selected by HRR should not be overridden */
+                if (tls->key_share == NULL)
+                    tls->key_share = key_share;
                 tls->cipher_suite = cipher_suite;
                 if (!is_second_flight && max_early_data_size != 0 && properties->client.max_early_data_size != NULL) {
                     tls->client.using_early_data = 1;

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -1996,15 +1996,17 @@ static int send_client_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptls_
     }
     ptls__key_schedule_update_hash(tls->key_schedule, emitter->buf->base + msghash_off, emitter->buf->off - msghash_off);
 
-    if (tls->client.using_early_data) {
-        if ((ret = setup_traffic_protection(tls, 1, "c e traffic", 1, 0)) != 0)
-            goto Exit;
-        if ((ret = push_change_cipher_spec(tls, emitter->buf)) != 0)
-            goto Exit;
-    }
-    if (resumption_secret.base != NULL && !is_second_flight) {
-        if ((ret = derive_exporter_secret(tls, 1)) != 0)
-            goto Exit;
+    if (!is_second_flight) {
+        if (tls->client.using_early_data) {
+            if ((ret = setup_traffic_protection(tls, 1, "c e traffic", 1, 0)) != 0)
+                goto Exit;
+            if ((ret = push_change_cipher_spec(tls, emitter->buf)) != 0)
+                goto Exit;
+        }
+        if (resumption_secret.base != NULL) {
+            if ((ret = derive_exporter_secret(tls, 1)) != 0)
+                goto Exit;
+        }
     }
     tls->state = cookie == NULL ? PTLS_STATE_CLIENT_EXPECT_SERVER_HELLO : PTLS_STATE_CLIENT_EXPECT_SECOND_SERVER_HELLO;
     ret = PTLS_ERROR_IN_PROGRESS;

--- a/t/picotls.c
+++ b/t/picotls.c
@@ -1207,16 +1207,15 @@ static void test_handshake_api(void)
     memset(coffs, 0, sizeof(coffs));
     memset(soffs, 0, sizeof(soffs));
 
+    ctx->save_ticket = NULL; /* don't allow further test to update the saved ticket */
+
+    /* 0-RTT resumption */
     size_t max_early_data_size = 0;
     ptls_handshake_properties_t client_hs_prop = {{{{NULL}, saved_ticket, &max_early_data_size}}};
     client = ptls_new(ctx, 0);
     *ptls_get_data_ptr(client) = &client_secrets;
     server = ptls_new(ctx_peer, 1);
     *ptls_get_data_ptr(server) = &server_secrets;
-
-    ctx->save_ticket = NULL; /* don't allow further test to update the saved ticket */
-
-    /* 0-RTT resumption */
     ret = ptls_handle_message(client, &cbuf, coffs, 0, NULL, 0, &client_hs_prop);
     ok(ret == PTLS_ERROR_IN_PROGRESS);
     ok(max_early_data_size != 0);
@@ -1238,8 +1237,91 @@ static void test_handshake_api(void)
     ok(memcmp(client_secrets[1][3], zeroes_of_max_digest_size, PTLS_MAX_DIGEST_SIZE) != 0);
     ret = feed_messages(server, &sbuf, soffs, cbuf.base, coffs, NULL);
     ok(ret == 0);
+    ok(sbuf.off == 0);
     ok(ptls_handshake_is_complete(server));
-    ok(memcmp(client_secrets[1][3], server_secrets[0][3], PTLS_MAX_DIGEST_SIZE) == 0);
+    ok(memcmp(server_secrets[0][3], zeroes_of_max_digest_size, PTLS_MAX_DIGEST_SIZE) != 0);
+
+    ptls_free(client);
+    ptls_free(server);
+
+    cbuf.off = 0;
+    sbuf.off = 0;
+    memset(client_secrets, 0, sizeof(client_secrets));
+    memset(server_secrets, 0, sizeof(server_secrets));
+    memset(coffs, 0, sizeof(coffs));
+    memset(soffs, 0, sizeof(soffs));
+
+    /* 0-RTT rejection */
+    ctx_peer->max_early_data_size = 0;
+    client_hs_prop = (ptls_handshake_properties_t){{{{NULL}, saved_ticket, &max_early_data_size}}};
+    client = ptls_new(ctx, 0);
+    *ptls_get_data_ptr(client) = &client_secrets;
+    server = ptls_new(ctx_peer, 1);
+    *ptls_get_data_ptr(server) = &server_secrets;
+    ret = ptls_handle_message(client, &cbuf, coffs, 0, NULL, 0, &client_hs_prop);
+    ok(ret == PTLS_ERROR_IN_PROGRESS);
+    ok(max_early_data_size != 0);
+    ok(memcmp(client_secrets[1][1], zeroes_of_max_digest_size, PTLS_MAX_DIGEST_SIZE) != 0);
+    ret = feed_messages(server, &sbuf, soffs, cbuf.base, coffs, NULL);
+    ok(ret == 0);
+    ok(sbuf.off != 0);
+    ok(!ptls_handshake_is_complete(server));
+    ret = feed_messages(client, &cbuf, coffs, sbuf.base, soffs, &client_hs_prop);
+    ok(ret == 0);
+    ok(cbuf.off != 0);
+    ok(ptls_handshake_is_complete(client));
+    ok(client_hs_prop.client.early_data_acceptance == PTLS_EARLY_DATA_REJECTED);
+    ok(memcmp(server_secrets[0][1], zeroes_of_max_digest_size, PTLS_MAX_DIGEST_SIZE) == 0);
+    ret = feed_messages(server, &sbuf, soffs, cbuf.base, coffs, NULL);
+    ok(ret == 0);
+    ok(sbuf.off == 0);
+    ok(ptls_handshake_is_complete(server));
+
+    ptls_free(client);
+    ptls_free(server);
+
+    cbuf.off = 0;
+    sbuf.off = 0;
+    memset(client_secrets, 0, sizeof(client_secrets));
+    memset(server_secrets, 0, sizeof(server_secrets));
+    memset(coffs, 0, sizeof(coffs));
+    memset(soffs, 0, sizeof(soffs));
+
+    /* HRR rejects 0-RTT */
+    ctx_peer->max_early_data_size = 8192;
+    ptls_handshake_properties_t server_hs_prop = {{{{NULL}}}};
+    server_hs_prop.server.enforce_retry = 1;
+    client_hs_prop = (ptls_handshake_properties_t){{{{NULL}, saved_ticket, &max_early_data_size}}};
+    client = ptls_new(ctx, 0);
+    *ptls_get_data_ptr(client) = &client_secrets;
+    server = ptls_new(ctx_peer, 1);
+    *ptls_get_data_ptr(server) = &server_secrets;
+    ret = ptls_handle_message(client, &cbuf, coffs, 0, NULL, 0, &client_hs_prop); /* -> CH */
+    ok(ret == PTLS_ERROR_IN_PROGRESS);
+    ok(max_early_data_size != 0);
+    ok(memcmp(client_secrets[1][1], zeroes_of_max_digest_size, PTLS_MAX_DIGEST_SIZE) != 0);
+    ret = feed_messages(server, &sbuf, soffs, cbuf.base, coffs, &server_hs_prop); /* CH -> HRR */
+    ok(ret == PTLS_ERROR_IN_PROGRESS);
+    ok(sbuf.off != 0);
+    ok(!ptls_handshake_is_complete(server));
+    ret = feed_messages(client, &cbuf, coffs, sbuf.base, soffs, &client_hs_prop); /* HRR  -> CH */
+    ok(ret == PTLS_ERROR_IN_PROGRESS);
+    ok(cbuf.off != 0);
+    ok(!ptls_handshake_is_complete(client));
+    ok(client_hs_prop.client.early_data_acceptance == PTLS_EARLY_DATA_ACCEPTANCE_UNKNOWN);
+    ret = feed_messages(server, &sbuf, soffs, cbuf.base, coffs, &server_hs_prop); /* CH -> SH..SF */
+    ok(ret == 0);
+    ok(!ptls_handshake_is_complete(server));
+    ok(memcmp(server_secrets[0][1], zeroes_of_max_digest_size, PTLS_MAX_DIGEST_SIZE) == 0);
+    ok(sbuf.off != 0);
+    ret = feed_messages(client, &cbuf, coffs, sbuf.base, soffs, &client_hs_prop); /* SH..SF -> CF */
+    ok(ret == 0);
+    ok(ptls_handshake_is_complete(client));
+    ok(client_hs_prop.client.early_data_acceptance == PTLS_EARLY_DATA_REJECTED); /* TODO detect this when receiving HRR */
+    ok(cbuf.off != 0);
+    ret = feed_messages(server, &sbuf, soffs, cbuf.base, coffs, &server_hs_prop); /* CF -> */
+    ok(ret == 0);
+    ok(ptls_handshake_is_complete(server));
 
     ptls_free(client);
     ptls_free(server);


### PR DESCRIPTION
Bugs being fixed:
* [x] 0-RTT key is generated twice (instead of just once), the second one being an incorrect value
* [x] `ptls_handle_message` emits 2nd CH as epoch 1 (instead of epoch 0)
* [x] signal rejection of 0-RTT when receiving HRR

The expected behavior in terms of protocol is, quoting from RFC 8446 section 4.2.10:
> A server which receives an “early_data” extension MUST behave in one of three ways:
> * (snip)
> * Request that the client send another ClientHello by responding with a HelloRetryRequest. A client MUST NOT include the “early_data” extension in its followup ClientHello. The server then ignores early data by skipping all records with external content type of “application_data” (indicating that they are encrypted), up to the configured max_early_data_size.