### PR TITLE
Send an alert in cli

### DIFF
--- a/t/cli.c
+++ b/t/cli.c
@@ -224,7 +224,17 @@ static int handle_connection(int sockfd, ptls_context_t *ctx, const char *server
 
         /* close the sender side when necessary */
         if (state == IN_1RTT && inputfd == -1) {
-            /* FIXME send close_alert */
+            ptls_buffer_t wbuf;
+            uint8_t wbuf_small[32];
+            ptls_buffer_init(&wbuf, wbuf_small, sizeof(wbuf_small));
+            if ((ret = ptls_send_alert(tls, &wbuf,
+                       PTLS_ALERT_LEVEL_WARNING, PTLS_ALERT_CLOSE_NOTIFY)) != 0) {
+                fprintf(stderr, "ptls_send_alert:%d\n", ret);
+            }
+            if (wbuf.off != 0) {
+                (void)write(sockfd, wbuf.base, wbuf.off);
+            }
+            ptls_buffer_dispose(&wbuf);
             shutdown(sockfd, SHUT_WR);
             state = IN_SHUTDOWN;
         }
@@ -264,7 +274,9 @@ static int run_server(struct sockaddr *sa, socklen_t salen, ptls_context_t *ctx,
         return 1;
     }
 
+    fprintf(stderr, "server started on port %d\n", ntohs(((struct sockaddr_in *) sa)->sin_port));
     while (1) {
+        fprintf(stderr, "waiting for connections\n");
         if ((conn_fd = accept(listen_fd, NULL, 0)) != -1)
             handle_connection(conn_fd, ctx, NULL, input_file, hsprop, request_key_update);
     }


### PR DESCRIPTION
I use `t/cli.c` for some testing, and noticed that it doesn't send an alert when it closes a connection. Could you please review this small patch? The patch updates `t/cli.c` with the following:
- send an `close_notify` alert before it closes the connection
- print a couple of messages which show that the server started and waits for connections