### PR TITLE
API to reject 0-RTT (while accepting resumption)

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -154,6 +154,7 @@ extern "C" {
 #define PTLS_ERROR_NOT_AVAILABLE (PTLS_ERROR_CLASS_INTERNAL + 7)
 #define PTLS_ERROR_COMPRESSION_FAILURE (PTLS_ERROR_CLASS_INTERNAL + 8)
 #define PTLS_ERROR_ESNI_RETRY (PTLS_ERROR_CLASS_INTERNAL + 8)
+#define PTLS_ERROR_REJECT_EARLY_DATA (PTLS_ERROR_CLASS_INTERNAL + 9)
 
 #define PTLS_ERROR_INCORRECT_BASE64 (PTLS_ERROR_CLASS_INTERNAL + 50)
 #define PTLS_ERROR_PEM_LABEL_NOT_FOUND (PTLS_ERROR_CLASS_INTERNAL + 51)
@@ -523,7 +524,10 @@ PTLS_CALLBACK_TYPE(int, verify_certificate, ptls_t *tls,
                    int (**verify_sign)(void *verify_ctx, ptls_iovec_t data, ptls_iovec_t sign), void **verify_data,
                    ptls_iovec_t *certs, size_t num_certs);
 /**
- * encrypt-and-signs (or verify-and-decrypts) a ticket (server-only)
+ * Encrypt-and-signs (or verify-and-decrypts) a ticket (server-only).
+ * When used for encryption (i.e., is_encrypt being set), the function should return 0 if successful, or else a non-zero value.
+ * When used for decryption, the function should return 0 (successful), PTLS_ERROR_REJECT_EARLY_DATA (successful, but 0-RTT is
+ * forbidden), or any other value to indicate failure.
  */
 PTLS_CALLBACK_TYPE(int, encrypt_ticket, ptls_t *tls, int is_encrypt, ptls_buffer_t *dst, ptls_iovec_t src);
 /**

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -3398,9 +3398,17 @@ static int try_psk_handshake(ptls_t *tls, size_t *psk_index, int *accept_early_d
     for (*psk_index = 0; *psk_index < ch->psk.identities.count; ++*psk_index) {
         struct st_ptls_client_hello_psk_t *identity = ch->psk.identities.list + *psk_index;
         /* decrypt and decode */
+        int can_accept_early_data = 1;
         decbuf.off = 0;
-        if ((tls->ctx->encrypt_ticket->cb(tls->ctx->encrypt_ticket, tls, 0, &decbuf, identity->identity)) != 0)
+        switch (tls->ctx->encrypt_ticket->cb(tls->ctx->encrypt_ticket, tls, 0, &decbuf, identity->identity)) {
+        case 0: /* decrypted */
+            break;
+        case PTLS_ERROR_REJECT_EARLY_DATA: /* decrypted, but early data is rejected */
+            can_accept_early_data = 0;
+            break;
+        default: /* decryption failure */
             continue;
+        }
         if (decode_session_identifier(&issue_at, &ticket_psk, &age_add, &ticket_server_name, &ticket_key_exchange_id, &ticket_csid,
                                       &ticket_negotiated_protocol, decbuf.base, decbuf.base + decbuf.off) != 0)
             continue;
@@ -3410,7 +3418,7 @@ static int try_psk_handshake(ptls_t *tls, size_t *psk_index, int *accept_early_d
         if (now - issue_at > (uint64_t)tls->ctx->ticket_lifetime * 1000)
             continue;
         *accept_early_data = 0;
-        if (ch->psk.early_data_indication) {
+        if (ch->psk.early_data_indication && can_accept_early_data) {
             /* accept early-data if abs(diff) between the reported age and the actual age is within += 10 seconds */
             int64_t delta = (now - issue_at) - (identity->obfuscated_ticket_age - age_add);
             if (delta < 0)


### PR DESCRIPTION
`encrypt_ticket` is the callback interface that allows an application to intervene with the resumption.

At the moment, returning zero from the callback means that the ticket has been decrypted, and that 0-RTT is acceptable. Returning a non-zero value means that the ticket has been rejected (due to decryption failure or whatever). There is no way for an application to indicate that 0-RTT is forbidden even though the ticket has been decrypted (and that it can be used for resuming the session).

This PR adds a new error code: PTLS_ERROR_REJECT_EARLY_DATA, that indicates the case.

Note: applications that want to associate arbitrary data to the session ticket are expected to customize the encrypt_ticket callback for attaching / detaching that arbitrary data.