### PR TITLE
More compatible with Windows

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -27,7 +27,7 @@ extern "C" {
 #endif
 
 #ifdef _WINDOWS
-#include "wincompat.h"
+#include "winsock.h"
 #endif
 
 #include <assert.h>

--- a/lib/fusion.c
+++ b/lib/fusion.c
@@ -38,7 +38,9 @@
  * IN THE SOFTWARE.
  */
 #include <stdint.h>
-
+#ifdef _WINDOWS
+#include <intrin.h>
+#endif
 #include <stdlib.h>
 #include <string.h>
 #include <immintrin.h>

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -25,7 +25,9 @@
 #include <stdlib.h>
 #include <string.h>
 #ifdef _WINDOWS
-#include "wincompat.h"
+#include <ws2tcpip.h>
+#include <winsock.h>
+#include <winsock2.h>
 #else
 #include <arpa/inet.h>
 #include <sys/time.h>
@@ -110,6 +112,36 @@
 #else
 #define PTLS_PROBE0(LABEL, tls)
 #define PTLS_PROBE(LABEL, tls, ...)
+#endif
+
+#ifdef _WINDOWS
+//Copy from https://www.man7.org/linux/man-pages/man2/gettimeofday.2.html
+struct timezone {
+               int tz_minuteswest;     /* minutes west of Greenwich */
+               int tz_dsttime;         /* type of DST correction */
+    };
+
+int gettimeofday(struct timeval * tp, struct timezone * tzp)
+{
+    // Copy from https://stackoverflow.com/questions/10905892/equivalent-of-gettimeday-for-windows
+    // Note: some broken versions only have 8 trailing zero's, the correct epoch has 9 trailing zero's
+    // This magic number is the number of 100 nanosecond intervals since January 1, 1601 (UTC)
+    // until 00:00:00 January 1, 1970 
+    static const uint64_t EPOCH = ((uint64_t) 116444736000000000ULL);
+
+    SYSTEMTIME  system_time;
+    FILETIME    file_time;
+    uint64_t    time;
+
+    GetSystemTime( &system_time );
+    SystemTimeToFileTime( &system_time, &file_time );
+    time =  ((uint64_t)file_time.dwLowDateTime )      ;
+    time += ((uint64_t)file_time.dwHighDateTime) << 32;
+
+    tp->tv_sec  = (long) ((time - EPOCH) / 10000000L);
+    tp->tv_usec = (long) (system_time.wMilliseconds * 1000);
+    return 0;
+}
 #endif
 
 /**


### PR DESCRIPTION
This changes a few bits of the code to make the library compatible with Windows. It changes some included header files to point to the Windows equivalents, as well as adding some more definitions that are not avaliable on Windows that should act as a drop-in replacement for their POSIX equivalents.