### PR TITLE
`-V` option for specifying cert store, use verify params of the cert store

### DIFF
--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -1237,7 +1237,6 @@ static int verify_cert_chain(X509_STORE *store, X509 *cert, STACK_OF(X509) * cha
         }
         X509_VERIFY_PARAM_set_purpose(params, is_server ? X509_PURPOSE_SSL_SERVER : X509_PURPOSE_SSL_CLIENT);
         X509_VERIFY_PARAM_set_depth(params, 98); /* use the default of OpenSSL 1.0.2 and above; see `man SSL_CTX_set_verify` */
-        X509_VERIFY_PARAM_set_flags(params, X509_V_FLAG_PARTIAL_CHAIN);
         if (!is_server) {
             assert(server_name != NULL && "ptls_set_server_name MUST be called");
             if (server_name != NULL) {

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -1237,13 +1237,11 @@ static int verify_cert_chain(X509_STORE *store, X509 *cert, STACK_OF(X509) * cha
         /* when _acting_ as client, set the server name */
         if (!is_server) {
             assert(server_name != NULL && "ptls_set_server_name MUST be called");
-            if (server_name != NULL) {
-                if (ptls_server_name_is_ipaddr(server_name)) {
-                    X509_VERIFY_PARAM_set1_ip_asc(params, server_name);
-                } else {
-                    X509_VERIFY_PARAM_set1_host(params, server_name, 0);
-                    X509_VERIFY_PARAM_set_hostflags(params, X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
-                }
+            if (ptls_server_name_is_ipaddr(server_name)) {
+                X509_VERIFY_PARAM_set1_ip_asc(params, server_name);
+            } else {
+                X509_VERIFY_PARAM_set1_host(params, server_name, 0);
+                X509_VERIFY_PARAM_set_hostflags(params, X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
             }
         }
     }

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -63,6 +63,7 @@
 
 #define EVP_PKEY_up_ref(p) CRYPTO_add(&(p)->references, 1, CRYPTO_LOCK_EVP_PKEY)
 #define X509_STORE_up_ref(p) CRYPTO_add(&(p)->references, 1, CRYPTO_LOCK_X509_STORE)
+#define X509_STORE_get0_param(p) ((p)->param)
 
 static HMAC_CTX *HMAC_CTX_new(void)
 {
@@ -1229,14 +1230,11 @@ static int verify_cert_chain(X509_STORE *store, X509 *cert, STACK_OF(X509) * cha
         goto Exit;
     }
 
-    {
-        X509_VERIFY_PARAM *params;
-        if ((params = X509_VERIFY_PARAM_new()) == NULL) {
-            ret = PTLS_ERROR_NO_MEMORY;
-            goto Exit;
-        }
+    { /* setup verify params */
+        X509_VERIFY_PARAM *params = X509_STORE_CTX_get0_param(verify_ctx);
         X509_VERIFY_PARAM_set_purpose(params, is_server ? X509_PURPOSE_SSL_SERVER : X509_PURPOSE_SSL_CLIENT);
         X509_VERIFY_PARAM_set_depth(params, 98); /* use the default of OpenSSL 1.0.2 and above; see `man SSL_CTX_set_verify` */
+        /* when _acting_ as client, set the server name */
         if (!is_server) {
             assert(server_name != NULL && "ptls_set_server_name MUST be called");
             if (server_name != NULL) {
@@ -1248,7 +1246,6 @@ static int verify_cert_chain(X509_STORE *store, X509 *cert, STACK_OF(X509) * cha
                 }
             }
         }
-        X509_STORE_CTX_set0_param(verify_ctx, params); /* params will be freed alongside verify_ctx */
     }
 
     if (X509_verify_cert(verify_ctx) != 1) {

--- a/t/cli.c
+++ b/t/cli.c
@@ -365,6 +365,7 @@ static void usage(const char *cmd)
            "                       argument is ignored.\n"
            "  -u                   update the traffic key when handshake is complete\n"
            "  -v                   verify peer using the default certificates\n"
+           "  -V CA-root-file      verify peer using the CA Root File\n"
            "  -y cipher-suite      cipher-suite to be used, e.g., aes128gcmsha256 (default:\n"
            "                       all)\n"
            "  -h                   print this help\n"
@@ -422,7 +423,7 @@ int main(int argc, char **argv)
     int family = 0;
     const char *raw_pub_key_file = NULL, *cert_location = NULL;
 
-    while ((ch = getopt(argc, argv, "46abBC:c:i:Ik:nN:es:Sr:E:K:l:y:vh")) != -1) {
+    while ((ch = getopt(argc, argv, "46abBC:c:i:Ik:nN:es:Sr:E:K:l:y:vV:h")) != -1) {
         switch (ch) {
         case '4':
             family = AF_INET;
@@ -503,7 +504,10 @@ int main(int argc, char **argv)
             setup_log_event(&ctx, optarg);
             break;
         case 'v':
-            setup_verify_certificate(&ctx);
+            setup_verify_certificate(&ctx, NULL);
+            break;
+        case 'V':
+            setup_verify_certificate(&ctx, optarg);
             break;
         case 'N': {
             ptls_key_exchange_algorithm_t *algo = NULL;


### PR DESCRIPTION
This PR adds `-V` option to the cli command that allows users specify custom cert stores, and also makes sure that the `verify_cert_chain` function respects the verification parameters associated to the cert store.

Some context regarding the latter point: in #347 we switch to using `X509_VERIFY_PARAM` for verifying the SNI. Unfortunate side effect of the new approach was that it replaced the verify params associated to `X509_STORE`, by creating a new `X509_VERIFY_PARAM` and then setting it to the context using `X509_STORE_CTX_set0_param`.

This PR changes the approach to one instead modifies the verify parameters associated to `X509_STORE_CTX`. By doing so, the properties (e.g., `X509_V_FLAG_PARTIAL_CHAIN`) inherited from `X509_STORE` by calling `X509_STORE_CTX_init` remains in effect.

FWIW, the new approach closely resembles what [OpenSSL does](https://github.com/openssl/openssl/blob/OpenSSL_1_1_1k/ssl/ssl_cert.c#L363-L446).

Credit: this PR is based on the changes proposed by @ha0li in https://github.com/h2o/h2o/pull/2621.