### PR TITLE
fix `make -jN` failure when dtrace is enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.11)
 CMAKE_POLICY(SET CMP0003 NEW)
+CMAKE_POLICY(SET CMP0046 NEW)
 
 PROJECT(picotls)
 
@@ -151,7 +152,7 @@ IF ((CMAKE_SIZEOF_VOID_P EQUAL 8) AND
         ADD_DEPENDENCIES(test-fusion.t generate-picotls-probes)
     ENDIF ()
     SET(TEST_EXES ${TEST_EXES} test-fusion.t)
-    
+
     LIST(APPEND PTLSBENCH_LIBS picotls-fusion)
 ENDIF ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.11)
 CMAKE_POLICY(SET CMP0003 NEW)
-CMAKE_POLICY(SET CMP0046 NEW)
 
 PROJECT(picotls)
 
@@ -152,7 +151,7 @@ IF ((CMAKE_SIZEOF_VOID_P EQUAL 8) AND
         ADD_DEPENDENCIES(test-fusion.t generate-picotls-probes)
     ENDIF ()
     SET(TEST_EXES ${TEST_EXES} test-fusion.t)
-
+    
     LIST(APPEND PTLSBENCH_LIBS picotls-fusion)
 ENDIF ()
 

--- a/cmake/dtrace-utils.cmake
+++ b/cmake/dtrace-utils.cmake
@@ -22,19 +22,24 @@ FUNCTION (CHECK_DTRACE d_file)
     ENDIF ()
 ENDFUNCTION ()
 
+# creates a phony target "generate-${prefix}-probes"
 FUNCTION (DEFINE_DTRACE_DEPENDENCIES d_file prefix)
+    ADD_CUSTOM_TARGET(generate-${prefix}-probes)
+
     ADD_CUSTOM_COMMAND(
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.h
         COMMAND dtrace -o ${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.h -s ${d_file} -h
         DEPENDS ${d_file})
-    ADD_CUSTOM_TARGET(generate-${prefix}-probes DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.h)
-    SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.h PROPERTIES GENERATED TRUE)
+    SET_SOURCE_FILES_PROPERTIES(${prefix}-probes.h PROPERTIES GENERATED TRUE)
+    ADD_CUSTOM_TARGET(_generate-${prefix}-probes_h DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.h)
+    ADD_DEPENDENCIES(generate-${prefix}-probes _generate-${prefix}-probes_h)
     IF (DTRACE_USES_OBJFILE)
         ADD_CUSTOM_COMMAND(
             OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.o
             COMMAND dtrace -o ${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.o -s ${d_file} -G
             DEPENDS ${d_file})
-        ADD_DEPENDENCIES(generate-${prefix}-probes ${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.o)
         SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.o PROPERTIES GENERATED TRUE)
+        ADD_CUSTOM_TARGET(_generate-${prefix}-probes_o)
+        ADD_DEPENDENCIES(generate-${prefix}-probes _generate-${prefix}-probes_o)
     ENDIF ()
 ENDFUNCTION ()

--- a/cmake/dtrace-utils.cmake
+++ b/cmake/dtrace-utils.cmake
@@ -22,24 +22,19 @@ FUNCTION (CHECK_DTRACE d_file)
     ENDIF ()
 ENDFUNCTION ()
 
-# creates a phony target "generate-${prefix}-probes"
 FUNCTION (DEFINE_DTRACE_DEPENDENCIES d_file prefix)
-    ADD_CUSTOM_TARGET(generate-${prefix}-probes)
-
     ADD_CUSTOM_COMMAND(
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.h
         COMMAND dtrace -k -o ${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.h -s ${d_file} -h
         DEPENDS ${d_file})
-    SET_SOURCE_FILES_PROPERTIES(${prefix}-probes.h PROPERTIES GENERATED TRUE)
-    ADD_CUSTOM_TARGET(_generate-${prefix}-probes_h DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.h)
-    ADD_DEPENDENCIES(generate-${prefix}-probes _generate-${prefix}-probes_h)
+    ADD_CUSTOM_TARGET(generate-${prefix}-probes DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.h)
+    SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.h PROPERTIES GENERATED TRUE)
     IF (DTRACE_USES_OBJFILE)
         ADD_CUSTOM_COMMAND(
             OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.o
             COMMAND dtrace -k -o ${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.o -s ${d_file} -G
             DEPENDS ${d_file})
+        ADD_DEPENDENCIES(generate-${prefix}-probes ${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.o)
         SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.o PROPERTIES GENERATED TRUE)
-        ADD_CUSTOM_TARGET(_generate-${prefix}-probes_o)
-        ADD_DEPENDENCIES(generate-${prefix}-probes _generate-${prefix}-probes_o)
     ENDIF ()
 ENDFUNCTION ()

--- a/cmake/dtrace-utils.cmake
+++ b/cmake/dtrace-utils.cmake
@@ -25,7 +25,7 @@ ENDFUNCTION ()
 FUNCTION (DEFINE_DTRACE_DEPENDENCIES d_file prefix)
     ADD_CUSTOM_COMMAND(
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.h
-        COMMAND dtrace -k -o ${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.h -s ${d_file} -h
+        COMMAND dtrace -o ${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.h -s ${d_file} -h
         DEPENDS ${d_file})
     ADD_CUSTOM_TARGET(generate-${prefix}-probes DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.h)
     SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.h PROPERTIES GENERATED TRUE)

--- a/cmake/dtrace-utils.cmake
+++ b/cmake/dtrace-utils.cmake
@@ -28,7 +28,7 @@ FUNCTION (DEFINE_DTRACE_DEPENDENCIES d_file prefix)
 
     ADD_CUSTOM_COMMAND(
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.h
-        COMMAND dtrace -o ${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.h -s ${d_file} -h
+        COMMAND dtrace -k -o ${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.h -s ${d_file} -h
         DEPENDS ${d_file})
     SET_SOURCE_FILES_PROPERTIES(${prefix}-probes.h PROPERTIES GENERATED TRUE)
     ADD_CUSTOM_TARGET(_generate-${prefix}-probes_h DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.h)
@@ -36,7 +36,7 @@ FUNCTION (DEFINE_DTRACE_DEPENDENCIES d_file prefix)
     IF (DTRACE_USES_OBJFILE)
         ADD_CUSTOM_COMMAND(
             OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.o
-            COMMAND dtrace -o ${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.o -s ${d_file} -G
+            COMMAND dtrace -k -o ${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.o -s ${d_file} -G
             DEPENDS ${d_file})
         SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.o PROPERTIES GENERATED TRUE)
         ADD_CUSTOM_TARGET(_generate-${prefix}-probes_o)


### PR DESCRIPTION
<del>
cf72eb3 is to suppress warnings like this:
> CMake Warning (dev) at deps/picotls/cmake/dtrace-utils.cmake:37 (ADD_DEPENDENCIES):
  Policy CMP0046 is not set: Error on non-existent dependency in
  add_dependencies.  Run "cmake --help-policy CMP0046" for policy details.
  Use the cmake_policy command to set the policy and suppress this warning.
</del>

<br/><br/>

3fd9529 is the fix by keeping (`-k`) statically-named temporary files used by `dtrace`, which leads to a build failure like:

```
 Traceback (most recent call last):
  File "/usr/bin/dtrace", line 445, in <module>
    sys.exit(main())
  File "/usr/bin/dtrace", line 432, in main
    os.remove(fname)
FileNotFoundError: [Errno 2] No such file or directory: '/home/goro/ghq/github.com/h2o/picotls/b/picotls-probes.o.dtrace-temp.c'
```

where `picotls-probes.o.dtrace-temp.c` is the temp file used by `dtrace` and has been removed by another sibling processes.
