### PR TITLE
reduce stack usage

### DIFF
--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -1236,7 +1236,7 @@ static int commission_handshake_secret(ptls_t *tls)
     return setup_traffic_protection(tls, is_enc, NULL, 2, 1);
 }
 
-static inline void log_client_random(ptls_t *tls)
+static void log_client_random(ptls_t *tls)
 {
     PTLS_PROBE(CLIENT_RANDOM, tls,
                ptls_hexdump(alloca(sizeof(tls->client_random) * 2 + 1), tls->client_random, sizeof(tls->client_random)));

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -2481,7 +2481,10 @@ static int client_handle_encrypted_extensions(ptls_t *tls, ptls_iovec_t message,
         default:
             if (should_collect_unknown_extension(tls, properties, type)) {
                 if (unknown_extensions == &no_unknown_extensions) {
-                    unknown_extensions = malloc(sizeof(*unknown_extensions) * (MAX_UNKNOWN_EXTENSIONS + 1));
+                    if ((unknown_extensions = malloc(sizeof(*unknown_extensions) * (MAX_UNKNOWN_EXTENSIONS + 1))) == NULL) {
+                        ret = PTLS_ERROR_NO_MEMORY;
+                        goto Exit;
+                    }
                     unknown_extensions[0].type = UINT16_MAX;
                 }
                 if ((ret = collect_unknown_extension(tls, type, src, end, unknown_extensions)) != 0)

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -4754,9 +4754,8 @@ int ptls_handshake(ptls_t *tls, ptls_buffer_t *_sendbuf, const void *input, size
 
     const uint8_t *src = input, *const src_end = src + *inlen;
     ptls_buffer_t decryptbuf;
-    uint8_t decryptbuf_small[256];
 
-    ptls_buffer_init(&decryptbuf, decryptbuf_small, sizeof(decryptbuf_small));
+    ptls_buffer_init(&decryptbuf, "", 0);
 
     /* perform handhake until completion or until all the input has been swallowed */
     ret = PTLS_ERROR_IN_PROGRESS;

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -3765,8 +3765,8 @@ static int server_handle_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptl
         if (ch->cookie.all.len != 0 && key_share.algorithm != NULL) {
 
             /* use cookie to check the integrity of the handshake, and update the context */
-            uint8_t sig[PTLS_MAX_DIGEST_SIZE];
             size_t sigsize = tls->ctx->cipher_suites[0]->hash->digest_size;
+            uint8_t *sig = alloca(sigsize);
             if ((ret = calc_cookie_signature(tls, properties, key_share.algorithm, ch->cookie.tbs, sig)) != 0)
                 goto Exit;
             if (!(ch->cookie.signature.len == sigsize && ptls_mem_equal(ch->cookie.signature.base, sig, sigsize))) {

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -2966,8 +2966,7 @@ static int client_handle_new_session_ticket(ptls_t *tls, ptls_iovec_t message)
 
     /* save the extension, along with the key of myself */
     ptls_buffer_t ticket_buf;
-    uint8_t ticket_buf_small[200];
-    ptls_buffer_init(&ticket_buf, ticket_buf_small, sizeof(ticket_buf_small));
+    ptls_buffer_init(&ticket_buf, "", 0);
     ptls_buffer_push64(&ticket_buf, tls->ctx->get_time->cb(tls->ctx->get_time));
     ptls_buffer_push16(&ticket_buf, tls->key_share->id);
     ptls_buffer_push16(&ticket_buf, tls->cipher_suite->id);

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -2955,7 +2955,7 @@ static int client_handle_new_session_ticket(ptls_t *tls, ptls_iovec_t message)
 
     /* save the extension, along with the key of myself */
     ptls_buffer_t ticket_buf;
-    uint8_t ticket_buf_small[512];
+    uint8_t ticket_buf_small[200];
     ptls_buffer_init(&ticket_buf, ticket_buf_small, sizeof(ticket_buf_small));
     ptls_buffer_push64(&ticket_buf, tls->ctx->get_time->cb(tls->ctx->get_time));
     ptls_buffer_push16(&ticket_buf, tls->key_share->id);
@@ -5063,7 +5063,7 @@ int hkdf_expand_label(ptls_hash_algorithm_t *algo, void *output, size_t outlen, 
                       ptls_iovec_t hash_value, const char *label_prefix)
 {
     ptls_buffer_t hkdf_label;
-    uint8_t hkdf_label_buf[512];
+    uint8_t hkdf_label_buf[80];
     int ret;
 
     assert(label_prefix != NULL);


### PR DESCRIPTION
This pull request reduces stack usage by doing the following:
* Reduce the excess size of, or eliminate the use of "smallbuf" (i.e., the stack-allocated buffer provided to ptls_buffer_t to reduce calls on malloc-free), when the cost of other operations (e.g., crypto) is expected to dwarf the performance improvement that we'd would gain from not using malloc.
* allocate `st_ptls_client_hello_t` on heap
* lazy-allocate certain objects

In master, the top 20 functions that consume stack space are as follows:
```
1640	server_handle_hello
616	hkdf_expand_label
608	client_handle_new_session_ticket
536	try_psk_handshake
504	client_handle_encrypted_extensions
392	ptls_handshake
344	build_esni_contents_hash
328	handle_certificate
296	send_certificate_and_certificate_verify
280	handle_certificate_verify
232	send_session_ticket
232	send_client_hello
168	ptls_export_secret
152	parse_esni_keys
152	log_secret
136	client_handle_hello
120	decode_client_hello.constprop.0
120	ptls_hkdf_expand
112	ptls_server_handle_message
112	ptls_client_handle_message
104	client_handle_finished
```

With this PR, the list changes becomes:
```
344	build_esni_contents_hash
328	handle_certificate
312	server_handle_hello
296	send_certificate_and_certificate_verify
280	handle_certificate_verify
232	send_session_ticket
232	send_client_hello
216	try_psk_handshake
184	hkdf_expand_label
168	ptls_export_secret
152	parse_esni_keys
152	log_secret
136	ptls_handshake
136	client_handle_hello
120	decode_client_hello.constprop.0
120	ptls_hkdf_expand
112	ptls_server_handle_message
112	ptls_client_handle_message
104	client_handle_finished
96	client_handle_new_session_ticket
```

Closes #298.