### PR TITLE
fix leak cipher ctx leak in ptls_openssl_(en/dec)crypt_ticket() calls

### DIFF
--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -1290,12 +1290,12 @@ Error:
 int ptls_openssl_encrypt_ticket(ptls_buffer_t *buf, ptls_iovec_t src,
                                 int (*cb)(unsigned char *key_name, unsigned char *iv, EVP_CIPHER_CTX *ctx, HMAC_CTX *hctx, int enc))
 {
-    static __thread EVP_CIPHER_CTX *cctx = NULL;
+    EVP_CIPHER_CTX *cctx = NULL;
     HMAC_CTX *hctx = NULL;
     uint8_t *dst;
     int clen, ret;
 
-    if (!cctx && (cctx = EVP_CIPHER_CTX_new()) == NULL) {
+    if ((cctx = EVP_CIPHER_CTX_new()) == NULL) {
         ret = PTLS_ERROR_NO_MEMORY;
         goto Exit;
     }
@@ -1350,11 +1350,11 @@ Exit:
 int ptls_openssl_decrypt_ticket(ptls_buffer_t *buf, ptls_iovec_t src,
                                 int (*cb)(unsigned char *key_name, unsigned char *iv, EVP_CIPHER_CTX *ctx, HMAC_CTX *hctx, int enc))
 {
-    static __thread EVP_CIPHER_CTX *cctx = NULL;
+    EVP_CIPHER_CTX *cctx = NULL;
     HMAC_CTX *hctx = NULL;
     int clen, ret;
 
-    if (!cctx && (cctx = EVP_CIPHER_CTX_new()) == NULL) {
+    if ((cctx = EVP_CIPHER_CTX_new()) == NULL) {
         ret = PTLS_ERROR_NO_MEMORY;
         goto Exit;
     }

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -1290,12 +1290,12 @@ Error:
 int ptls_openssl_encrypt_ticket(ptls_buffer_t *buf, ptls_iovec_t src,
                                 int (*cb)(unsigned char *key_name, unsigned char *iv, EVP_CIPHER_CTX *ctx, HMAC_CTX *hctx, int enc))
 {
-    EVP_CIPHER_CTX *cctx = NULL;
+    static __thread EVP_CIPHER_CTX *cctx = NULL;
     HMAC_CTX *hctx = NULL;
     uint8_t *dst;
     int clen, ret;
 
-    if ((cctx = EVP_CIPHER_CTX_new()) == NULL) {
+    if (!cctx && (cctx = EVP_CIPHER_CTX_new()) == NULL) {
         ret = PTLS_ERROR_NO_MEMORY;
         goto Exit;
     }
@@ -1350,11 +1350,11 @@ Exit:
 int ptls_openssl_decrypt_ticket(ptls_buffer_t *buf, ptls_iovec_t src,
                                 int (*cb)(unsigned char *key_name, unsigned char *iv, EVP_CIPHER_CTX *ctx, HMAC_CTX *hctx, int enc))
 {
-    EVP_CIPHER_CTX *cctx = NULL;
+    static __thread EVP_CIPHER_CTX *cctx = NULL;
     HMAC_CTX *hctx = NULL;
     int clen, ret;
 
-    if ((cctx = EVP_CIPHER_CTX_new()) == NULL) {
+    if (!cctx && (cctx = EVP_CIPHER_CTX_new()) == NULL) {
         ret = PTLS_ERROR_NO_MEMORY;
         goto Exit;
     }

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -1234,14 +1234,6 @@ Exit:
     return ret;
 }
 
-static void cleanup_cipher_ctx(EVP_CIPHER_CTX *ctx)
-{
-    if (!EVP_CIPHER_CTX_reset(ctx)) {
-        fprintf(stderr, "EVP_CIPHER_CTX_reset() failed\n");
-        abort();
-    }
-}
-
 int ptls_openssl_init_verify_certificate(ptls_openssl_verify_certificate_t *self, X509_STORE *store)
 {
     *self = (ptls_openssl_verify_certificate_t){{verify_cert}};
@@ -1341,7 +1333,7 @@ int ptls_openssl_encrypt_ticket(ptls_buffer_t *buf, ptls_iovec_t src,
 
 Exit:
     if (cctx != NULL)
-        cleanup_cipher_ctx(cctx);
+        EVP_CIPHER_CTX_free(cctx);
     if (hctx != NULL)
         HMAC_CTX_free(hctx);
     return ret;
@@ -1411,7 +1403,7 @@ int ptls_openssl_decrypt_ticket(ptls_buffer_t *buf, ptls_iovec_t src,
 
 Exit:
     if (cctx != NULL)
-        cleanup_cipher_ctx(cctx);
+        EVP_CIPHER_CTX_free(cctx);
     if (hctx != NULL)
         HMAC_CTX_free(hctx);
     return ret;


### PR DESCRIPTION
fix leak while keeping with, I presume, the original intention behind using `EVP_CIPHER_CTX_reset()` instead of `EVP_CIPHER_CTX_new/EVP_CIPHER_CTX_free`