### PR TITLE
Fix build errors

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -1371,10 +1371,6 @@ extern void (*volatile ptls_clear_memory)(void *p, size_t len);
  */
 extern int (*volatile ptls_mem_equal)(const void *x, const void *y, size_t len);
 /**
- *
- */
-static ptls_iovec_t ptls_iovec_init(const void *p, size_t len);
-/**
  * checks if a server name is an IP address.
  */
 int ptls_server_name_is_ipaddr(const char *name);
@@ -1404,7 +1400,7 @@ char *ptls_hexdump(char *dst, const void *src, size_t len);
  * the default get_time callback
  */
 extern ptls_get_time_t ptls_get_time;
-#if PICOTLS_USE_DTRACE
+#if defined(PICOTLS_USE_DTRACE) && PICOTLS_USE_DTRACE
 /**
  *
  */
@@ -1443,7 +1439,7 @@ inline void ptls_buffer_init(ptls_buffer_t *buf, void *smallbuf, size_t smallbuf
 inline void ptls_buffer_dispose(ptls_buffer_t *buf)
 {
     ptls_buffer__release_memory(buf);
-    *buf = (ptls_buffer_t){NULL};
+    *buf = (ptls_buffer_t){NULL, 0, 0, 0};
 }
 
 inline uint8_t *ptls_encode_quicint(uint8_t *p, uint64_t v)


### PR DESCRIPTION
From gcc:
- error: redundant redeclaration of ‘ptls_iovec_init’ [-Werror=redundant-decls]
- error: "PICOTLS_USE_DTRACE" is not defined, evaluates to 0 [-Werror=undef]

From clang:
- missing field 'off' initializer [-Werror,-Wmissing-field-initializers]