### PR TITLE
add `const char *ptls_cipher_suite_t::name` that contains the name of the cipher

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -105,8 +105,11 @@ extern "C" {
 
 /* cipher-suites */
 #define PTLS_CIPHER_SUITE_AES_128_GCM_SHA256 0x1301
+#define PTLS_CIPHER_SUITE_NAME_AES_128_GCM_SHA256 "TLS_AES_128_GCM_SHA256"
 #define PTLS_CIPHER_SUITE_AES_256_GCM_SHA384 0x1302
+#define PTLS_CIPHER_SUITE_NAME_AES_256_GCM_SHA384 "TLS_AES_256_GCM_SHA384"
 #define PTLS_CIPHER_SUITE_CHACHA20_POLY1305_SHA256 0x1303
+#define PTLS_CIPHER_SUITE_NAME_CHACHA20_POLY1305_SHA256 "TLS_CHACHA20_POLY1305_SHA256"
 
 /* negotiated_groups */
 #define PTLS_GROUP_SECP256R1 23
@@ -445,9 +448,22 @@ typedef const struct st_ptls_hash_algorithm_t {
 } ptls_hash_algorithm_t;
 
 typedef const struct st_ptls_cipher_suite_t {
+    /**
+     * ID as defined by the TLS Cipher Suites registry
+     */
     uint16_t id;
+    /**
+     * underlying AEAD algorithm
+     */
     ptls_aead_algorithm_t *aead;
+    /**
+     * underlying hash algorithm
+     */
     ptls_hash_algorithm_t *hash;
+    /**
+     * value of the "Description" field of the TLS Cipher Suites registry
+     */
+    const char *name;
 } ptls_cipher_suite_t;
 
 struct st_ptls_traffic_protection_t;

--- a/lib/cifra/aes128.c
+++ b/lib/cifra/aes128.c
@@ -57,5 +57,7 @@ ptls_aead_algorithm_t ptls_minicrypto_aes128gcm = {"AES128-GCM",
                                                    PTLS_AESGCM_TAG_SIZE,
                                                    sizeof(struct aesgcm_context_t),
                                                    aead_aes128gcm_setup_crypto};
-ptls_cipher_suite_t ptls_minicrypto_aes128gcmsha256 = {PTLS_CIPHER_SUITE_AES_128_GCM_SHA256, &ptls_minicrypto_aes128gcm,
-                                                       &ptls_minicrypto_sha256};
+ptls_cipher_suite_t ptls_minicrypto_aes128gcmsha256 = {.id = PTLS_CIPHER_SUITE_AES_128_GCM_SHA256,
+                                                       .name = PTLS_CIPHER_SUITE_NAME_AES_128_GCM_SHA256,
+                                                       .aead = &ptls_minicrypto_aes128gcm,
+                                                       .hash = &ptls_minicrypto_sha256};

--- a/lib/cifra/aes256.c
+++ b/lib/cifra/aes256.c
@@ -57,5 +57,7 @@ ptls_aead_algorithm_t ptls_minicrypto_aes256gcm = {"AES256-GCM",
                                                    PTLS_AESGCM_TAG_SIZE,
                                                    sizeof(struct aesgcm_context_t),
                                                    aead_aes256gcm_setup_crypto};
-ptls_cipher_suite_t ptls_minicrypto_aes256gcmsha384 = {PTLS_CIPHER_SUITE_AES_256_GCM_SHA384, &ptls_minicrypto_aes256gcm,
-                                                       &ptls_minicrypto_sha384};
+ptls_cipher_suite_t ptls_minicrypto_aes256gcmsha384 = {.id = PTLS_CIPHER_SUITE_AES_256_GCM_SHA384,
+                                                       .name = PTLS_CIPHER_SUITE_NAME_AES_256_GCM_SHA384,
+                                                       .aead = &ptls_minicrypto_aes256gcm,
+                                                       .hash = &ptls_minicrypto_sha384};

--- a/lib/cifra/chacha20.c
+++ b/lib/cifra/chacha20.c
@@ -225,5 +225,7 @@ ptls_aead_algorithm_t ptls_minicrypto_chacha20poly1305 = {"CHACHA20-POLY1305",
                                                           PTLS_CHACHA20POLY1305_TAG_SIZE,
                                                           sizeof(struct chacha20poly1305_context_t),
                                                           aead_chacha20poly1305_setup_crypto};
-ptls_cipher_suite_t ptls_minicrypto_chacha20poly1305sha256 = {PTLS_CIPHER_SUITE_CHACHA20_POLY1305_SHA256,
-                                                              &ptls_minicrypto_chacha20poly1305, &ptls_minicrypto_sha256};
+ptls_cipher_suite_t ptls_minicrypto_chacha20poly1305sha256 = {.id = PTLS_CIPHER_SUITE_CHACHA20_POLY1305_SHA256,
+                                                              .name = PTLS_CIPHER_SUITE_NAME_CHACHA20_POLY1305_SHA256,
+                                                              .aead = &ptls_minicrypto_chacha20poly1305,
+                                                              .hash = &ptls_minicrypto_sha256};

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -1604,10 +1604,14 @@ ptls_hash_algorithm_t ptls_openssl_sha256 = {PTLS_SHA256_BLOCK_SIZE, PTLS_SHA256
                                              PTLS_ZERO_DIGEST_SHA256};
 ptls_hash_algorithm_t ptls_openssl_sha384 = {PTLS_SHA384_BLOCK_SIZE, PTLS_SHA384_DIGEST_SIZE, sha384_create,
                                              PTLS_ZERO_DIGEST_SHA384};
-ptls_cipher_suite_t ptls_openssl_aes128gcmsha256 = {PTLS_CIPHER_SUITE_AES_128_GCM_SHA256, &ptls_openssl_aes128gcm,
-                                                    &ptls_openssl_sha256};
-ptls_cipher_suite_t ptls_openssl_aes256gcmsha384 = {PTLS_CIPHER_SUITE_AES_256_GCM_SHA384, &ptls_openssl_aes256gcm,
-                                                    &ptls_openssl_sha384};
+ptls_cipher_suite_t ptls_openssl_aes128gcmsha256 = {.id = PTLS_CIPHER_SUITE_AES_128_GCM_SHA256,
+                                                    .name = PTLS_CIPHER_SUITE_NAME_AES_128_GCM_SHA256,
+                                                    .aead = &ptls_openssl_aes128gcm,
+                                                    .hash = &ptls_openssl_sha256};
+ptls_cipher_suite_t ptls_openssl_aes256gcmsha384 = {.id = PTLS_CIPHER_SUITE_AES_256_GCM_SHA384,
+                                                    .name = PTLS_CIPHER_SUITE_NAME_AES_256_GCM_SHA384,
+                                                    .aead = &ptls_openssl_aes256gcm,
+                                                    .hash = &ptls_openssl_sha384};
 #if PTLS_OPENSSL_HAVE_CHACHA20_POLY1305
 ptls_cipher_algorithm_t ptls_openssl_chacha20 = {
     "CHACHA20",           PTLS_CHACHA20_KEY_SIZE, 1 /* block size */, PTLS_CHACHA20_IV_SIZE, sizeof(struct cipher_context_t),
@@ -1622,8 +1626,10 @@ ptls_aead_algorithm_t ptls_openssl_chacha20poly1305 = {"CHACHA20-POLY1305",
                                                        PTLS_CHACHA20POLY1305_TAG_SIZE,
                                                        sizeof(struct aead_crypto_context_t),
                                                        aead_chacha20poly1305_setup_crypto};
-ptls_cipher_suite_t ptls_openssl_chacha20poly1305sha256 = {PTLS_CIPHER_SUITE_CHACHA20_POLY1305_SHA256,
-                                                           &ptls_openssl_chacha20poly1305, &ptls_openssl_sha256};
+ptls_cipher_suite_t ptls_openssl_chacha20poly1305sha256 = {.id = PTLS_CIPHER_SUITE_CHACHA20_POLY1305_SHA256,
+                                                           .name = PTLS_CIPHER_SUITE_NAME_CHACHA20_POLY1305_SHA256,
+                                                           .aead = &ptls_openssl_chacha20poly1305,
+                                                           .hash = &ptls_openssl_sha256};
 #endif
 ptls_cipher_suite_t *ptls_openssl_cipher_suites[] = {&ptls_openssl_aes256gcmsha384, &ptls_openssl_aes128gcmsha256,
 #if PTLS_OPENSSL_HAVE_CHACHA20_POLY1305


### PR DESCRIPTION
So as to not break source-level compatibility of existing programs that define their own `ptls_cipher_suite_t` using compound literal expression with positional parameters, the `name` field is added at the end of `ptls_cipher_suite_t`.