### PR TITLE
simplify tracing

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -563,10 +563,6 @@ typedef struct st_ptls_decompress_certificate_t {
  */
 PTLS_CALLBACK_TYPE(int, update_esni_key, ptls_t *tls, ptls_iovec_t secret, ptls_hash_algorithm_t *hash,
                    const void *hashed_esni_contents);
-/**
- * return if USDT probes should be activated for the connection
- */
-PTLS_CALLBACK_TYPE(int, is_traced, ptls_t *tls);
 
 /**
  * the configuration
@@ -677,10 +673,6 @@ struct st_ptls_context_t {
      *
      */
     ptls_update_esni_key_t *update_esni_key;
-    /**
-     *
-     */
-    ptls_is_traced_t *is_traced;
     /**
      *
      */
@@ -1019,6 +1011,14 @@ int ptls_is_psk_handshake(ptls_t *tls);
  * returns a pointer to user data pointer (client is reponsible for freeing the associated data prior to calling ptls_free)
  */
 void **ptls_get_data_ptr(ptls_t *tls);
+/**
+ *
+ */
+int ptls_is_traced(ptls_t *tls);
+/**
+ *
+ */
+void ptls_set_is_traced(ptls_t *tls, int is_traced);
 /**
  * proceeds with the handshake, optionally taking some input from peer. The function returns zero in case the handshake completed
  * successfully. PTLS_ERROR_IN_PROGRESS is returned in case the handshake is incomplete. Otherwise, an error value is returned. The

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -1014,11 +1014,11 @@ void **ptls_get_data_ptr(ptls_t *tls);
 /**
  *
  */
-int ptls_is_traced(ptls_t *tls);
+int ptls_skip_tracing(ptls_t *tls);
 /**
  *
  */
-void ptls_set_is_traced(ptls_t *tls, int is_traced);
+void ptls_set_skip_tracing(ptls_t *tls, int skip_tracing);
 /**
  * proceeds with the handshake, optionally taking some input from peer. The function returns zero in case the handshake completed
  * successfully. PTLS_ERROR_IN_PROGRESS is returned in case the handshake is incomplete. Otherwise, an error value is returned. The

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -93,7 +93,7 @@
 #endif
 
 #if PICOTLS_USE_DTRACE
-#define PTLS_SHOULD_PROBE(LABEL, tls) (PTLS_UNLIKELY(PICOTLS_##LABEL##_ENABLED()) && (tls)->is_traced)
+#define PTLS_SHOULD_PROBE(LABEL, tls) (PTLS_UNLIKELY(PICOTLS_##LABEL##_ENABLED()) && !(tls)->skip_tracing)
 #define PTLS_PROBE0(LABEL, tls)                                                                                                    \
     do {                                                                                                                           \
         ptls_t *_tls = (tls);                                                                                                      \
@@ -230,7 +230,7 @@ struct st_ptls_t {
     unsigned send_change_cipher_spec : 1;
     unsigned needs_key_update : 1;
     unsigned key_update_send_request : 1;
-    unsigned is_traced : 1;
+    unsigned skip_tracing : 1;
     /**
      * misc.
      */
@@ -4272,14 +4272,14 @@ void **ptls_get_data_ptr(ptls_t *tls)
     return &tls->data_ptr;
 }
 
-int ptls_is_traced(ptls_t *tls)
+int ptls_skip_tracing(ptls_t *tls)
 {
-    return tls->is_traced;
+    return tls->skip_tracing;
 }
 
-void ptls_set_is_traced(ptls_t *tls, int is_traced)
+void ptls_set_skip_tracing(ptls_t *tls, int skip_tracing)
 {
-    tls->is_traced = is_traced;
+    tls->skip_tracing = skip_tracing;
 }
 
 static int handle_handshake_message(ptls_t *tls, ptls_message_emitter_t *emitter, ptls_iovec_t message, int is_end_of_record,

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -93,10 +93,7 @@
 #endif
 
 #if PICOTLS_USE_DTRACE
-#define PTLS_SHOULD_PROBE(LABEL, tls)                                                                                              \
-    (PTLS_UNLIKELY(PICOTLS_##LABEL##_ENABLED()) &&                                                                                 \
-     (tls->ctx->is_traced == NULL || tls->ctx->is_traced->cb(tls->ctx->is_traced, tls)))
-
+#define PTLS_SHOULD_PROBE(LABEL, tls) (PTLS_UNLIKELY(PICOTLS_##LABEL##_ENABLED()) && (tls)->is_traced)
 #define PTLS_PROBE0(LABEL, tls)                                                                                                    \
     do {                                                                                                                           \
         ptls_t *_tls = (tls);                                                                                                      \
@@ -233,6 +230,7 @@ struct st_ptls_t {
     unsigned send_change_cipher_spec : 1;
     unsigned needs_key_update : 1;
     unsigned key_update_send_request : 1;
+    unsigned is_traced : 1;
     /**
      * misc.
      */
@@ -4272,6 +4270,16 @@ int ptls_is_psk_handshake(ptls_t *tls)
 void **ptls_get_data_ptr(ptls_t *tls)
 {
     return &tls->data_ptr;
+}
+
+int ptls_is_traced(ptls_t *tls)
+{
+    return tls->is_traced;
+}
+
+void ptls_set_is_traced(ptls_t *tls, int is_traced)
+{
+    tls->is_traced = is_traced;
 }
 
 static int handle_handshake_message(ptls_t *tls, ptls_message_emitter_t *emitter, ptls_iovec_t message, int is_end_of_record,


### PR DESCRIPTION
The callback-based API introduced in #241 was difficult to use, as the back pointer needs to be setup at an appropriate moment.

This PR reverts the introduction of that API, and instead introduces a boolean flag that can be get / set indicating if the TLS connection is being traced.