### PR TITLE
Add workaround for array detection in Xcode <10

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -45,8 +45,11 @@ extern "C" {
 #define PTLS_BUILD_ASSERT(cond) 1
 #endif
 
-/* __builtin_types_compatible_p yields incorrect results when older versions of GCC is used; see #303 */
-#if defined(__clang__) || __GNUC__ >= 6
+/* __builtin_types_compatible_p yields incorrect results when older versions of GCC is used; see #303
+ * Clang with Xcode 9.4 or prior is known to not work correctly when a pointer is const-qualified.
+ * Clang on Linux is okay with older versions.
+ * See https://github.com/h2o/quicly/pull/306#issuecomment-626037269 */
+#if (defined(__clang__) && (!defined(__APPLE__) || __clang_major__ >= 10)) || __GNUC__ >= 6
 #define PTLS_ASSERT_IS_ARRAY_EXPR(a) PTLS_BUILD_ASSERT_EXPR(__builtin_types_compatible_p(__typeof__(a[0])[], __typeof__(a)))
 #else
 #define PTLS_ASSERT_IS_ARRAY_EXPR(a) 1


### PR DESCRIPTION
Is has been discovered that Xcode prior to version 10 cannot correctly
detect if an expression is an array.

```
    struct s {
        int a[10];
    };

    void fun(const struct s *s)
    {
        PTLS_ASSERT_IS_ARRAY_EXPR(s->a);
    }
````

Clang in older Xcode returns false for the above PTLS_ASSERT_IS_ARRAY_EXPR,
while it should be true. Removing the const qualifier from the parameter
declaration resolves the issue.
See https://github.com/h2o/quicly/pull/306#issuecomment-626037269 for details.

Clang in Ubuntu seems to be fine, even with older versions.