### PR TITLE
Additional extensions and allow sending multiple tickets

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -831,6 +831,10 @@ typedef struct st_ptls_handshake_properties_t {
      */
     ptls_raw_extension_t *additional_extensions;
     /**
+     * an optional list of extensions to send in NST, terminated by type == UINT16_MAX
+     */
+    ptls_raw_extension_t *nst_extensions;
+    /**
      * an optional callback that returns a boolean value indicating if a particular extension should be collected
      */
     int (*collect_extension)(ptls_t *tls, struct st_ptls_handshake_properties_t *properties, uint16_t type);


### PR DESCRIPTION
This provides two features:

-  Support for additional extensions to send in New Session Ticket message. 
-  Allow sending multiple tickets during a session.

Both are required to implement (but not limited to) the bdp extension which are described here (https://tools.ietf.org/html/draft-kuhn-quic-0rtt-bdp-07)