### PR TITLE
External PSK mode

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -827,7 +827,7 @@ typedef struct st_ptls_handshake_properties_t {
     /**
      * [optional] if set, the endpoints negotiate using the provided pre-shared key only
      */
-    struct {
+    struct st_ptls_external_psk_t {
         ptls_iovec_t identity;
         ptls_iovec_t key;
     } pre_shared_key;

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -825,7 +825,7 @@ typedef struct st_ptls_handshake_properties_t {
      */
     int (*collected_extensions)(ptls_t *tls, struct st_ptls_handshake_properties_t *properties, ptls_raw_extension_t *extensions);
     /**
-     * [optional] if set, the endpoints negotiate using the provided pre-shared key only
+     * [optional] if set, the endpoints negotiate using the provided pre-shared key
      */
     struct st_ptls_external_psk_t {
         ptls_iovec_t identity;

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -824,6 +824,13 @@ typedef struct st_ptls_handshake_properties_t {
      * an optional callback that reports the extensions being collected
      */
     int (*collected_extensions)(ptls_t *tls, struct st_ptls_handshake_properties_t *properties, ptls_raw_extension_t *extensions);
+    /**
+     * [optional] if set, the endpoints negotiate using the provided pre-shared key only
+     */
+    struct {
+        ptls_iovec_t identity;
+        ptls_iovec_t key;
+    } pre_shared_key;
 } ptls_handshake_properties_t;
 #ifdef _WINDOWS
 #pragma warning(pop)

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -3455,8 +3455,12 @@ static int vec_is_string(ptls_iovec_t x, const char *y)
     return strncmp((const char *)x.base, y, x.len) == 0 && y[x.len] == '\0';
 }
 
+/**
+ * Looks for a PSK identity that can be used, and if found, updates the handshake state and returns the necessary variables. If
+ * external_psk is set, only tries handshake using those keys provided. Otherwise, tries resumption.
+ */
 static int try_psk_handshake(ptls_t *tls, size_t *psk_index, int *accept_early_data, struct st_ptls_client_hello_t *ch,
-                             ptls_iovec_t ch_trunc, ptls_handshake_properties_t *properties)
+                             ptls_iovec_t ch_trunc, struct st_ptls_external_psk_t *external_psk)
 {
     ptls_buffer_t decbuf;
     ptls_iovec_t ticket_psk, ticket_server_name, ticket_negotiated_protocol;
@@ -3471,14 +3475,15 @@ static int try_psk_handshake(ptls_t *tls, size_t *psk_index, int *accept_early_d
     for (*psk_index = 0; *psk_index < ch->psk.identities.count; ++*psk_index) {
         struct st_ptls_client_hello_psk_t *identity = ch->psk.identities.list + *psk_index;
         /* negotiate using fixed pre-shared key */
-        if (properties != NULL && properties->pre_shared_key.identity.base != NULL) {
-            if (identity->identity.len == properties->pre_shared_key.identity.len &&
-                memcmp(identity->identity.base, properties->pre_shared_key.identity.base, identity->identity.len) == 0) {
+        if (external_psk != NULL) {
+            if (identity->identity.len == external_psk->identity.len &&
+                memcmp(identity->identity.base, external_psk->identity.base, identity->identity.len) == 0) {
                 *accept_early_data = 1;
                 tls->key_share = NULL;
-                ticket_psk = properties->pre_shared_key.key;
+                ticket_psk = external_psk->key;
                 goto Found;
             }
+            continue;
         }
         /* decrypt ticket and decode */
         if (tls->ctx->encrypt_ticket == NULL || tls->ctx->key_exchanges == NULL)
@@ -3811,100 +3816,108 @@ static int server_handle_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptl
         });
     }
 
-    if (!is_second_flight) {
-        if (ch->cookie.all.len != 0 && key_share.algorithm != NULL) {
+    /* use cookie to check the integrity of the handshake, and update the context */
+    if (!is_second_flight && ch->cookie.all.len != 0 && key_share.algorithm != NULL) {
+        size_t sigsize = tls->ctx->cipher_suites[0]->hash->digest_size;
+        uint8_t *sig = alloca(sigsize);
+        if ((ret = calc_cookie_signature(tls, properties, key_share.algorithm, ch->cookie.tbs, sig)) != 0)
+            goto Exit;
+        if (!(ch->cookie.signature.len == sigsize && ptls_mem_equal(ch->cookie.signature.base, sig, sigsize))) {
+            ret = PTLS_ALERT_HANDSHAKE_FAILURE;
+            goto Exit;
+        }
+        /* integrity check passed; update states */
+        key_schedule_update_ch1hash_prefix(tls->key_schedule);
+        ptls__key_schedule_update_hash(tls->key_schedule, ch->cookie.ch1_hash.base, ch->cookie.ch1_hash.len);
+        key_schedule_extract(tls->key_schedule, ptls_iovec_init(NULL, 0));
+        /* ... reusing sendbuf to rebuild HRR for hash calculation */
+        size_t hrr_start = emitter->buf->off;
+        EMIT_HELLO_RETRY_REQUEST(tls->key_schedule, ch->cookie.sent_key_share ? key_share.algorithm : NULL, {
+            buffer_push_extension(emitter->buf, PTLS_EXTENSION_TYPE_COOKIE,
+                                  { ptls_buffer_pushv(emitter->buf, ch->cookie.all.base, ch->cookie.all.len); });
+        });
+        emitter->buf->off = hrr_start;
+        is_second_flight = 1;
+    }
 
-            /* use cookie to check the integrity of the handshake, and update the context */
-            size_t sigsize = tls->ctx->cipher_suites[0]->hash->digest_size;
-            uint8_t *sig = alloca(sigsize);
-            if ((ret = calc_cookie_signature(tls, properties, key_share.algorithm, ch->cookie.tbs, sig)) != 0)
-                goto Exit;
-            if (!(ch->cookie.signature.len == sigsize && ptls_mem_equal(ch->cookie.signature.base, sig, sigsize))) {
-                ret = PTLS_ALERT_HANDSHAKE_FAILURE;
+    /* try external psk handshake */
+    if (!is_second_flight && ch->psk.hash_end != 0 &&
+        (ch->psk.ke_modes & ((1u << PTLS_PSK_KE_MODE_PSK) | (1u << PTLS_PSK_KE_MODE_PSK_DHE))) != 0 && properties != NULL &&
+        properties->pre_shared_key.identity.base != NULL && !tls->ctx->require_client_authentication) {
+        if ((ret = try_psk_handshake(tls, &psk_index, &accept_early_data, ch,
+                                     ptls_iovec_init(message.base, ch->psk.hash_end - message.base),
+                                     &properties->pre_shared_key)) != 0)
+            goto Exit;
+    }
+
+    /* send HelloRetryRequest if enforced by config or upon key-share mismatch, unless PSK has already been selected */
+    if (!is_second_flight && psk_index == SIZE_MAX &&
+        (key_share.algorithm == NULL || (properties != NULL && properties->server.enforce_retry))) {
+        ptls_key_exchange_algorithm_t *negotiated_group = NULL;
+        if (tls->ctx->key_exchanges != NULL) {
+            if (ch->negotiated_groups.base == NULL) {
+                ret = PTLS_ALERT_MISSING_EXTENSION;
                 goto Exit;
             }
-            /* integrity check passed; update states */
-            key_schedule_update_ch1hash_prefix(tls->key_schedule);
-            ptls__key_schedule_update_hash(tls->key_schedule, ch->cookie.ch1_hash.base, ch->cookie.ch1_hash.len);
-            key_schedule_extract(tls->key_schedule, ptls_iovec_init(NULL, 0));
-            /* ... reusing sendbuf to rebuild HRR for hash calculation */
-            size_t hrr_start = emitter->buf->off;
-            EMIT_HELLO_RETRY_REQUEST(tls->key_schedule, ch->cookie.sent_key_share ? key_share.algorithm : NULL, {
-                buffer_push_extension(emitter->buf, PTLS_EXTENSION_TYPE_COOKIE,
-                                      { ptls_buffer_pushv(emitter->buf, ch->cookie.all.base, ch->cookie.all.len); });
-            });
-            emitter->buf->off = hrr_start;
-            is_second_flight = 1;
-
-        } else if (key_share.algorithm == NULL || (properties != NULL && properties->server.enforce_retry)) {
-
-            /* send HelloRetryRequest  */
-            ptls_key_exchange_algorithm_t *negotiated_group = NULL;
-            if (tls->ctx->key_exchanges != NULL) {
-                if (ch->negotiated_groups.base == NULL) {
-                    ret = PTLS_ALERT_MISSING_EXTENSION;
-                    goto Exit;
-                }
-                if ((ret = select_negotiated_group(&negotiated_group, tls->ctx->key_exchanges, ch->negotiated_groups.base,
-                                                   ch->negotiated_groups.base + ch->negotiated_groups.len)) != 0)
-                    goto Exit;
-            }
-            ptls__key_schedule_update_hash(tls->key_schedule, message.base, message.len);
-            assert(tls->key_schedule->generation == 0);
-            if (properties != NULL && properties->server.retry_uses_cookie) {
-                /* emit HRR with cookie (note: we MUST omit KeyShare if the client has specified the correct one; see 46554f0)
-                 */
-                EMIT_HELLO_RETRY_REQUEST(NULL, key_share.algorithm != NULL ? NULL : negotiated_group, {
-                    ptls_buffer_t *sendbuf = emitter->buf;
-                    buffer_push_extension(sendbuf, PTLS_EXTENSION_TYPE_COOKIE, {
+            if ((ret = select_negotiated_group(&negotiated_group, tls->ctx->key_exchanges, ch->negotiated_groups.base,
+                                               ch->negotiated_groups.base + ch->negotiated_groups.len)) != 0)
+                goto Exit;
+        }
+        ptls__key_schedule_update_hash(tls->key_schedule, message.base, message.len);
+        assert(tls->key_schedule->generation == 0);
+        if (properties != NULL && properties->server.retry_uses_cookie) {
+            /* emit HRR with cookie (note: we MUST omit KeyShare if the client has specified the correct one; see 46554f0)
+             */
+            EMIT_HELLO_RETRY_REQUEST(NULL, key_share.algorithm != NULL ? NULL : negotiated_group, {
+                ptls_buffer_t *sendbuf = emitter->buf;
+                buffer_push_extension(sendbuf, PTLS_EXTENSION_TYPE_COOKIE, {
+                    ptls_buffer_push_block(sendbuf, 2, {
+                        /* push to-be-signed data */
+                        size_t tbs_start = sendbuf->off;
                         ptls_buffer_push_block(sendbuf, 2, {
-                            /* push to-be-signed data */
-                            size_t tbs_start = sendbuf->off;
-                            ptls_buffer_push_block(sendbuf, 2, {
-                                /* first block of the cookie data is the hash(ch1) */
-                                ptls_buffer_push_block(sendbuf, 1, {
-                                    size_t sz = tls->cipher_suite->hash->digest_size;
-                                    if ((ret = ptls_buffer_reserve(sendbuf, sz)) != 0)
-                                        goto Exit;
-                                    key_schedule_extract_ch1hash(tls->key_schedule, sendbuf->base + sendbuf->off);
-                                    sendbuf->off += sz;
-                                });
-                                /* second is if we have sent key_share extension */
-                                ptls_buffer_push(sendbuf, key_share.algorithm == NULL);
-                                /* we can add more data here */
-                            });
-                            size_t tbs_len = sendbuf->off - tbs_start;
-                            /* push the signature */
+                            /* first block of the cookie data is the hash(ch1) */
                             ptls_buffer_push_block(sendbuf, 1, {
-                                size_t sz = tls->ctx->cipher_suites[0]->hash->digest_size;
+                                size_t sz = tls->cipher_suite->hash->digest_size;
                                 if ((ret = ptls_buffer_reserve(sendbuf, sz)) != 0)
                                     goto Exit;
-                                if ((ret = calc_cookie_signature(tls, properties, negotiated_group,
-                                                                 ptls_iovec_init(sendbuf->base + tbs_start, tbs_len),
-                                                                 sendbuf->base + sendbuf->off)) != 0)
-                                    goto Exit;
+                                key_schedule_extract_ch1hash(tls->key_schedule, sendbuf->base + sendbuf->off);
                                 sendbuf->off += sz;
                             });
+                            /* second is if we have sent key_share extension */
+                            ptls_buffer_push(sendbuf, key_share.algorithm == NULL);
+                            /* we can add more data here */
+                        });
+                        size_t tbs_len = sendbuf->off - tbs_start;
+                        /* push the signature */
+                        ptls_buffer_push_block(sendbuf, 1, {
+                            size_t sz = tls->ctx->cipher_suites[0]->hash->digest_size;
+                            if ((ret = ptls_buffer_reserve(sendbuf, sz)) != 0)
+                                goto Exit;
+                            if ((ret = calc_cookie_signature(tls, properties, negotiated_group,
+                                                             ptls_iovec_init(sendbuf->base + tbs_start, tbs_len),
+                                                             sendbuf->base + sendbuf->off)) != 0)
+                                goto Exit;
+                            sendbuf->off += sz;
                         });
                     });
                 });
-                if ((ret = push_change_cipher_spec(tls, emitter)) != 0)
-                    goto Exit;
-                ret = PTLS_ERROR_STATELESS_RETRY;
-            } else {
-                /* invoking stateful retry; roll the key schedule and emit HRR */
-                key_schedule_transform_post_ch1hash(tls->key_schedule);
-                key_schedule_extract(tls->key_schedule, ptls_iovec_init(NULL, 0));
-                EMIT_HELLO_RETRY_REQUEST(tls->key_schedule, key_share.algorithm != NULL ? NULL : negotiated_group, {});
-                if ((ret = push_change_cipher_spec(tls, emitter)) != 0)
-                    goto Exit;
-                tls->state = PTLS_STATE_SERVER_EXPECT_SECOND_CLIENT_HELLO;
-                if (ch->psk.early_data_indication)
-                    tls->server.early_data_skipped_bytes = 0;
-                ret = PTLS_ERROR_IN_PROGRESS;
-            }
-            goto Exit;
+            });
+            if ((ret = push_change_cipher_spec(tls, emitter)) != 0)
+                goto Exit;
+            ret = PTLS_ERROR_STATELESS_RETRY;
+        } else {
+            /* invoking stateful retry; roll the key schedule and emit HRR */
+            key_schedule_transform_post_ch1hash(tls->key_schedule);
+            key_schedule_extract(tls->key_schedule, ptls_iovec_init(NULL, 0));
+            EMIT_HELLO_RETRY_REQUEST(tls->key_schedule, key_share.algorithm != NULL ? NULL : negotiated_group, {});
+            if ((ret = push_change_cipher_spec(tls, emitter)) != 0)
+                goto Exit;
+            tls->state = PTLS_STATE_SERVER_EXPECT_SECOND_CLIENT_HELLO;
+            if (ch->psk.early_data_indication)
+                tls->server.early_data_skipped_bytes = 0;
+            ret = PTLS_ERROR_IN_PROGRESS;
         }
+        goto Exit;
     }
 
     /* handle unknown extensions */
@@ -3912,12 +3925,11 @@ static int server_handle_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptl
         goto Exit;
 
     /* try psk handshake */
-    if (!is_second_flight && ch->psk.hash_end != 0 &&
+    if (!is_second_flight && psk_index == SIZE_MAX && ch->psk.hash_end != 0 &&
         (ch->psk.ke_modes & ((1u << PTLS_PSK_KE_MODE_PSK) | (1u << PTLS_PSK_KE_MODE_PSK_DHE))) != 0 &&
-        (tls->ctx->encrypt_ticket != NULL || properties->pre_shared_key.identity.base != NULL) &&
-        !tls->ctx->require_client_authentication) {
+        tls->ctx->encrypt_ticket != NULL && !tls->ctx->require_client_authentication) {
         if ((ret = try_psk_handshake(tls, &psk_index, &accept_early_data, ch,
-                                     ptls_iovec_init(message.base, ch->psk.hash_end - message.base), properties)) != 0) {
+                                     ptls_iovec_init(message.base, ch->psk.hash_end - message.base), NULL)) != 0) {
             goto Exit;
         }
     }

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -3367,6 +3367,10 @@ static int decode_client_hello(ptls_t *tls, struct st_ptls_client_hello_t *ch, c
                 do {
                     struct st_ptls_client_hello_psk_t psk = {{NULL}};
                     ptls_decode_open_block(src, end, 2, {
+                        if (end - src < 1) {
+                            ret = PTLS_ALERT_DECODE_ERROR;
+                            goto Exit;
+                        }
                         psk.identity = ptls_iovec_init(src, end - src);
                         src = end;
                     });

--- a/t/picotls.c
+++ b/t/picotls.c
@@ -1139,9 +1139,14 @@ static void test_stateless_hrr_aad_change(void)
     ptls_buffer_dispose(&sbuf);
 }
 
-static void test_pre_shared_key(void)
+static void do_test_pre_shared_key(int clear_ke)
 {
-    uint32_t max_early_data_size_backup = ctx->max_early_data_size;
+    struct {
+        ptls_key_exchange_algorithm_t **key_exchanges;
+        uint32_t max_early_data_size;
+    } backup = {ctx->key_exchanges, ctx->max_early_data_size};
+    if (clear_ke)
+        ctx->key_exchanges = NULL;
     ctx->max_early_data_size = 16384;
 
     ptls_t *client = ptls_new(ctx, 0), *server = ptls_new(ctx, 1);
@@ -1228,7 +1233,14 @@ static void test_pre_shared_key(void)
     ptls_free(client);
     ptls_free(server);
 
-    ctx->max_early_data_size = max_early_data_size_backup;
+    ctx->key_exchanges = backup.key_exchanges;
+    ctx->max_early_data_size = backup.max_early_data_size;
+}
+
+static void test_pre_shared_key(void)
+{
+    do_test_pre_shared_key(0);
+    do_test_pre_shared_key(1);
 }
 
 typedef uint8_t traffic_secrets_t[2 /* is_enc */][4 /* epoch */][PTLS_MAX_DIGEST_SIZE /* octets */];


### PR DESCRIPTION
At the moment, external PSK cannot be used together with retry.

Current design of picotls is based on the assumption that (ec)dhe will be used when a HelloRetryRequest is involved. Ideally we should support handshake that uses both retry and external PSK, but that does not need to happen now.