### PR TITLE
Various changes related to ChangeCipherSpec

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -662,7 +662,8 @@ struct st_ptls_context_t {
      */
     unsigned use_exporter : 1;
     /**
-     * if ChangeCipherSpec message should be sent during handshake
+     * if ChangeCipherSpec record should be sent during handshake. If the client sends CCS, the server sends one in response
+     * regardless of the value of this flag. See RFC 8446 Appendix D.3.
      */
     unsigned send_change_cipher_spec : 1;
     /**

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -2889,6 +2889,9 @@ static int client_handle_finished(ptls_t *tls, ptls_message_emitter_t *emitter, 
             goto Exit;
     }
 
+    if ((ret = push_change_cipher_spec(tls, emitter->buf)) != 0)
+        goto Exit;
+
     if (tls->client.certificate_request.context.base != NULL) {
         /* If this is a resumed session, the server must not send the certificate request in the handshake */
         if (tls->is_psk_handshake) {
@@ -2904,8 +2907,6 @@ static int client_handle_finished(ptls_t *tls, ptls_message_emitter_t *emitter, 
             goto Exit;
     }
 
-    if ((ret = push_change_cipher_spec(tls, emitter->buf)) != 0)
-        goto Exit;
     ret = send_finished(tls, emitter);
 
     memcpy(tls->traffic_protection.enc.secret, send_secret, sizeof(send_secret));

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -3638,10 +3638,12 @@ static int server_handle_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptl
     if (tls->ctx->require_dhe_on_psk)
         ch.psk.ke_modes &= ~(1u << PTLS_PSK_KE_MODE_PSK);
 
-    /* handle client_random, SNI, ESNI */
+    /* handle client_random, legacy_session_id, SNI, ESNI */
     if (!is_second_flight) {
         memcpy(tls->client_random, ch.random_bytes, sizeof(tls->client_random));
         log_client_random(tls);
+        if (ch.legacy_session_id.len != 0)
+            tls->send_change_cipher_spec = 1;
         ptls_iovec_t server_name = {NULL};
         int is_esni = 0;
         if (ch.esni.cipher != NULL && tls->ctx->esni != NULL) {

--- a/t/cli.c
+++ b/t/cli.c
@@ -567,6 +567,7 @@ int main(int argc, char **argv)
             static size_t max_early_data_size;
             hsprop.client.max_early_data_size = &max_early_data_size;
         }
+        ctx.send_change_cipher_spec = 1;
     }
     if (key_exchanges[0] == NULL)
         key_exchanges[0] = &ptls_openssl_secp256r1;


### PR DESCRIPTION
Namely,
* as a server, send CCS regardless of the configuration, if the client sends one (this is a MUST in RFC 8446 Appendix D.3)
* raise UNEXPECTED_MESSAGE when emission of CCS is required while using a protocol that does not use TLS records (e.g., QUIC)
* in the example client, use compatibility mode

amends #305.