### PR TITLE
add name field to `ptls_key_exchange_algorithm_t`

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -113,10 +113,15 @@ extern "C" {
 
 /* negotiated_groups */
 #define PTLS_GROUP_SECP256R1 23
+#define PTLS_GROUP_NAME_SECP256R1 "scep256r1"
 #define PTLS_GROUP_SECP384R1 24
+#define PTLS_GROUP_NAME_SECP384R1 "secp384r1"
 #define PTLS_GROUP_SECP521R1 25
+#define PTLS_GROUP_NAME_SECP521R1 "secp521r1"
 #define PTLS_GROUP_X25519 29
+#define PTLS_GROUP_NAME_X25519 "x25519"
 #define PTLS_GROUP_X448 30
+#define PTLS_GROUP_NAME_X448 "x448"
 
 /* signature algorithms */
 #define PTLS_SIGNATURE_RSA_PKCS1_SHA1 0x0201
@@ -293,6 +298,10 @@ typedef const struct st_ptls_key_exchange_algorithm_t {
      * crypto-specific data
      */
     intptr_t data;
+    /**
+     * Description as defined in the IANA TLS registry
+     */
+    const char *name;
 } ptls_key_exchange_algorithm_t;
 
 /**

--- a/lib/cifra/x25519.c
+++ b/lib/cifra/x25519.c
@@ -116,4 +116,5 @@ Exit:
     return ret;
 }
 
-ptls_key_exchange_algorithm_t ptls_minicrypto_x25519 = {PTLS_GROUP_X25519, x25519_create_key_exchange, x25519_key_exchange};
+ptls_key_exchange_algorithm_t ptls_minicrypto_x25519 = {
+    .id = PTLS_GROUP_X25519, .name = PTLS_GROUP_NAME_X25519, .create = x25519_create_key_exchange, .exchange = x25519_key_exchange};

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -1555,18 +1555,31 @@ Exit:
     return ret;
 }
 
-ptls_key_exchange_algorithm_t ptls_openssl_secp256r1 = {PTLS_GROUP_SECP256R1, x9_62_create_key_exchange, secp_key_exchange,
-                                                        NID_X9_62_prime256v1};
+ptls_key_exchange_algorithm_t ptls_openssl_secp256r1 = {.id = PTLS_GROUP_SECP256R1,
+                                                        .name = PTLS_GROUP_NAME_SECP256R1,
+                                                        .create = x9_62_create_key_exchange,
+                                                        .exchange = secp_key_exchange,
+                                                        .data = NID_X9_62_prime256v1};
 #if PTLS_OPENSSL_HAVE_SECP384R1
-ptls_key_exchange_algorithm_t ptls_openssl_secp384r1 = {PTLS_GROUP_SECP384R1, x9_62_create_key_exchange, secp_key_exchange,
-                                                        NID_secp384r1};
+ptls_key_exchange_algorithm_t ptls_openssl_secp384r1 = {.id = PTLS_GROUP_SECP384R1,
+                                                        .name = PTLS_GROUP_NAME_SECP384R1,
+                                                        .create = x9_62_create_key_exchange,
+                                                        .exchange = secp_key_exchange,
+                                                        .data = NID_secp384r1};
 #endif
 #if PTLS_OPENSSL_HAVE_SECP521R1
-ptls_key_exchange_algorithm_t ptls_openssl_secp521r1 = {PTLS_GROUP_SECP521R1, x9_62_create_key_exchange, secp_key_exchange,
-                                                        NID_secp521r1};
+ptls_key_exchange_algorithm_t ptls_openssl_secp521r1 = {.id = PTLS_GROUP_SECP521R1,
+                                                        .name = PTLS_GROUP_NAME_SECP521R1,
+                                                        .create = x9_62_create_key_exchange,
+                                                        .exchange = secp_key_exchange,
+                                                        .data = NID_secp521r1};
 #endif
 #if PTLS_OPENSSL_HAVE_X25519
-ptls_key_exchange_algorithm_t ptls_openssl_x25519 = {PTLS_GROUP_X25519, evp_keyex_create, evp_keyex_exchange, NID_X25519};
+ptls_key_exchange_algorithm_t ptls_openssl_x25519 = {.id = PTLS_GROUP_X25519,
+                                                     .name = PTLS_GROUP_NAME_X25519,
+                                                     .create = evp_keyex_create,
+                                                     .exchange = evp_keyex_exchange,
+                                                     .data = NID_X25519};
 #endif
 ptls_key_exchange_algorithm_t *ptls_openssl_key_exchanges[] = {&ptls_openssl_secp256r1, NULL};
 ptls_cipher_algorithm_t ptls_openssl_aes128ecb = {

--- a/lib/uecc.c
+++ b/lib/uecc.c
@@ -186,6 +186,8 @@ int ptls_minicrypto_init_secp256r1sha256_sign_certificate(ptls_minicrypto_secp25
     return 0;
 }
 
-ptls_key_exchange_algorithm_t ptls_minicrypto_secp256r1 = {PTLS_GROUP_SECP256R1, secp256r1_create_key_exchange,
-                                                           secp256r1_key_exchange};
+ptls_key_exchange_algorithm_t ptls_minicrypto_secp256r1 = {.id = PTLS_GROUP_SECP256R1,
+                                                           .name = PTLS_GROUP_NAME_SECP256R1,
+                                                           .create = secp256r1_create_key_exchange,
+                                                           .exchange = secp256r1_key_exchange};
 ptls_key_exchange_algorithm_t *ptls_minicrypto_key_exchanges[] = {&ptls_minicrypto_secp256r1, NULL};


### PR DESCRIPTION
Does the same thing as #355 for negotiated groups.

Source compatibility is also retained here, by adding the `name` field at the end of the struct.