### PR TITLE
Add EXTERNAL_READ_ENTROPY define.

### DIFF
--- a/lib/cifra.c
+++ b/lib/cifra.c
@@ -89,6 +89,8 @@ static void read_entropy(uint8_t *entropy, size_t size)
     }
 }
 #endif
+#elif defined(EXTERNAL_READ_ENTROPY)
+/* read_entropy() provided elsewhere */
 #else
 static void read_entropy(uint8_t *entropy, size_t size)
 {


### PR DESCRIPTION
This lets one provide a substitute for the default `read_entropy()` call, e.g.,  on
embedded platforms where `/dev/urandom` and `/dev/random` are unavailable.