### PR TITLE
Add SECURITY.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,0 +1,9 @@
+---
+name: File an issue
+about: For all non-security issues
+title: ''
+labels: ''
+assignees: ''
+
+---
+

--- a/README.md
+++ b/README.md
@@ -80,3 +80,7 @@ License
 
 The software is provided under the MIT license.
 Note that additional licences apply if you use the minicrypto binding (see above).
+
+Reporting Security Issues
+---
+Please report vulnerabilities to h2o-vuln@googlegroups.com. See [SECURITY.md](SECURITY.md) for more information.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+## Report a security issue
+
+The h2o/picotls project team welcomes security reports and is committed to providing prompt attention to security issues. Security issues should be reported privately via h2o-vuln@googlegroups.com.
+
+## Security advisories
+
+Remediation of security vulnerabilities is prioritized by the project team. The project team endeavors to coordinate remediation with third-party stakeholders, and is committed to transparency in the disclosure process. The picotls/h2o team announces security issues via [h2o project Github Release notes](https://github.com/h2o/h2o/releases) as well as [the h2o website](h2o.examp1e.net) on a best-effort basis.


### PR DESCRIPTION
Hello,

This PR adds a [github.com security policy](https://help.github.com/en/github/managing-security-vulnerabilities/adding-a-security-policy-to-your-repository) to the picotls repo, similar to the one [we added to h2o](https://github.com/h2o/h2o/pull/2356). Like the h2o PR, it also adds a basic [Github Issue Template](https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository). Together, these changes should result in:

- A Github Issue workflow that directs users to report security issues privately
- Explicitly capturing the security policy using up-to-date github.com conventions

The security policy aims to reflect the existing vulnerability coordination and disclosure policies for picotls. Feedback and direct edits from maintainers are welcomed of course!

cc @deweerdt -- if you have a PR that supersedes this feel free to close this one.

Thanks,
Jon