### PR TITLE
Adjusts CI matrix to use openssl 1.0.2, 1.1.0, libressl 3.2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,19 +4,29 @@ sudo: required
 
 matrix:
   include:
-    - name: Linux (gcc-8)
+    - name: Linux (gcc)
       os: linux
-      compiler: gcc-8
-      addons:
-        apt:
-          sources: ['ubuntu-toolchain-r-test']
-          packages: ['gcc-8']
+      dist: focal
+      compiler: gcc
       before_install: &bs_linux
         - sudo apt-get install faketime libscope-guard-perl libtest-tcp-perl
     - name: Linux (clang)
       os: linux
+      dist: focal
       compiler: clang
       before_install: *bs_linux
+    - name: Linux (OpenSSL 1.1.0)
+      os: linux
+      before_install:
+        - sudo apt-get install faketime libscope-guard-perl libtest-tcp-perl
+        - curl https://www.openssl.org/source/old/1.1.0/openssl-1.1.0l.tar.gz | tar xzf -
+        - cd openssl-1.1.0l
+        - ./config --prefix=/usr/local/openssl-1.1.0
+        - make
+        - sudo make install
+        - cd ..
+      env:
+        - PKG_CONFIG_PATH=/usr/local/openssl-1.1.0/lib/pkgconfig
     - name: Linux (OpenSSL 1.0.2)
       os: linux
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,18 @@ matrix:
         - cd ..
       env:
         - PKG_CONFIG_PATH=/usr/local/openssl-1.0.2/lib/pkgconfig
+    - name: Linux (libressl 3.2)
+      os: linux
+      before_install:
+        - sudo apt-get install faketime libscope-guard-perl libtest-tcp-perl
+        - curl https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.2.5.tar.gz | tar xzf -
+        - cd libressl-3.2.5
+        - ./configure --prefix=/usr/local/libressl-3.2
+        - make
+        - sudo make install
+        - cd ..
+      env:
+        - PKG_CONFIG_PATH=/usr/local/libressl-3.2/lib/pkgconfig
     - name: macOS (Xcode)
       os: osx
       addons: &addons_macos


### PR DESCRIPTION
Up until now, surprisingly, only OpenSSL 1.0.2 was used.