### PR TITLE
Conversion fixes for utils.h

### DIFF
--- a/t/util.h
+++ b/t/util.h
@@ -88,7 +88,7 @@ struct st_util_save_ticket_t {
 
 static int util_save_ticket_cb(ptls_save_ticket_t *_self, ptls_t *tls, ptls_iovec_t src)
 {
-    struct st_util_save_ticket_t *self = (void *)_self;
+    struct st_util_save_ticket_t *self = (struct st_util_save_ticket_t*)_self;
     FILE *fp;
 
     if ((fp = fopen(self->fn, "wb")) == NULL) {
@@ -180,7 +180,7 @@ static inline void setup_esni(ptls_context_t *ctx, const char *esni_fn, ptls_key
         fclose(fp);
     }
 
-    if ((ctx->esni = malloc(sizeof(*ctx->esni) * 2)) == NULL || (*ctx->esni = malloc(sizeof(**ctx->esni))) == NULL) {
+    if ((ctx->esni = (ptls_esni_context_t**) malloc(sizeof(*ctx->esni) * 2)) == NULL || (*ctx->esni = (ptls_esni_context_t*) malloc(sizeof(**ctx->esni))) == NULL) {
         fprintf(stderr, "no memory\n");
         exit(1);
     }
@@ -198,7 +198,7 @@ struct st_util_log_event_t {
 
 static void log_event_cb(ptls_log_event_t *_self, ptls_t *tls, const char *type, const char *fmt, ...)
 {
-    struct st_util_log_event_t *self = (void *)_self;
+    struct st_util_log_event_t *self = (struct st_util_log_event_t*)_self;
     char randomhex[PTLS_HELLO_RANDOM_SIZE * 2 + 1];
     va_list args;
 
@@ -234,14 +234,14 @@ struct st_util_session_cache_t {
 
 static int encrypt_ticket_cb(ptls_encrypt_ticket_t *_self, ptls_t *tls, int is_encrypt, ptls_buffer_t *dst, ptls_iovec_t src)
 {
-    struct st_util_session_cache_t *self = (void *)_self;
+    struct st_util_session_cache_t *self = (struct st_util_session_cache_t*)_self;
     int ret;
 
     if (is_encrypt) {
 
         /* replace the cached entry along with a newly generated session id */
         free(self->data.base);
-        if ((self->data.base = malloc(src.len)) == NULL)
+        if ((self->data.base = (uint8_t *) malloc(src.len)) == NULL)
             return PTLS_ERROR_NO_MEMORY;
 
         ptls_get_context(tls)->random_bytes(self->id, sizeof(self->id));
@@ -336,8 +336,9 @@ static inline ptls_iovec_t resolve_esni_keys(const char *server_name)
     ptls_buffer_t decode_buf;
     ptls_base64_decode_state_t ds;
     int answer_len;
-
-    ptls_buffer_init(&decode_buf, "", 0);
+    
+    char* buf = "";
+    ptls_buffer_init(&decode_buf, buf, 0);
 
     if (snprintf(esni_name, sizeof(esni_name), "_esni.%s", server_name) > sizeof(esni_name) - 1)
         goto Error;
@@ -349,8 +350,8 @@ static inline ptls_iovec_t resolve_esni_keys(const char *server_name)
         goto Error;
     if (ns_parserr(&msg, ns_s_an, 0, &rr) != 0)
         goto Error;
-    base64 = (void *)ns_rr_rdata(rr);
-    if (!normalize_txt((void *)base64, ns_rr_rdlen(rr)))
+    base64 = (char *)ns_rr_rdata(rr);
+    if (!normalize_txt((uint8_t *)base64, ns_rr_rdlen(rr)))
         goto Error;
 
     ptls_base64_decode_init(&ds);


### PR DESCRIPTION
Although `utils.h` header is not included in the API of the library, it has a lot of useful utility functions.
When this file is included in a C++ project, there are certain conversion errors the compiler is complaining about.
This PR fixes them.

```shell
/picotls/t/util.h: In function ‘int util_save_ticket_cb(ptls_save_ticket_t*, ptls_t*, ptls_iovec_t)’:
/picotls/t/util.h:91:42: error: invalid conversion from ‘void*’ to ‘st_util_save_ticket_t*’ [-fpermissive]
     struct st_util_save_ticket_t *self = (void *)_self;
                                          ^~~~~~~~~~~~~
/picotls/t/util.h: In function ‘void setup_esni(ptls_context_t*, const char*, ptls_key_exchange_context_t**)’:
/picotls/t/util.h:183:28: error: invalid conversion from ‘void*’ to ‘ptls_esni_context_t** {aka st_ptls_esni_context_t**}’ [-fpermissive]
     if ((ctx->esni = malloc(sizeof(*ctx->esni) * 2)) == NULL || (*ctx->esni = malloc(sizeof(**ctx->esni))) == NULL) {
                      ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
/picotls/t/util.h:183:85: error: invalid conversion from ‘void*’ to ‘ptls_esni_context_t* {aka st_ptls_esni_context_t*}’ [-fpermissive]
     if ((ctx->esni = malloc(sizeof(*ctx->esni) * 2)) == NULL || (*ctx->esni = malloc(sizeof(**ctx->esni))) == NULL) {
                                                                               ~~~~~~^~~~~~~~~~~~~~~~~~~~~
/picotls/t/util.h: In function ‘void log_event_cb(ptls_log_event_t*, ptls_t*, const char*, const char*, ...)’:
/picotls/t/util.h:201:40: error: invalid conversion from ‘void*’ to ‘st_util_log_event_t*’ [-fpermissive]
     struct st_util_log_event_t *self = (void *)_self;
                                        ^~~~~~~~~~~~~
/picotls/t/util.h: In function ‘int encrypt_ticket_cb(ptls_encrypt_ticket_t*, ptls_t*, int, ptls_buffer_t*, ptls_iovec_t)’:
/picotls/t/util.h:237:44: error: invalid conversion from ‘void*’ to ‘st_util_session_cache_t*’ [-fpermissive]
     struct st_util_session_cache_t *self = (void *)_self;
                                            ^~~~~~~~~~~~~
/picotls/t/util.h:244:38: error: invalid conversion from ‘void*’ to ‘uint8_t* {aka unsigned char*}’ [-fpermissive]
         if ((self->data.base = malloc(src.len)) == NULL)
                                ~~~~~~^~~~~~~~~

/picotls/t/util.h: In function ‘ptls_iovec_t resolve_esni_keys(const char*)’:
/picotls/t/util.h:340:40: error: invalid conversion from ‘const void*’ to ‘void*’ [-fpermissive]
     ptls_buffer_init(&decode_buf, "", 0);
                                        ^

/picotls/include/picotls.h:1430:13: note: initializing argument 2 of ‘void ptls_buffer_init(ptls_buffer_t*, void*, size_t)’
 inline void ptls_buffer_init(ptls_buffer_t *buf, void *smallbuf, size_t smallbuf_size)
             ^~~~~~~~~~~~~~~~
/picotls/t/util.h:352:14: error: invalid conversion from ‘void*’ to ‘char*’ [-fpermissive]
     base64 = (void *)ns_rr_rdata(rr);
              ^
/picotls/t/util.h:353:24: error: invalid conversion from ‘void*’ to ‘uint8_t* {aka unsigned char*}’ [-fpermissive]
     if (!normalize_txt((void *)base64, ns_rr_rdlen(rr)))
                        ^~~~~~~~~~~~~~
/picotls/t/util.h:310:19: note:   initializing argument 1 of ‘int normalize_txt(uint8_t*, size_t)’
 static inline int normalize_txt(uint8_t *p, size_t len)
                   ^~~~~~~~~~~~~
```