### PR TITLE
Enable developers to access the raw client_hello message

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -469,6 +469,10 @@ typedef struct st_ptls_on_client_hello_parameters_t {
      */
     ptls_iovec_t server_name;
     /**
+     * Raw value of the client_hello message.
+     */
+    ptls_iovec_t raw_message;
+    /**
      *
      */
     struct {

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -3599,7 +3599,7 @@ static int server_handle_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptl
             server_name = ch.server_name;
         }
         if (tls->ctx->on_client_hello != NULL) {
-            ptls_on_client_hello_parameters_t params = {server_name,
+            ptls_on_client_hello_parameters_t params = {server_name, message,
                                                         {ch.alpn.list, ch.alpn.count},
                                                         {ch.signature_algorithms.list, ch.signature_algorithms.count},
                                                         {ch.cert_compression_algos.list, ch.cert_compression_algos.count},


### PR DESCRIPTION
## Why

Providing the raw [ClientHello](https://tools.ietf.org/html/rfc8446#section-4.1.2) value via the `on_client_hello` callback is beneficial to developers in various ways -- Analytics, Fingerprinting and etc.

## How

The raw message is already available within `server_handle_hello()`. Therefore it's just a matter of additional assignment when initializing `ptls_on_client_hello_parameters_t`. The developer is responsible for copying the value for further processing of the data in their callback / system.