### PR TITLE
cap buffer size

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ matrix:
         homebrew:
           packages:
             - libfaketime
+            - openssl
       env:
         - CMAKE_OPTS=" -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl/"
       before_install: &bs_macos

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -632,6 +632,10 @@ struct st_ptls_context_t {
      */
     uint32_t max_early_data_size;
     /**
+     * maximum size of the message buffer (default: 0 = unlimited = 3 + 2^24 bytes)
+     */
+    size_t max_message_buffer_size;
+    /**
      * the field is obsolete; should be set to NULL for QUIC draft-17.  Note also that even though everybody did, it was incorrect
      * to set the value to "quic " in the earlier versions of the draft.
      */

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -634,7 +634,7 @@ struct st_ptls_context_t {
     /**
      * maximum size of the message buffer (default: 0 = unlimited = 3 + 2^24 bytes)
      */
-    size_t max_message_buffer_size;
+    size_t max_buffer_size;
     /**
      * the field is obsolete; should be set to NULL for QUIC draft-17.  Note also that even though everybody did, it was incorrect
      * to set the value to "quic " in the earlier versions of the draft.

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -4461,9 +4461,9 @@ static int handle_alert(ptls_t *tls, const uint8_t *src, size_t len)
 
 static int message_buffer_is_overflow(ptls_context_t *ctx, size_t size)
 {
-    if (ctx->max_message_buffer_size == 0)
+    if (ctx->max_buffer_size == 0)
         return 0;
-    if (size <= ctx->max_message_buffer_size)
+    if (size <= ctx->max_buffer_size)
         return 0;
     return 1;
 }

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -4459,6 +4459,15 @@ static int handle_alert(ptls_t *tls, const uint8_t *src, size_t len)
     return PTLS_ALERT_TO_PEER_ERROR(desc);
 }
 
+static int message_buffer_is_overflow(ptls_context_t *ctx, size_t size)
+{
+    if (ctx->max_message_buffer_size == 0)
+        return 0;
+    if (size <= ctx->max_message_buffer_size)
+        return 0;
+    return 1;
+}
+
 static int handle_handshake_record(ptls_t *tls,
                                    int (*cb)(ptls_t *tls, ptls_message_emitter_t *emitter, ptls_iovec_t message,
                                              int is_end_of_record, ptls_handshake_properties_t *properties),
@@ -4477,6 +4486,8 @@ static int handle_handshake_record(ptls_t *tls,
         src = rec->fragment;
         src_end = src + rec->length;
     } else {
+        if (message_buffer_is_overflow(tls->ctx, tls->recvbuf.mess.off + rec->length))
+            return PTLS_ALERT_HANDSHAKE_FAILURE;
         if ((ret = ptls_buffer_reserve(&tls->recvbuf.mess, rec->length)) != 0)
             return ret;
         memcpy(tls->recvbuf.mess.base + tls->recvbuf.mess.off, rec->fragment, rec->length);
@@ -4505,15 +4516,18 @@ static int handle_handshake_record(ptls_t *tls,
 
     /* keep last partial message in buffer */
     if (src != src_end) {
+        size_t new_size = src_end - src;
+        if (message_buffer_is_overflow(tls->ctx, new_size))
+            return PTLS_ALERT_HANDSHAKE_FAILURE;
         if (tls->recvbuf.mess.base == NULL) {
             ptls_buffer_init(&tls->recvbuf.mess, "", 0);
-            if ((ret = ptls_buffer_reserve(&tls->recvbuf.mess, src_end - src)) != 0)
+            if ((ret = ptls_buffer_reserve(&tls->recvbuf.mess, new_size)) != 0)
                 return ret;
-            memcpy(tls->recvbuf.mess.base, src, src_end - src);
+            memcpy(tls->recvbuf.mess.base, src, new_size);
         } else {
-            memmove(tls->recvbuf.mess.base, src, src_end - src);
+            memmove(tls->recvbuf.mess.base, src, new_size);
         }
-        tls->recvbuf.mess.off = src_end - src;
+        tls->recvbuf.mess.off = new_size;
         ret = PTLS_ERROR_IN_PROGRESS;
     } else {
         ptls_buffer_dispose(&tls->recvbuf.mess);

--- a/t/picotls.c
+++ b/t/picotls.c
@@ -450,7 +450,7 @@ static void test_fragmented_message(void)
     struct st_ptls_record_t rec = {PTLS_CONTENT_TYPE_HANDSHAKE, 0x0301};
     int ret;
 
-    tlsctx.max_message_buffer_size = 14;
+    tlsctx.max_buffer_size = 14;
 
 #define SET_RECORD(lit)                                                                                                            \
     do {                                                                                                                           \

--- a/t/picotls.c
+++ b/t/picotls.c
@@ -445,9 +445,12 @@ static int test_fragmented_message_record(ptls_t *tls, struct st_ptls_message_em
 
 static void test_fragmented_message(void)
 {
-    ptls_t tls = {NULL};
+    ptls_context_t tlsctx = {NULL};
+    ptls_t tls = {&tlsctx};
     struct st_ptls_record_t rec = {PTLS_CONTENT_TYPE_HANDSHAKE, 0x0301};
     int ret;
+
+    tlsctx.max_message_buffer_size = 14;
 
 #define SET_RECORD(lit)                                                                                                            \
     do {                                                                                                                           \
@@ -505,6 +508,22 @@ static void test_fragmented_message(void)
               "end",
               7) == 0);
     ok(test_fragmented_message_queue.vec[2].is_end_of_record);
+
+    /* overflow (post-cb) */
+    test_fragmented_message_queue.count = 0;
+    SET_RECORD("\x01\x00\x00\xff" "0123456789ab");
+    ret = handle_handshake_record(&tls, test_fragmented_message_record, NULL, &rec, NULL);
+    ok(ret == PTLS_ALERT_HANDSHAKE_FAILURE);
+    ok(test_fragmented_message_queue.count == 0);
+
+    /* overflow (pre-cb) */
+    SET_RECORD("\x01\x00\x00\xff" "0123456789");
+    ret = handle_handshake_record(&tls, test_fragmented_message_record, NULL, &rec, NULL);
+    ok(ret == PTLS_ERROR_IN_PROGRESS);
+    SET_RECORD("abcdef");
+    ret = handle_handshake_record(&tls, test_fragmented_message_record, NULL, &rec, NULL);
+    ok(ret == PTLS_ALERT_HANDSHAKE_FAILURE);
+    ok(test_fragmented_message_queue.count == 0);
 
 #undef SET_RECORD
 }


### PR DESCRIPTION
Introduces `ptls_context_t::max_buffer_size`.

When set to a non-zero value, indicates the maximum amount of memory that can be used for buffering TLS handshake messages. picotls will return handshake_failure when receiving a partial handshake message that does not fit into the buffer.