### PR TITLE
Fix Visual Studio compiler warnings

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -493,7 +493,7 @@ typedef struct st_ptls_on_client_hello_parameters_t {
     /**
      * if ESNI was used
      */
-    uint8_t esni : 1;
+    unsigned int esni : 1;
 } ptls_on_client_hello_parameters_t;
 
 /**

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -439,15 +439,13 @@ typedef struct st_ptls_esni_secret_t {
     ptls_iovec_t secret;
     uint8_t nonce[PTLS_ESNI_NONCE_SIZE];
     uint8_t esni_contents_hash[PTLS_MAX_DIGEST_SIZE];
-    union {
-        struct {
-            ptls_key_exchange_algorithm_t *key_share;
-            ptls_cipher_suite_t *cipher;
-            ptls_iovec_t pubkey;
-            uint8_t record_digest[PTLS_MAX_DIGEST_SIZE];
-            uint16_t padded_length;
-        } client;
-    };
+    struct {
+        ptls_key_exchange_algorithm_t *key_share;
+        ptls_cipher_suite_t *cipher;
+        ptls_iovec_t pubkey;
+        uint8_t record_digest[PTLS_MAX_DIGEST_SIZE];
+        uint16_t padded_length;
+    } client;
     uint16_t version;
 } ptls_esni_secret_t;
 


### PR DESCRIPTION
This PR fixes two warnings in Visual Studio in the public interface header.
```
picotls\include\picotls.h(450,6): warning C4201: nonstandard extension used: nameless struct/union
picotls\include\picotls.h(498,21): warning C4214: nonstandard extension used: bit field types other than int
```
