### PR TITLE
`ptls_default_skip_tracing` can be a constant when tracing is not used

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -1222,10 +1222,14 @@ char *ptls_hexdump(char *dst, const void *src, size_t len);
  * the default get_time callback
  */
 extern ptls_get_time_t ptls_get_time;
+#if PICOTLS_USE_DTRACE
 /**
  *
  */
 extern PTLS_THREADLOCAL unsigned ptls_default_skip_tracing;
+#else
+#define ptls_default_skip_tracing 0
+#endif
 
 /* inline functions */
 

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -5071,7 +5071,9 @@ static uint64_t get_time(ptls_get_time_t *self)
 }
 
 ptls_get_time_t ptls_get_time = {get_time};
+#if PICOTLS_USE_DTRACE
 PTLS_THREADLOCAL unsigned ptls_default_skip_tracing = 0;
+#endif
 
 int ptls_is_server(ptls_t *tls)
 {


### PR DESCRIPTION
@larseggert Does something like this help?