### PR TITLE
openssl: use EVP_CIPHER_CTX_reset

### DIFF
--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -37,6 +37,7 @@
 #include <openssl/evp.h>
 #include <openssl/objects.h>
 #include <openssl/rand.h>
+#include <openssl/rsa.h>
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 #include <openssl/x509_vfy.h>
@@ -78,6 +79,11 @@ static void HMAC_CTX_free(HMAC_CTX *ctx)
 {
     HMAC_CTX_cleanup(ctx);
     OPENSSL_free(ctx);
+}
+
+static int EVP_CIPHER_CTX_reset(EVP_CIPHER_CTX *ctx)
+{
+    EVP_CIPHER_CTX_cleanup(ctx);
 }
 
 #endif
@@ -1222,8 +1228,8 @@ Exit:
 
 static void cleanup_cipher_ctx(EVP_CIPHER_CTX *ctx)
 {
-    if (!EVP_CIPHER_CTX_cleanup(ctx)) {
-        fprintf(stderr, "EVP_CIPHER_CTX_cleanup() failed\n");
+    if (!EVP_CIPHER_CTX_reset(ctx)) {
+        fprintf(stderr, "EVP_CIPHER_CTX_reset() failed\n");
         abort();
     }
 }


### PR DESCRIPTION
EVP_CIPHER_CTX_cleanup is deprecated and optionally unavailable.