### PR TITLE
introduce `ptls_default_skip_tracing` TLS global

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -42,6 +42,12 @@ extern "C" {
 #define PTLS_UNLIKELY(x) (x)
 #endif
 
+#ifdef _WINDOWS
+#define PTLS_THREADLOCAL __declspec(thread)
+#else
+#define PTLS_THREADLOCAL __thread
+#endif
+
 #ifndef PTLS_FUZZ_HANDSHAKE
 #define PTLS_FUZZ_HANDSHAKE 0
 #endif
@@ -1198,12 +1204,10 @@ int ptls_esni_init_context(ptls_context_t *ctx, ptls_esni_context_t *esni, ptls_
  *
  */
 void ptls_esni_dispose_context(ptls_esni_context_t *esni);
-
 /**
  * Obtain the ESNI secrets negotiated during the handshake.
  */
 ptls_esni_secret_t *ptls_get_esni_secret(ptls_t *ctx);
-
 /**
  *
  */
@@ -1212,6 +1216,10 @@ char *ptls_hexdump(char *dst, const void *src, size_t len);
  * the default get_time callback
  */
 extern ptls_get_time_t ptls_get_time;
+/**
+ *
+ */
+extern PTLS_THREADLOCAL unsigned ptls_default_skip_tracing;
 
 /* inline functions */
 

--- a/lib/cifra/random.c
+++ b/lib/cifra/random.c
@@ -111,11 +111,7 @@ static void read_entropy(uint8_t *entropy, size_t size)
 
 void ptls_minicrypto_random_bytes(void *buf, size_t len)
 {
-#ifdef _WINDOWS
-    static __declspec(thread) cf_hash_drbg_sha256 ctx;
-#else
-    static __thread cf_hash_drbg_sha256 ctx;
-#endif
+    static PTLS_THREADLOCAL cf_hash_drbg_sha256 ctx;
 
     if (cf_hash_drbg_sha256_needs_reseed(&ctx)) {
         uint8_t entropy[256];

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -4136,6 +4136,7 @@ ptls_t *ptls_new(ptls_context_t *ctx, int is_server)
     *tls = (ptls_t){ctx};
     tls->is_server = is_server;
     tls->send_change_cipher_spec = ctx->send_change_cipher_spec;
+    tls->skip_tracing = ptls_default_skip_tracing;
     if (!is_server) {
         tls->state = PTLS_STATE_CLIENT_HANDSHAKE_START;
         tls->ctx->random_bytes(tls->client_random, sizeof(tls->client_random));
@@ -5062,6 +5063,7 @@ static uint64_t get_time(ptls_get_time_t *self)
 }
 
 ptls_get_time_t ptls_get_time = {get_time};
+PTLS_THREADLOCAL unsigned ptls_default_skip_tracing = 1;
 
 int ptls_is_server(ptls_t *tls)
 {


### PR DESCRIPTION
This is the most practical way of passing parameters to picotls upon instantiation from application (e.g., h2o) to picotls through layers in between (e.g., quicly).