### PR TITLE
Use X509_VERIFY_PARAM for certificate verification

### DIFF
--- a/include/picotls/openssl.h
+++ b/include/picotls/openssl.h
@@ -117,6 +117,8 @@ typedef struct st_ptls_openssl_verify_certificate_t {
     X509_STORE *cert_store;
 } ptls_openssl_verify_certificate_t;
 
+void ptls_openssl_set_default_algos(ptls_verify_certificate_t *self);
+
 int ptls_openssl_init_verify_certificate(ptls_openssl_verify_certificate_t *self, X509_STORE *store);
 void ptls_openssl_dispose_verify_certificate(ptls_openssl_verify_certificate_t *self);
 X509_STORE *ptls_openssl_create_default_certificate_store(void);

--- a/include/picotls/openssl.h
+++ b/include/picotls/openssl.h
@@ -117,8 +117,6 @@ typedef struct st_ptls_openssl_verify_certificate_t {
     X509_STORE *cert_store;
 } ptls_openssl_verify_certificate_t;
 
-void ptls_openssl_set_default_algos(ptls_verify_certificate_t *self);
-
 int ptls_openssl_init_verify_certificate(ptls_openssl_verify_certificate_t *self, X509_STORE *store);
 void ptls_openssl_dispose_verify_certificate(ptls_openssl_verify_certificate_t *self);
 X509_STORE *ptls_openssl_create_default_certificate_store(void);

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -1240,12 +1240,19 @@ static int verify_cert_chain(X509_STORE *store, X509 *cert, STACK_OF(X509) * cha
     X509_VERIFY_PARAM_set_purpose(params, is_server ? X509_PURPOSE_SSL_SERVER : X509_PURPOSE_SSL_CLIENT);
     X509_VERIFY_PARAM_set_depth(params, 2);
 
+#ifdef X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS
     if (server_name != NULL) {
-        if (ptls_server_name_is_ipaddr(server_name)) 
-            X509_VERIFY_PARAM_set1_host(params, server_name, 0);
-        else                                        
+        if (ptls_server_name_is_ipaddr(server_name)) {
             X509_VERIFY_PARAM_set1_ip_asc(params, server_name);
+        }
+        else {
+            X509_VERIFY_PARAM_set1_host(params, server_name, 0);
+            X509_VERIFY_PARAM_set_hostflags(params, X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
+        }          
     }
+    #else
+#warning "hostname validation is disabled; OpenSSL >= 1.0.2 or LibreSSL >= 2.5.0 is required"
+#endif
 
     X509_STORE_CTX_set0_param(verify_ctx, params);
 

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -1335,6 +1335,11 @@ Exit:
     return ret;
 }
 
+void ptls_openssl_set_default_algos(ptls_verify_certificate_t *self)
+{
+    self->algos = default_signature_schemes;
+}
+
 int ptls_openssl_init_verify_certificate(ptls_openssl_verify_certificate_t *self, X509_STORE *store)
 {
     *self = (ptls_openssl_verify_certificate_t){{verify_cert, default_signature_schemes}};

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -1301,8 +1301,6 @@ static int verify_cert(ptls_verify_certificate_t *_self, ptls_t *tls,
 
     assert(num_certs != 0);
 
-    printf("verify_cert -> check point 1\n");
-
     /* convert certificates to OpenSSL representation */
     if ((cert = to_x509(certs[0])) == NULL) {
         ret = PTLS_ALERT_BAD_CERTIFICATE;
@@ -1317,13 +1315,9 @@ static int verify_cert(ptls_verify_certificate_t *_self, ptls_t *tls,
         sk_X509_push(chain, interm);
     }
 
-    printf("verify_cert -> check point 2\n");
-
     /* verify the chain */
     if ((ret = verify_cert_chain(self->cert_store, cert, chain, ptls_is_server(tls), ptls_get_server_name(tls))) != 0)
         goto Exit;
-
-    printf("verify_cert -> check point 3\n");
 
     /* extract public key for verifying the TLS handshake signature */
     if ((*verify_data = X509_get_pubkey(cert)) == NULL) {

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -1218,6 +1218,7 @@ Exit:
 static int verify_cert_chain(X509_STORE *store, X509 *cert, STACK_OF(X509) * chain, int is_server, const char *server_name)
 {
     X509_STORE_CTX *verify_ctx;
+    X509_VERIFY_PARAM *params;
     int ret;
 
     assert(server_name != NULL && "ptls_set_server_name MUST be called");
@@ -1227,11 +1228,27 @@ static int verify_cert_chain(X509_STORE *store, X509 *cert, STACK_OF(X509) * cha
         ret = PTLS_ERROR_NO_MEMORY;
         goto Exit;
     }
+    if ((params = X509_VERIFY_PARAM_new()) == NULL) {
+        ret = PTLS_ERROR_NO_MEMORY;
+        goto Exit;
+    }
     if (X509_STORE_CTX_init(verify_ctx, store, cert, chain) != 1) {
         ret = PTLS_ERROR_LIBRARY;
         goto Exit;
     }
-    X509_STORE_CTX_set_purpose(verify_ctx, is_server ? X509_PURPOSE_SSL_SERVER : X509_PURPOSE_SSL_CLIENT);
+
+    X509_VERIFY_PARAM_set_purpose(params, is_server ? X509_PURPOSE_SSL_SERVER : X509_PURPOSE_SSL_CLIENT);
+    X509_VERIFY_PARAM_set_depth(params, 2);
+
+    if (server_name != NULL) {
+        if (ptls_server_name_is_ipaddr(server_name)) 
+            X509_VERIFY_PARAM_set1_host(params, server_name, 0);
+        else                                        
+            X509_VERIFY_PARAM_set1_ip_asc(params, server_name);
+    }
+
+    X509_STORE_CTX_set0_param(verify_ctx, params);
+
     if (X509_verify_cert(verify_ctx) != 1) {
         int x509_err = X509_STORE_CTX_get_error(verify_ctx);
         switch (x509_err) {
@@ -1252,6 +1269,7 @@ static int verify_cert_chain(X509_STORE *store, X509 *cert, STACK_OF(X509) * cha
             ret = PTLS_ALERT_UNKNOWN_CA;
             break;
         case X509_V_ERR_INVALID_CA:
+
             ret = PTLS_ALERT_BAD_CERTIFICATE;
             break;
         default:
@@ -1261,32 +1279,13 @@ static int verify_cert_chain(X509_STORE *store, X509 *cert, STACK_OF(X509) * cha
         goto Exit;
     }
 
-#ifdef X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS
-    /* verify CN */
-    if (server_name != NULL) {
-        if (ptls_server_name_is_ipaddr(server_name)) {
-            ret = X509_check_ip_asc(cert, server_name, 0);
-        } else {
-            ret = X509_check_host(cert, server_name, strlen(server_name), X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS, NULL);
-        }
-        if (ret != 1) {
-            if (ret == 0) { /* failed match */
-                ret = PTLS_ALERT_BAD_CERTIFICATE;
-            } else {
-                ret = PTLS_ERROR_LIBRARY;
-            }
-            goto Exit;
-        }
-    }
-#else
-#warning "hostname validation is disabled; OpenSSL >= 1.0.2 or LibreSSL >= 2.5.0 is required"
-#endif
-
     ret = 0;
 
 Exit:
+    // X509_VERIFY_PARAM *params is freed by the store
     if (verify_ctx != NULL)
         X509_STORE_CTX_free(verify_ctx);
+
     return ret;
 }
 
@@ -1302,6 +1301,8 @@ static int verify_cert(ptls_verify_certificate_t *_self, ptls_t *tls,
 
     assert(num_certs != 0);
 
+    printf("verify_cert -> check point 1\n");
+
     /* convert certificates to OpenSSL representation */
     if ((cert = to_x509(certs[0])) == NULL) {
         ret = PTLS_ALERT_BAD_CERTIFICATE;
@@ -1316,9 +1317,13 @@ static int verify_cert(ptls_verify_certificate_t *_self, ptls_t *tls,
         sk_X509_push(chain, interm);
     }
 
+    printf("verify_cert -> check point 2\n");
+
     /* verify the chain */
     if ((ret = verify_cert_chain(self->cert_store, cert, chain, ptls_is_server(tls), ptls_get_server_name(tls))) != 0)
         goto Exit;
+
+    printf("verify_cert -> check point 3\n");
 
     /* extract public key for verifying the TLS handshake signature */
     if ((*verify_data = X509_get_pubkey(cert)) == NULL) {

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -1275,8 +1275,8 @@ static int verify_cert_chain(X509_STORE *store, X509 *cert, STACK_OF(X509) * cha
         case X509_V_ERR_CERT_REJECTED:
             ret = PTLS_ALERT_UNKNOWN_CA;
             break;
+        case X509_V_ERR_HOSTNAME_MISMATCH:
         case X509_V_ERR_INVALID_CA:
-
             ret = PTLS_ALERT_BAD_CERTIFICATE;
             break;
         default:

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -1337,11 +1337,6 @@ Exit:
     return ret;
 }
 
-void ptls_openssl_set_default_algos(ptls_verify_certificate_t *self)
-{
-    self->algos = default_signature_schemes;
-}
-
 int ptls_openssl_init_verify_certificate(ptls_openssl_verify_certificate_t *self, X509_STORE *store)
 {
     *self = (ptls_openssl_verify_certificate_t){{verify_cert, default_signature_schemes}};

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -1238,9 +1238,8 @@ static int verify_cert_chain(X509_STORE *store, X509 *cert, STACK_OF(X509) * cha
     }
 
     X509_VERIFY_PARAM_set_purpose(params, is_server ? X509_PURPOSE_SSL_SERVER : X509_PURPOSE_SSL_CLIENT);
-    X509_VERIFY_PARAM_set_depth(params, 2);
+    X509_VERIFY_PARAM_set_depth(params, 1);
 
-#ifdef X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS
     if (server_name != NULL) {
         if (ptls_server_name_is_ipaddr(server_name)) {
             X509_VERIFY_PARAM_set1_ip_asc(params, server_name);
@@ -1250,9 +1249,6 @@ static int verify_cert_chain(X509_STORE *store, X509 *cert, STACK_OF(X509) * cha
             X509_VERIFY_PARAM_set_hostflags(params, X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
         }          
     }
-    #else
-#warning "hostname validation is disabled; OpenSSL >= 1.0.2 or LibreSSL >= 2.5.0 is required"
-#endif
 
     X509_STORE_CTX_set0_param(verify_ctx, params);
 

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -1522,7 +1522,7 @@ Exit:
 static int push_signature_algorithms(ptls_verify_certificate_t *vc, ptls_buffer_t *sendbuf)
 {
     /* The list sent when verify callback is not registered */
-    static const uint16_t default_algos[] = {PTLS_SIGNATURE_RSA_PSS_RSAE_SHA256, PTLS_SIGNATURE_ECDSA_SECP256R1_SHA256,
+    static const uint16_t default_algos[] = {PTLS_SIGNATURE_ED25519, PTLS_SIGNATURE_RSA_PSS_RSAE_SHA256, PTLS_SIGNATURE_ECDSA_SECP256R1_SHA256,
                                              PTLS_SIGNATURE_RSA_PKCS1_SHA256, PTLS_SIGNATURE_RSA_PKCS1_SHA1, UINT16_MAX};
     int ret;
 


### PR DESCRIPTION
when using a custom certificate verification callback in [picoquic_enable_custom_verify_certificate_callback](https://github.com/private-octopus/picoquic/blob/0c18817bfdeffd74ff860ef1e8e13c4e357e40fa/picoquic/tls_api.c#L1275) currently no algo values are installed on the callback object, so we get segfaulted in `push_signature_algorithms` during the handshake.

the algo values are hidden inside openssl.c, and `ptls_openssl_init_verify_certificate` allocates an `X509_STORE` if you pass in `NULL` so i figured this is the best solution?

also SNI was broken for me. but adopting this new way corrects it.

and openssl says...

> Applications are strongly advised to use this interface in preference to explicitly calling X509_check_host(3), hostname checks may be out of scope with the DANE-EE(3) certificate usage, and the internal check will be suppressed as appropriate when DANE verification is enabled.

[https://www.openssl.org/docs/man1.1.0/man3/X509_VERIFY_PARAM_set1_host.html](https://www.openssl.org/docs/man1.1.0/man3/X509_VERIFY_PARAM_set1_host.html)

this approach also unifies the verification and makes other vectors of verification simply appendable.

my server certificate looks like this:

```
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number: 4096 (0x1000)
        Signature Algorithm: ED25519
        Issuer: C = US, ST = NY, O = Test Inc., OU = Test Intermediary CA, CN = 1nt3r, emailAddress = security@test.com
        Validity
            Not Before: Mar 23 16:16:10 2021 GMT
            Not After : Jun  9 16:16:10 2029 GMT
        Subject: C = US, ST = NY, L = NYC, O = Test Inc., OU = Test Intermediary CA, CN = server, emailAddress = security@test.com
        Subject Public Key Info:
            Public Key Algorithm: ED25519
                ED25519 Public-Key:
                pub:
                    c1:ce:ec:2e:94:85:e1:40:88:dc:be:82:73:71:ca:
                    96:12:6c:f0:ff:82:43:76:bf:10:2b:ea:f0:be:34:
                    45:85
        X509v3 extensions:
            X509v3 Basic Constraints: 
                CA:FALSE
            X509v3 Subject Key Identifier: 
                7E:2B:3F:64:2F:C6:90:F1:C9:94:7B:A5:06:1F:51:F7:D1:90:90:8B
            X509v3 Authority Key Identifier: 
                keyid:31:BC:26:9B:7D:39:22:0F:3C:D0:58:F3:DC:1E:B9:33:A3:24:96:9D
                DirName:/C=US/ST=NY/L=NYC/O=Test Inc./OU=Testing Root CA/CN=r00t/emailAddress=security@test.com
                serial:10:00

            X509v3 Key Usage: critical
                Digital Signature, Key Encipherment
            X509v3 Extended Key Usage: 
                TLS Web Client Authentication
            X509v3 Subject Alternative Name: 
                IP Address:0.0.0.0, IP Address:127.0.0.1, IP Address:0:0:0:0:0:0:0:1, DNS:localhost, DNS:0.0.0.0, DNS:127.0.0.1, DNS:::1
    Signature Algorithm: ED25519
         20:e7:35:10:ee:ef:c6:4e:57:a5:da:b0:c0:ea:34:45:99:30:
         e3:4d:75:6e:d4:4f:61:e7:92:85:58:96:7d:6b:fa:a8:0a:94:
         d0:e5:b7:43:f3:09:77:2a:2f:85:07:3d:21:43:7b:1b:45:50:
         b3:dd:71:6d:8a:cb:4c:8e:44:0c
```