### PR TITLE
Fix check for ChaCha_Poly1305 detection

### DIFF
--- a/include/picotls/openssl.h
+++ b/include/picotls/openssl.h
@@ -30,10 +30,13 @@ extern "C" {
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
 #include <openssl/x509.h>
+#include <openssl/opensslconf.h>
 #include "../picotls.h"
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+#if !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305)
 #define PTLS_OPENSSL_HAVE_CHACHA20_POLY1305 1
+#endif
 #endif
 
 extern ptls_key_exchange_algorithm_t ptls_openssl_secp256r1;


### PR DESCRIPTION
OpenSSL exposes OPENSSL_NO_CHACHA and OPENSSL_NO_POLY1305 when either no-chacha
or no-poly1305 flags are passed to OpenSSL at build time which disables it.

Signed-off-by: James Taylor <james@jtaylor.id.au>