### PR TITLE
non-temporal aes-gcm engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         include:
           - name: "Linux / OpenSSL 1.1.0"
-            command: make -f misc/docker-ci.mk CMAKE_ARGS='-DOPENSSL_ROOT_DIR=-DOPENSSL_ROOT_DIR=/opt/openssl-1.1.0' CONTAINER_NAME='h2oserver/h2o-ci:ubuntu1604'
+            command: make -f misc/docker-ci.mk CMAKE_ARGS='-DOPENSSL_ROOT_DIR=-DOPENSSL_ROOT_DIR=/opt/openssl-1.1.0 -DWITH_FUSION=OFF' CONTAINER_NAME='h2oserver/h2o-ci:ubuntu1604'
           - name: "Linux / OpenSSL 1.1.1"
             command: make -f misc/docker-ci.mk
           - name: "Linux / OpenSSL 1.1.1 + ASan & UBSan"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,14 +148,14 @@ ENDIF ()
 
 IF (WITH_FUSION)
     ADD_LIBRARY(picotls-fusion lib/fusion.c)
-    SET_TARGET_PROPERTIES(picotls-fusion PROPERTIES COMPILE_FLAGS "-mavx2 -maes -mpclmul")
+    SET_TARGET_PROPERTIES(picotls-fusion PROPERTIES COMPILE_FLAGS "-mavx2 -maes -mpclmul -mvaes -mvpclmulqdq")
     TARGET_LINK_LIBRARIES(picotls-fusion picotls-core)
     ADD_EXECUTABLE(test-fusion.t
         deps/picotest/picotest.c
         lib/picotls.c
         t/fusion.c)
     TARGET_LINK_LIBRARIES(test-fusion.t picotls-minicrypto)
-    SET_TARGET_PROPERTIES(test-fusion.t PROPERTIES COMPILE_FLAGS "-mavx2 -maes -mpclmul")
+    SET_TARGET_PROPERTIES(test-fusion.t PROPERTIES COMPILE_FLAGS "-mavx2 -maes -mpclmul -mvaes -mvpclmulqdq")
     IF (WITH_DTRACE)
         ADD_DEPENDENCIES(test-fusion.t generate-picotls-probes)
     ENDIF ()

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -70,6 +70,10 @@ extern "C" {
 #define PTLS_FUZZ_HANDSHAKE 0
 #endif
 
+#ifndef PTLS_SIZEOF_CACHE_LINE
+#define PTLS_SIZEOF_CACHE_LINE 64
+#endif
+
 #define PTLS_HELLO_RANDOM_SIZE 32
 
 #define PTLS_AES128_KEY_SIZE 16

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -397,6 +397,10 @@ typedef const struct st_ptls_aead_algorithm_t {
      */
     size_t tag_size;
     /**
+     * if encrypted bytes are going to be written using non-temporal store instructions (i.e., skip cache)
+     */
+    unsigned non_temporal : 1;
+    /**
      * size of memory allocated for ptls_aead_context_t. AEAD implementations can set this value to something greater than
      * sizeof(ptls_aead_context_t) and stuff additional data at the bottom of the struct.
      */

--- a/include/picotls/fusion.h
+++ b/include/picotls/fusion.h
@@ -86,6 +86,7 @@ int ptls_fusion_aesgcm_decrypt(ptls_fusion_aesgcm_context_t *ctx, void *output, 
 
 extern ptls_cipher_algorithm_t ptls_fusion_aes128ctr, ptls_fusion_aes256ctr;
 extern ptls_aead_algorithm_t ptls_fusion_aes128gcm, ptls_fusion_aes256gcm;
+extern ptls_aead_algorithm_t ptls_fastls_aes128gcm, ptls_fastls_aes256gcm;
 
 /**
  * Returns a boolean indicating if fusion can be used.

--- a/include/picotls/fusion.h
+++ b/include/picotls/fusion.h
@@ -40,7 +40,7 @@ typedef struct ptls_fusion_aesecb_context {
         __m256i m256[PTLS_FUSION_AES256_ROUNDS + 1];
     } keys;
     unsigned rounds;
-    uint8_t avx256;
+    uint8_t aesni256;
 } __attribute__((aligned(32))) ptls_fusion_aesecb_context_t;
 
 typedef struct ptls_fusion_aesgcm_context ptls_fusion_aesgcm_context_t;
@@ -94,7 +94,7 @@ int ptls_fusion_aesgcm_decrypt(ptls_fusion_aesgcm_context_t *ctx, void *output, 
  * when `ptls_fusion_is_supported_by_cpu` is called. Users can update the flag to enforce behavior. Engines that do not have support
  * for these 256-bit instructions will continue using the 128-bit ones, even when this flag is set.
  */
-extern int ptls_fusion_can_avx256;
+extern int ptls_fusion_can_aesni256;
 extern ptls_cipher_algorithm_t ptls_fusion_aes128ctr, ptls_fusion_aes256ctr;
 extern ptls_aead_algorithm_t ptls_fusion_aes128gcm, ptls_fusion_aes256gcm;
 extern ptls_aead_algorithm_t ptls_non_temporal_aes128gcm, ptls_non_temporal_aes256gcm;

--- a/include/picotls/fusion.h
+++ b/include/picotls/fusion.h
@@ -97,7 +97,7 @@ int ptls_fusion_aesgcm_decrypt(ptls_fusion_aesgcm_context_t *ctx, void *output, 
 extern int ptls_fusion_can_avx256;
 extern ptls_cipher_algorithm_t ptls_fusion_aes128ctr, ptls_fusion_aes256ctr;
 extern ptls_aead_algorithm_t ptls_fusion_aes128gcm, ptls_fusion_aes256gcm;
-extern ptls_aead_algorithm_t ptls_fastls_aes128gcm, ptls_fastls_aes256gcm;
+extern ptls_aead_algorithm_t ptls_non_temporal_aes128gcm, ptls_non_temporal_aes256gcm;
 
 /**
  * Returns a boolean indicating if fusion can be used.

--- a/include/picotls/fusion.h
+++ b/include/picotls/fusion.h
@@ -28,19 +28,24 @@ extern "C" {
 
 #include <stddef.h>
 #include <emmintrin.h>
+#include <immintrin.h>
 #include "../picotls.h"
 
 #define PTLS_FUSION_AES128_ROUNDS 10
 #define PTLS_FUSION_AES256_ROUNDS 14
 
 typedef struct ptls_fusion_aesecb_context {
-    __m128i keys[PTLS_FUSION_AES256_ROUNDS + 1];
+    union {
+        __m128i m128[PTLS_FUSION_AES256_ROUNDS + 1];
+        __m256i m256[PTLS_FUSION_AES256_ROUNDS + 1];
+    } keys;
     unsigned rounds;
-} ptls_fusion_aesecb_context_t;
+    uint8_t avx256;
+} __attribute__((aligned(32))) ptls_fusion_aesecb_context_t;
 
 typedef struct ptls_fusion_aesgcm_context ptls_fusion_aesgcm_context_t;
 
-void ptls_fusion_aesecb_init(ptls_fusion_aesecb_context_t *ctx, int is_enc, const void *key, size_t key_size);
+void ptls_fusion_aesecb_init(ptls_fusion_aesecb_context_t *ctx, int is_enc, const void *key, size_t key_size, int avx256);
 void ptls_fusion_aesecb_dispose(ptls_fusion_aesecb_context_t *ctx);
 void ptls_fusion_aesecb_encrypt(ptls_fusion_aesecb_context_t *ctx, void *dst, const void *src);
 
@@ -84,6 +89,12 @@ void ptls_fusion_aesgcm_encrypt(ptls_fusion_aesgcm_context_t *ctx, void *output,
 int ptls_fusion_aesgcm_decrypt(ptls_fusion_aesgcm_context_t *ctx, void *output, const void *input, size_t inlen, __m128i ctr,
                                const void *aad, size_t aadlen, const void *tag);
 
+/**
+ * A boolean flag indicating if vaes and vpclmulqdq (256-bit crypto instructions) should be used. This flag is set automatically
+ * when `ptls_fusion_is_supported_by_cpu` is called. Users can update the flag to enforce behavior. Engines that do not have support
+ * for these 256-bit instructions will continue using the 128-bit ones, even when this flag is set.
+ */
+extern int ptls_fusion_can_avx256;
 extern ptls_cipher_algorithm_t ptls_fusion_aes128ctr, ptls_fusion_aes256ctr;
 extern ptls_aead_algorithm_t ptls_fusion_aes128gcm, ptls_fusion_aes256gcm;
 extern ptls_aead_algorithm_t ptls_fastls_aes128gcm, ptls_fastls_aes256gcm;

--- a/lib/cifra/aes128.c
+++ b/lib/cifra/aes128.c
@@ -55,6 +55,7 @@ ptls_aead_algorithm_t ptls_minicrypto_aes128gcm = {"AES128-GCM",
                                                    PTLS_AES128_KEY_SIZE,
                                                    PTLS_AESGCM_IV_SIZE,
                                                    PTLS_AESGCM_TAG_SIZE,
+                                                   0,
                                                    sizeof(struct aesgcm_context_t),
                                                    aead_aes128gcm_setup_crypto};
 ptls_cipher_suite_t ptls_minicrypto_aes128gcmsha256 = {.id = PTLS_CIPHER_SUITE_AES_128_GCM_SHA256,

--- a/lib/cifra/aes256.c
+++ b/lib/cifra/aes256.c
@@ -55,6 +55,7 @@ ptls_aead_algorithm_t ptls_minicrypto_aes256gcm = {"AES256-GCM",
                                                    PTLS_AES256_KEY_SIZE,
                                                    PTLS_AESGCM_IV_SIZE,
                                                    PTLS_AESGCM_TAG_SIZE,
+                                                   0,
                                                    sizeof(struct aesgcm_context_t),
                                                    aead_aes256gcm_setup_crypto};
 ptls_cipher_suite_t ptls_minicrypto_aes256gcmsha384 = {.id = PTLS_CIPHER_SUITE_AES_256_GCM_SHA384,

--- a/lib/cifra/chacha20.c
+++ b/lib/cifra/chacha20.c
@@ -226,6 +226,7 @@ ptls_aead_algorithm_t ptls_minicrypto_chacha20poly1305 = {"CHACHA20-POLY1305",
                                                           PTLS_CHACHA20_KEY_SIZE,
                                                           PTLS_CHACHA20POLY1305_IV_SIZE,
                                                           PTLS_CHACHA20POLY1305_TAG_SIZE,
+                                                          0,
                                                           sizeof(struct chacha20poly1305_context_t),
                                                           aead_chacha20poly1305_setup_crypto};
 ptls_cipher_suite_t ptls_minicrypto_chacha20poly1305sha256 = {.id = PTLS_CIPHER_SUITE_CHACHA20_POLY1305_SHA256,

--- a/lib/fusion.c
+++ b/lib/fusion.c
@@ -1221,6 +1221,7 @@ ptls_aead_algorithm_t ptls_fusion_aes128gcm = {"AES128-GCM",
                                                PTLS_AES128_KEY_SIZE,
                                                PTLS_AESGCM_IV_SIZE,
                                                PTLS_AESGCM_TAG_SIZE,
+                                               0,
                                                sizeof(struct aesgcm_context),
                                                aes128gcm_setup};
 ptls_aead_algorithm_t ptls_fusion_aes256gcm = {"AES256-GCM",
@@ -1231,6 +1232,7 @@ ptls_aead_algorithm_t ptls_fusion_aes256gcm = {"AES256-GCM",
                                                PTLS_AES256_KEY_SIZE,
                                                PTLS_AESGCM_IV_SIZE,
                                                PTLS_AESGCM_TAG_SIZE,
+                                               0,
                                                sizeof(struct aesgcm_context),
                                                aes256gcm_setup};
 
@@ -2132,6 +2134,7 @@ ptls_aead_algorithm_t ptls_non_temporal_aes128gcm = {"AES128-GCM",
                                                      PTLS_AES128_KEY_SIZE,
                                                      PTLS_AESGCM_IV_SIZE,
                                                      PTLS_AESGCM_TAG_SIZE,
+                                                     1,
                                                      sizeof(struct aesgcm_context),
                                                      non_temporal_aes128gcm_setup};
 ptls_aead_algorithm_t ptls_non_temporal_aes256gcm = {"AES256-GCM",
@@ -2142,6 +2145,7 @@ ptls_aead_algorithm_t ptls_non_temporal_aes256gcm = {"AES256-GCM",
                                                      PTLS_AES256_KEY_SIZE,
                                                      PTLS_AESGCM_IV_SIZE,
                                                      PTLS_AESGCM_TAG_SIZE,
+                                                     1,
                                                      sizeof(struct aesgcm_context),
                                                      non_temporal_aes256gcm_setup};
 

--- a/lib/fusion.c
+++ b/lib/fusion.c
@@ -1221,7 +1221,7 @@ static void fastls_encrypt_v(struct st_ptls_aead_context_t *_ctx, void *_output,
                 /* slow path, load at most 6 * 16 bytes to encbuf then encrypt in-place */
                 size_t bytes_copied = 0;
                 do {
-                    if (srclen >= 16 && bytes_copied < 5 * 80) {
+                    if (srclen >= 16 && bytes_copied < 5 * 16) {
                         _mm_storeu_si128((void *)(encp + bytes_copied), _mm_loadu_si128((void *)src));
                         bytes_copied += 16;
                         src += 16;

--- a/lib/fusion.c
+++ b/lib/fusion.c
@@ -1108,15 +1108,11 @@ static void fastls_encrypt_v(struct st_ptls_aead_context_t *_ctx, void *output, 
     int32_t state = 0;
 
     /* Bytes are written here first then written using NT store instructions, 64 bytes at a time. */
-    char encbuf[32 * 6 /* >= 64 + 6 * 16 + 16 */] __attribute__((aligned(32))), *encp;
+    char encbuf[32 * 6] __attribute__((aligned(32))), *encp;
 
     /* `encbuf` should be large enough to store up to 63-bytes of unaligned bytes, 6 16-byte AES blocks, plus AEAD tag that is
      * append to the ciphertext before writing the bytes to main memory using NT store instructions. */
     PTLS_BUILD_ASSERT(sizeof(encbuf) >= 64 + 6 * 16 + 16);
-
-    /* clear encbuf to suppress UB warning */
-    for (size_t i = 0; i < sizeof(encbuf) / 32; i += 32)
-        _mm256_store_si256((void *)encbuf + i, _mm256_setzero_si256());
 
     /* determine `num_bytes_write_delayed` as well as initializing `encbuf`, adjusting `output` */
     if ((encp = encbuf + ((uintptr_t)output & 63)) != encbuf) {

--- a/lib/fusion.c
+++ b/lib/fusion.c
@@ -1298,6 +1298,7 @@ static inline void write_remaining_bytes(uint8_t *dst, const uint8_t *src, const
     }
 }
 
+NO_SANITIZE_ADDRESS
 static void non_temporal_encrypt_v128(struct st_ptls_aead_context_t *_ctx, void *_output, ptls_iovec_t *input, size_t incnt,
                                       uint64_t seq, const void *aad, size_t aadlen)
 {

--- a/lib/fusion.c
+++ b/lib/fusion.c
@@ -63,20 +63,22 @@ struct ptls_fusion_aesgcm_context {
     ptls_fusion_aesecb_context_t ecb;
     size_t capacity;
     size_t ghash_cnt;
-    struct ptls_fusion_aesgcm_ghash_precompute128 {
-        __m128i H;
-        __m128i r;
-    } ghash128[0];
-    union ptls_fusion_aesgcm_ghash_precompute256 {
-        struct {
-            __m128i H[2];
-            __m128i r[2];
-        };
-        struct {
-            __m256i Hx2;
-            __m256i rx2;
-        };
-    } ghash256[0];
+    union {
+        struct ptls_fusion_aesgcm_ghash_precompute128 {
+            __m128i H;
+            __m128i r;
+        } ghash128[0];
+        union ptls_fusion_aesgcm_ghash_precompute256 {
+            struct {
+                __m128i H[2];
+                __m128i r[2];
+            };
+            struct {
+                __m256i Hx2;
+                __m256i rx2;
+            };
+        } ghash256[0];
+    };
 };
 
 struct ctr_context {

--- a/lib/fusion.c
+++ b/lib/fusion.c
@@ -63,10 +63,20 @@ struct ptls_fusion_aesgcm_context {
     ptls_fusion_aesecb_context_t ecb;
     size_t capacity;
     size_t ghash_cnt;
-    struct ptls_fusion_aesgcm_ghash_precompute {
+    struct ptls_fusion_aesgcm_ghash_precompute128 {
         __m128i H;
         __m128i r;
-    } ghash[0];
+    } ghash128[0];
+    union ptls_fusion_aesgcm_ghash_precompute256 {
+        struct {
+            __m128i H[2];
+            __m128i r[2];
+        };
+        struct {
+            __m256i Hx2;
+            __m256i rx2;
+        };
+    } ghash256[0];
 };
 
 struct ctr_context {
@@ -87,10 +97,14 @@ struct aesgcm_context {
 
 static const uint64_t poly_[2] __attribute__((aligned(16))) = {1, 0xc200000000000000};
 #define poly (*(__m128i *)poly_)
-static const uint8_t bswap8_[16] __attribute__((aligned(16))) = {15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
-#define bswap8 (*(__m128i *)bswap8_)
-static const uint8_t one8_[16] __attribute__((aligned(16))) = {1};
-#define one8 (*(__m128i *)one8_)
+static const uint8_t byteswap_[32] __attribute__((aligned(32))) = {15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0,
+                                                                   15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
+#define byteswap128 (*(__m128i *)byteswap_)
+#define byteswap256 (*(__m256i *)byteswap_)
+static const uint8_t one_[16] __attribute__((aligned(16))) = {1};
+#define one8 (*(__m128i *)one_)
+static const uint8_t incr128x2_[32] __attribute__((aligned(32))) = {2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2};
+#define incr128x2 (*(__m256i *)incr128x2_)
 
 /* This function is covered by the Apache License and the MIT License. The origin is crypto/modes/asm/ghash-x86_64.pl of openssl
  * at commit 33388b4. */
@@ -155,12 +169,31 @@ static __m128i gfmul(__m128i x, __m128i y)
     return _mm_xor_si128(hi, lo);
 }
 
-struct ptls_fusion_gfmul_state {
+static inline __m128i gfmul_do_reduce(__m128i hi, __m128i lo, __m128i mid)
+{
+    mid = _mm_xor_si128(mid, hi);
+    mid = _mm_xor_si128(mid, lo);
+    lo = _mm_xor_si128(lo, _mm_slli_si128(mid, 8));
+    hi = _mm_xor_si128(hi, _mm_srli_si128(mid, 8));
+
+    /* fast reduction, using https://crypto.stanford.edu/RealWorldCrypto/slides/gueron.pdf */
+    __m128i r = _mm_clmulepi64_si128(lo, poly, 0x10);
+    lo = _mm_shuffle_epi32(lo, 78);
+    lo = _mm_xor_si128(lo, r);
+    r = _mm_clmulepi64_si128(lo, poly, 0x10);
+    lo = _mm_shuffle_epi32(lo, 78);
+    lo = _mm_xor_si128(lo, r);
+    lo = _mm_xor_si128(hi, lo);
+
+    return lo;
+}
+
+struct ptls_fusion_gfmul_state128 {
     __m128i hi, lo, mid;
 };
 
-static inline void gfmul_do_step(struct ptls_fusion_gfmul_state *gstate, __m128i X,
-                                 struct ptls_fusion_aesgcm_ghash_precompute *precompute)
+static inline void gfmul_do_step128(struct ptls_fusion_gfmul_state128 *gstate, __m128i X,
+                                    struct ptls_fusion_aesgcm_ghash_precompute128 *precompute)
 {
     __m128i t = _mm_clmulepi64_si128(precompute->H, X, 0x00);
     gstate->lo = _mm_xor_si128(gstate->lo, t);
@@ -172,86 +205,159 @@ static inline void gfmul_do_step(struct ptls_fusion_gfmul_state *gstate, __m128i
     gstate->mid = _mm_xor_si128(gstate->mid, t);
 }
 
-static inline void gfmul_firststep(struct ptls_fusion_gfmul_state *gstate, __m128i X,
-                                   struct ptls_fusion_aesgcm_ghash_precompute *precompute)
+static inline void gfmul_firststep128(struct ptls_fusion_gfmul_state128 *gstate, __m128i X,
+                                      struct ptls_fusion_aesgcm_ghash_precompute128 *precompute)
 {
-    X = _mm_shuffle_epi8(X, bswap8);
+    X = _mm_shuffle_epi8(X, byteswap128);
     X = _mm_xor_si128(gstate->lo, X);
     gstate->lo = _mm_setzero_si128();
     gstate->hi = _mm_setzero_si128();
     gstate->mid = _mm_setzero_si128();
-    gfmul_do_step(gstate, X, precompute);
+    gfmul_do_step128(gstate, X, precompute);
 }
 
-static inline void gfmul_nextstep(struct ptls_fusion_gfmul_state *gstate, __m128i X,
-                                  struct ptls_fusion_aesgcm_ghash_precompute *precompute)
+static inline void gfmul_nextstep128(struct ptls_fusion_gfmul_state128 *gstate, __m128i X,
+                                     struct ptls_fusion_aesgcm_ghash_precompute128 *precompute)
 {
-    X = _mm_shuffle_epi8(X, bswap8);
-    gfmul_do_step(gstate, X, precompute);
+    X = _mm_shuffle_epi8(X, byteswap128);
+    gfmul_do_step128(gstate, X, precompute);
 }
 
-static inline void gfmul_reduce(struct ptls_fusion_gfmul_state *gstate)
+static inline void gfmul_reduce128(struct ptls_fusion_gfmul_state128 *gstate)
 {
-    /* finish multiplication */
-    gstate->mid = _mm_xor_si128(gstate->mid, gstate->hi);
-    gstate->mid = _mm_xor_si128(gstate->mid, gstate->lo);
-    gstate->lo = _mm_xor_si128(gstate->lo, _mm_slli_si128(gstate->mid, 8));
-    gstate->hi = _mm_xor_si128(gstate->hi, _mm_srli_si128(gstate->mid, 8));
-
-    /* fast reduction, using https://crypto.stanford.edu/RealWorldCrypto/slides/gueron.pdf */
-    __m128i r = _mm_clmulepi64_si128(gstate->lo, poly, 0x10);
-    gstate->lo = _mm_shuffle_epi32(gstate->lo, 78);
-    gstate->lo = _mm_xor_si128(gstate->lo, r);
-    r = _mm_clmulepi64_si128(gstate->lo, poly, 0x10);
-    gstate->lo = _mm_shuffle_epi32(gstate->lo, 78);
-    gstate->lo = _mm_xor_si128(gstate->lo, r);
-    gstate->lo = _mm_xor_si128(gstate->hi, gstate->lo);
+    gstate->lo = gfmul_do_reduce(gstate->hi, gstate->lo, gstate->mid);
 }
 
-static inline __m128i gfmul_get_tag(struct ptls_fusion_gfmul_state *gstate, __m128i ek0)
+static inline __m128i gfmul_get_tag128(struct ptls_fusion_gfmul_state128 *gstate, __m128i ek0)
 {
-    __m128i tag = _mm_shuffle_epi8(gstate->lo, bswap8);
+    __m128i tag = _mm_shuffle_epi8(gstate->lo, byteswap128);
+    tag = _mm_xor_si128(tag, ek0);
+    return tag;
+}
+
+struct ptls_fusion_gfmul_state256 {
+    __m256i hi, lo, mid;
+};
+
+static inline void gfmul_do_step256(struct ptls_fusion_gfmul_state256 *gstate, __m256i X,
+                                    union ptls_fusion_aesgcm_ghash_precompute256 *precompute)
+{
+    __m256i t = _mm256_clmulepi64_epi128(precompute->Hx2, X, 0x00);
+    gstate->lo = _mm256_xor_si256(gstate->lo, t);
+    t = _mm256_clmulepi64_epi128(precompute->Hx2, X, 0x11);
+    gstate->hi = _mm256_xor_si256(gstate->hi, t);
+    t = _mm256_shuffle_epi32(X, 78);
+    t = _mm256_xor_si256(t, X);
+    t = _mm256_clmulepi64_epi128(precompute->rx2, t, 0x00);
+    gstate->mid = _mm256_xor_si256(gstate->mid, t);
+}
+
+static inline void gfmul_firststep256(struct ptls_fusion_gfmul_state256 *gstate, __m256i X, int half,
+                                      union ptls_fusion_aesgcm_ghash_precompute256 *precompute)
+{
+    X = _mm256_shuffle_epi8(X, byteswap256);
+    X = _mm256_xor_si256(gstate->lo, X);
+    if (half)
+        X = _mm256_permute2f128_si256(X, X, 0x08);
+    gstate->lo = _mm256_setzero_si256();
+    gstate->hi = _mm256_setzero_si256();
+    gstate->mid = _mm256_setzero_si256();
+    gfmul_do_step256(gstate, X, precompute);
+}
+
+static inline void gfmul_nextstep256(struct ptls_fusion_gfmul_state256 *gstate, __m256i X,
+                                     union ptls_fusion_aesgcm_ghash_precompute256 *precompute)
+{
+    X = _mm256_shuffle_epi8(X, byteswap256);
+    gfmul_do_step256(gstate, X, precompute);
+}
+
+static inline void gfmul_reduce256(struct ptls_fusion_gfmul_state256 *gstate)
+{
+#define XOR_256TO128(y) _mm_xor_si128(_mm256_castsi256_si128(y), _mm256_extractf128_si256((y), 1))
+    __m128i hi = XOR_256TO128(gstate->hi);
+    __m128i lo = XOR_256TO128(gstate->lo);
+    __m128i mid = XOR_256TO128(gstate->mid);
+#undef XOR_256TO128
+
+    lo = gfmul_do_reduce(hi, lo, mid);
+    gstate->lo = _mm256_castsi128_si256(lo);
+}
+
+static inline __m128i gfmul_get_tag256(struct ptls_fusion_gfmul_state256 *gstate, __m128i ek0)
+{
+    __m128i tag = _mm_shuffle_epi8(_mm256_castsi256_si128(gstate->lo), byteswap128);
     tag = _mm_xor_si128(tag, ek0);
     return tag;
 }
 
 static inline __m128i aesecb_encrypt(ptls_fusion_aesecb_context_t *ctx, __m128i v)
 {
-    size_t i;
+#define ROUNDKEY(i) (ctx->avx256 ? _mm256_castsi256_si128(ctx->keys.m256[i]) : ctx->keys.m128[i])
 
-    v = _mm_xor_si128(v, ctx->keys[0]);
-    for (i = 1; i < ctx->rounds; ++i)
-        v = _mm_aesenc_si128(v, ctx->keys[i]);
-    v = _mm_aesenclast_si128(v, ctx->keys[i]);
+    v = _mm_xor_si128(v, ROUNDKEY(0));
+    for (size_t i = 1; i < ctx->rounds; ++i)
+        v = _mm_aesenc_si128(v, ROUNDKEY(i));
+    v = _mm_aesenclast_si128(v, ROUNDKEY(ctx->rounds));
 
     return v;
+
+#undef ROUNDKEY
 }
 
-static const uint8_t loadn_mask[31] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-                                       0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+// 32-bytes of 0xff followed by 31-bytes of 0x00
+static const uint8_t loadn_mask[63] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                                       0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+                                       0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 static const uint8_t loadn_shuffle[31] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
                                           0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, // first 16 bytes map to byte offsets
                                           0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80,
                                           0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80}; // latter 15 bytes map to zero
 
 NO_SANITIZE_ADDRESS
-static inline __m128i loadn(const void *p, size_t l)
+static inline __m128i loadn_end_of_page(const void *p, size_t l)
 {
-    __m128i v, mask = _mm_loadu_si128((__m128i *)(loadn_mask + 16 - l));
+    uintptr_t shift = (uintptr_t)p & 15;
+    __m128i pattern = _mm_loadu_si128((const __m128i *)(loadn_shuffle + shift));
+    return _mm_shuffle_epi8(_mm_load_si128((const __m128i *)((uintptr_t)p - shift)), pattern);
+}
+
+static inline __m128i loadn128(const void *p, size_t l)
+{
+    __m128i v, mask = _mm_loadu_si128((__m128i *)(loadn_mask + 32 - l));
     uintptr_t mod4k = (uintptr_t)p % 4096;
 
-    if (PTLS_LIKELY(mod4k <= 4080) || mod4k + l > 4096) {
+    if (PTLS_LIKELY(mod4k <= 4096 - 16) || mod4k + l > 4096) {
         v = _mm_loadu_si128(p);
     } else {
-        uintptr_t shift = (uintptr_t)p & 15;
-        __m128i pattern = _mm_loadu_si128((const __m128i *)(loadn_shuffle + shift));
-        v = _mm_shuffle_epi8(_mm_load_si128((const __m128i *)((uintptr_t)p - shift)), pattern);
+        v = loadn_end_of_page(p, l);
     }
     v = _mm_and_si128(v, mask);
+
     return v;
 }
 
-static inline void storen(void *_p, size_t l, __m128i v)
+static inline __m256i loadn256(const void *p, size_t l)
+{
+    __m256i v, mask = _mm256_loadu_si256((__m256i *)(loadn_mask + 32 - l));
+    uintptr_t mod4k = (uintptr_t)p % 4096;
+
+    if (PTLS_LIKELY(mod4k < 4096 - 32) || mod4k + l > 4096) {
+        v = _mm256_loadu_si256(p);
+    } else if (l > 16) {
+        __m128i first16 = _mm_loadu_si128(p), second16 = loadn128((uint8_t *)(p + 16), l - 16);
+        v = _mm256_permute2f128_si256(_mm256_castsi128_si256(first16), _mm256_castsi128_si256(second16), 0x20);
+    } else if (l == 16) {
+        v = _mm256_castsi128_si256(_mm_loadu_si128(p));
+    } else {
+        v = _mm256_castsi128_si256(loadn_end_of_page(p, l));
+    }
+    v = _mm256_and_si256(v, mask);
+
+    return v;
+}
+
+static inline void storen128(void *_p, size_t l, __m128i v)
 {
     uint8_t buf[16], *p = _p;
 
@@ -268,18 +374,18 @@ void ptls_fusion_aesgcm_encrypt(ptls_fusion_aesgcm_context_t *ctx, void *output,
 #define AESECB6_INIT()                                                                                                             \
     do {                                                                                                                           \
         ctr = _mm_add_epi64(ctr, one8);                                                                                            \
-        bits0 = _mm_shuffle_epi8(ctr, bswap8);                                                                                     \
+        bits0 = _mm_shuffle_epi8(ctr, byteswap128);                                                                                \
         ctr = _mm_add_epi64(ctr, one8);                                                                                            \
-        bits1 = _mm_shuffle_epi8(ctr, bswap8);                                                                                     \
+        bits1 = _mm_shuffle_epi8(ctr, byteswap128);                                                                                \
         ctr = _mm_add_epi64(ctr, one8);                                                                                            \
-        bits2 = _mm_shuffle_epi8(ctr, bswap8);                                                                                     \
+        bits2 = _mm_shuffle_epi8(ctr, byteswap128);                                                                                \
         ctr = _mm_add_epi64(ctr, one8);                                                                                            \
-        bits3 = _mm_shuffle_epi8(ctr, bswap8);                                                                                     \
+        bits3 = _mm_shuffle_epi8(ctr, byteswap128);                                                                                \
         ctr = _mm_add_epi64(ctr, one8);                                                                                            \
-        bits4 = _mm_shuffle_epi8(ctr, bswap8);                                                                                     \
+        bits4 = _mm_shuffle_epi8(ctr, byteswap128);                                                                                \
         if (PTLS_LIKELY(srclen > 16 * 5)) {                                                                                        \
             ctr = _mm_add_epi64(ctr, one8);                                                                                        \
-            bits5 = _mm_shuffle_epi8(ctr, bswap8);                                                                                 \
+            bits5 = _mm_shuffle_epi8(ctr, byteswap128);                                                                            \
         } else {                                                                                                                   \
             if ((state & STATE_EK0_BEEN_FED) == 0) {                                                                               \
                 bits5 = ek0;                                                                                                       \
@@ -287,11 +393,11 @@ void ptls_fusion_aesgcm_encrypt(ptls_fusion_aesgcm_context_t *ctx, void *output,
             }                                                                                                                      \
             if ((state & STATE_SUPP_USED) != 0 && srclen <= 16 * 4 && (const __m128i *)supp->input + 1 <= dst_ghash) {             \
                 bits4 = _mm_loadu_si128(supp->input);                                                                              \
-                bits4keys = ((struct ctr_context *)supp->ctx)->fusion.keys;                                                        \
+                bits4keys = ((struct ctr_context *)supp->ctx)->fusion.keys.m128;                                                   \
                 state |= STATE_SUPP_IN_PROCESS;                                                                                    \
             }                                                                                                                      \
         }                                                                                                                          \
-        __m128i k = ctx->ecb.keys[0];                                                                                              \
+        __m128i k = ctx->ecb.keys.m128[0];                                                                                         \
         bits0 = _mm_xor_si128(bits0, k);                                                                                           \
         bits1 = _mm_xor_si128(bits1, k);                                                                                           \
         bits2 = _mm_xor_si128(bits2, k);                                                                                           \
@@ -303,7 +409,7 @@ void ptls_fusion_aesgcm_encrypt(ptls_fusion_aesgcm_context_t *ctx, void *output,
 /* aes block update */
 #define AESECB6_UPDATE(i)                                                                                                          \
     do {                                                                                                                           \
-        __m128i k = ctx->ecb.keys[i];                                                                                              \
+        __m128i k = ctx->ecb.keys.m128[i];                                                                                         \
         bits0 = _mm_aesenc_si128(bits0, k);                                                                                        \
         bits1 = _mm_aesenc_si128(bits1, k);                                                                                        \
         bits2 = _mm_aesenc_si128(bits2, k);                                                                                        \
@@ -315,7 +421,7 @@ void ptls_fusion_aesgcm_encrypt(ptls_fusion_aesgcm_context_t *ctx, void *output,
 /* aesenclast */
 #define AESECB6_FINAL(i)                                                                                                           \
     do {                                                                                                                           \
-        __m128i k = ctx->ecb.keys[i];                                                                                              \
+        __m128i k = ctx->ecb.keys.m128[i];                                                                                         \
         bits0 = _mm_aesenclast_si128(bits0, k);                                                                                    \
         bits1 = _mm_aesenclast_si128(bits1, k);                                                                                    \
         bits2 = _mm_aesenclast_si128(bits2, k);                                                                                    \
@@ -325,10 +431,10 @@ void ptls_fusion_aesgcm_encrypt(ptls_fusion_aesgcm_context_t *ctx, void *output,
     } while (0)
 
     __m128i ek0, bits0, bits1, bits2, bits3, bits4, bits5 = _mm_setzero_si128();
-    const __m128i *bits4keys = ctx->ecb.keys; /* is changed to supp->ctx.keys when calcurating suppout */
-    struct ptls_fusion_gfmul_state gstate = {0};
+    const __m128i *bits4keys = ctx->ecb.keys.m128; /* is changed to supp->ctx.keys when calcurating suppout */
+    struct ptls_fusion_gfmul_state128 gstate = {0};
     __m128i gdatabuf[6];
-    __m128i ac = _mm_shuffle_epi8(_mm_set_epi32(0, (int)aadlen * 8, 0, (int)inlen * 8), bswap8);
+    __m128i ac = _mm_shuffle_epi8(_mm_set_epi32(0, (int)aadlen * 8, 0, (int)inlen * 8), byteswap128);
 
     // src and dst are updated after the chunk is processed
     const __m128i *src = input;
@@ -338,7 +444,7 @@ void ptls_fusion_aesgcm_encrypt(ptls_fusion_aesgcm_context_t *ctx, void *output,
     const __m128i *aad = _aad, *dst_ghash = dst;
     size_t dst_ghashlen = srclen;
 
-    struct ptls_fusion_aesgcm_ghash_precompute *ghash_precompute = ctx->ghash + (aadlen + 15) / 16 + (srclen + 15) / 16 + 1;
+    struct ptls_fusion_aesgcm_ghash_precompute128 *ghash_precompute = ctx->ghash128 + (aadlen + 15) / 16 + (srclen + 15) / 16 + 1;
 
 #define STATE_EK0_BEEN_FED 0x3
 #define STATE_EK0_INCOMPLETE 0x2
@@ -349,7 +455,7 @@ void ptls_fusion_aesgcm_encrypt(ptls_fusion_aesgcm_context_t *ctx, void *output,
 
     /* build counter */
     ctr = _mm_insert_epi32(ctr, 1, 0);
-    ek0 = _mm_shuffle_epi8(ctr, bswap8);
+    ek0 = _mm_shuffle_epi8(ctr, byteswap128);
 
     /* start preparing AES */
     AESECB6_INIT();
@@ -362,7 +468,7 @@ void ptls_fusion_aesgcm_encrypt(ptls_fusion_aesgcm_context_t *ctx, void *output,
         while (gdata_cnt < 6) {
             if (PTLS_LIKELY(aadlen < 16)) {
                 if (aadlen != 0) {
-                    gdatabuf[gdata_cnt++] = loadn(aad, aadlen);
+                    gdatabuf[gdata_cnt++] = loadn128(aad, aadlen);
                     aadlen = 0;
                 }
                 goto MainLoop;
@@ -379,7 +485,7 @@ MainLoop:
         size_t i;
         for (i = 2; i < gdata_cnt + 2; ++i) {
             AESECB6_UPDATE(i);
-            gfmul_nextstep(&gstate, _mm_loadu_si128(gdata++), --ghash_precompute);
+            gfmul_nextstep128(&gstate, _mm_loadu_si128(gdata++), --ghash_precompute);
         }
         for (; i < ctx->ecb.rounds; ++i)
             AESECB6_UPDATE(i);
@@ -429,7 +535,7 @@ MainLoop:
 #undef APPLY
                 goto ApplyEnd;
             ApplyRemainder:
-                storen(dst, srclen, _mm_xor_si128(loadn(src, srclen), bits0));
+                storen128(dst, srclen, _mm_xor_si128(loadn128(src, srclen), bits0));
                 dst = (__m128i *)((uint8_t *)dst + srclen);
                 srclen = 0;
             ApplyEnd:;
@@ -447,7 +553,7 @@ MainLoop:
             while (gdata_cnt < 6) {
                 if (aadlen < 16) {
                     if (aadlen != 0) {
-                        gdatabuf[gdata_cnt++] = loadn(aad, aadlen);
+                        gdatabuf[gdata_cnt++] = loadn128(aad, aadlen);
                         aadlen = 0;
                     }
                     goto GdataFillDST;
@@ -467,7 +573,7 @@ MainLoop:
             while (gdata_cnt < 6) {
                 if (dst_ghashlen < 16) {
                     if (dst_ghashlen != 0) {
-                        gdatabuf[gdata_cnt++] = loadn(dst_ghash, dst_ghashlen);
+                        gdatabuf[gdata_cnt++] = loadn128(dst_ghash, dst_ghashlen);
                         dst_ghashlen = 0;
                     }
                     if (gdata_cnt < 6)
@@ -490,16 +596,16 @@ Finish:
      */
     assert(STATE_EK0_READY());
     for (size_t i = 0; i < gdata_cnt; ++i)
-        gfmul_nextstep(&gstate, gdatabuf[i], --ghash_precompute);
+        gfmul_nextstep128(&gstate, gdatabuf[i], --ghash_precompute);
 
-    gfmul_reduce(&gstate);
-    _mm_storeu_si128(dst, gfmul_get_tag(&gstate, ek0));
+    gfmul_reduce128(&gstate);
+    _mm_storeu_si128(dst, gfmul_get_tag128(&gstate, ek0));
 
     /* Finish the calculation of supplemental vector. Done at the very last, because the sample might cover the GCM tag. */
     if ((state & STATE_SUPP_USED) != 0) {
         size_t i;
         if ((state & STATE_SUPP_IN_PROCESS) == 0) {
-            bits4keys = ((struct ctr_context *)supp->ctx)->fusion.keys;
+            bits4keys = ((struct ctr_context *)supp->ctx)->fusion.keys.m128;
             bits4 = _mm_xor_si128(_mm_loadu_si128(supp->input), bits4keys[0]);
             i = 1;
         } else {
@@ -525,10 +631,10 @@ int ptls_fusion_aesgcm_decrypt(ptls_fusion_aesgcm_context_t *ctx, void *output, 
 {
     __m128i ek0 = _mm_setzero_si128(), bits0, bits1 = _mm_setzero_si128(), bits2 = _mm_setzero_si128(), bits3 = _mm_setzero_si128(),
             bits4 = _mm_setzero_si128(), bits5 = _mm_setzero_si128();
-    struct ptls_fusion_gfmul_state gstate = {0};
+    struct ptls_fusion_gfmul_state128 gstate = {0};
     __m128i gdatabuf[6];
-    __m128i ac = _mm_shuffle_epi8(_mm_set_epi32(0, (int)aadlen * 8, 0, (int)inlen * 8), bswap8);
-    struct ptls_fusion_aesgcm_ghash_precompute *ghash_precompute = ctx->ghash + (aadlen + 15) / 16 + (inlen + 15) / 16 + 1;
+    __m128i ac = _mm_shuffle_epi8(_mm_set_epi32(0, (int)aadlen * 8, 0, (int)inlen * 8), byteswap128);
+    struct ptls_fusion_aesgcm_ghash_precompute128 *ghash_precompute = ctx->ghash128 + (aadlen + 15) / 16 + (inlen + 15) / 16 + 1;
 
     const __m128i *gdata; // points to the elements fed into GHASH
     size_t gdata_cnt;
@@ -539,7 +645,7 @@ int ptls_fusion_aesgcm_decrypt(ptls_fusion_aesgcm_context_t *ctx, void *output, 
 
     /* schedule ek0 and suppkey */
     ctr = _mm_add_epi64(ctr, one8);
-    bits0 = _mm_xor_si128(_mm_shuffle_epi8(ctr, bswap8), ctx->ecb.keys[0]);
+    bits0 = _mm_xor_si128(_mm_shuffle_epi8(ctr, byteswap128), ctx->ecb.keys.m128[0]);
     ++nondata_aes_cnt;
 
 #define STATE_IS_FIRST_RUN 0x1
@@ -556,7 +662,7 @@ int ptls_fusion_aesgcm_decrypt(ptls_fusion_aesgcm_context_t *ctx, void *output, 
             while (gdata_cnt < 6) {
                 if (aadlen < 16) {
                     if (aadlen != 0) {
-                        gdatabuf[gdata_cnt++] = loadn(aad, aadlen);
+                        gdatabuf[gdata_cnt++] = loadn128(aad, aadlen);
                         aadlen = 0;
                         ++nondata_aes_cnt;
                     }
@@ -578,7 +684,7 @@ int ptls_fusion_aesgcm_decrypt(ptls_fusion_aesgcm_context_t *ctx, void *output, 
             while (gdata_cnt < 6) {
                 if (src_ghashlen < 16) {
                     if (src_ghashlen != 0) {
-                        gdatabuf[gdata_cnt++] = loadn(src_ghash, src_ghashlen);
+                        gdatabuf[gdata_cnt++] = loadn128(src_ghash, src_ghashlen);
                         src_ghash = (__m128i *)((uint8_t *)src_ghash + src_ghashlen);
                         src_ghashlen = 0;
                     }
@@ -600,7 +706,7 @@ int ptls_fusion_aesgcm_decrypt(ptls_fusion_aesgcm_context_t *ctx, void *output, 
 #define INIT_BITS(n, keys)                                                                                                         \
     case n:                                                                                                                        \
         ctr = _mm_add_epi64(ctr, one8);                                                                                            \
-        bits##n = _mm_xor_si128(_mm_shuffle_epi8(ctr, bswap8), keys[0]);
+        bits##n = _mm_xor_si128(_mm_shuffle_epi8(ctr, byteswap128), keys.m128[0]);
         InitAllBits:
             INIT_BITS(0, ctx->ecb.keys);
             INIT_BITS(1, ctx->ecb.keys);
@@ -614,7 +720,7 @@ int ptls_fusion_aesgcm_decrypt(ptls_fusion_aesgcm_context_t *ctx, void *output, 
         { /* run aes and ghash */
 #define AESECB6_UPDATE(i)                                                                                                          \
     do {                                                                                                                           \
-        __m128i k = ctx->ecb.keys[i];                                                                                              \
+        __m128i k = ctx->ecb.keys.m128[i];                                                                                         \
         bits0 = _mm_aesenc_si128(bits0, k);                                                                                        \
         bits1 = _mm_aesenc_si128(bits1, k);                                                                                        \
         bits2 = _mm_aesenc_si128(bits2, k);                                                                                        \
@@ -626,11 +732,11 @@ int ptls_fusion_aesgcm_decrypt(ptls_fusion_aesgcm_context_t *ctx, void *output, 
             size_t aesi;
             for (aesi = 1; aesi <= gdata_cnt; ++aesi) {
                 AESECB6_UPDATE(aesi);
-                gfmul_nextstep(&gstate, _mm_loadu_si128(gdata++), --ghash_precompute);
+                gfmul_nextstep128(&gstate, _mm_loadu_si128(gdata++), --ghash_precompute);
             }
             for (; aesi < ctx->ecb.rounds; ++aesi)
                 AESECB6_UPDATE(aesi);
-            __m128i k = ctx->ecb.keys[aesi];
+            __m128i k = ctx->ecb.keys.m128[aesi];
             bits0 = _mm_aesenclast_si128(bits0, k);
             bits1 = _mm_aesenclast_si128(bits1, k);
             bits2 = _mm_aesenclast_si128(bits2, k);
@@ -685,19 +791,19 @@ Finish:
     if (src_aeslen == 16) {
         _mm_storeu_si128(dst, _mm_xor_si128(_mm_loadu_si128(src_aes), bits0));
     } else if (src_aeslen != 0) {
-        storen(dst, src_aeslen, _mm_xor_si128(loadn(src_aes, src_aeslen), bits0));
+        storen128(dst, src_aeslen, _mm_xor_si128(loadn128(src_aes, src_aeslen), bits0));
     }
 
     assert((state & STATE_IS_FIRST_RUN) == 0);
 
     /* the only case where AES operation is complete and GHASH is not is when the application of AC is remaining */
     if ((state & STATE_GHASH_HAS_MORE) != 0) {
-        assert(ghash_precompute - 1 == ctx->ghash);
-        gfmul_nextstep(&gstate, ac, --ghash_precompute);
+        assert(ghash_precompute - 1 == ctx->ghash128);
+        gfmul_nextstep128(&gstate, ac, --ghash_precompute);
     }
 
-    gfmul_reduce(&gstate);
-    __m128i calctag = gfmul_get_tag(&gstate, ek0);
+    gfmul_reduce128(&gstate);
+    __m128i calctag = gfmul_get_tag128(&gstate, ek0);
 
     return _mm_movemask_epi8(_mm_cmpeq_epi8(calctag, _mm_loadu_si128(tag))) == 0xffff;
 
@@ -716,7 +822,7 @@ static __m128i expand_key(__m128i key, __m128i temp)
     return key;
 }
 
-void ptls_fusion_aesecb_init(ptls_fusion_aesecb_context_t *ctx, int is_enc, const void *key, size_t key_size)
+void ptls_fusion_aesecb_init(ptls_fusion_aesecb_context_t *ctx, int is_enc, const void *key, size_t key_size, int avx256)
 {
     assert(is_enc && "decryption is not supported (yet)");
 
@@ -733,37 +839,48 @@ void ptls_fusion_aesecb_init(ptls_fusion_aesecb_context_t *ctx, int is_enc, cons
         assert(!"invalid key size; AES128 / AES256 are supported");
         break;
     }
+    ctx->avx256 = avx256;
 
-    ctx->keys[i++] = _mm_loadu_si128((__m128i *)key);
+    /* load and expand keys using keys.m128 */
+    ctx->keys.m128[i++] = _mm_loadu_si128((__m128i *)key);
     if (key_size == 32)
-        ctx->keys[i++] = _mm_loadu_si128((__m128i *)key + 1);
-
+        ctx->keys.m128[i++] = _mm_loadu_si128((__m128i *)key + 1);
+    while (1) {
 #define EXPAND(R)                                                                                                                  \
-    do {                                                                                                                           \
-        ctx->keys[i] = expand_key(ctx->keys[i - key_size / 16],                                                                    \
-                                  _mm_shuffle_epi32(_mm_aeskeygenassist_si128(ctx->keys[i - 1], R), _MM_SHUFFLE(3, 3, 3, 3)));     \
+    {                                                                                                                              \
+        ctx->keys.m128[i] =                                                                                                        \
+            expand_key(ctx->keys.m128[i - key_size / 16],                                                                          \
+                       _mm_shuffle_epi32(_mm_aeskeygenassist_si128(ctx->keys.m128[i - 1], R), _MM_SHUFFLE(3, 3, 3, 3)));           \
         if (i == ctx->rounds)                                                                                                      \
-            goto Done;                                                                                                             \
+            break;                                                                                                                 \
         ++i;                                                                                                                       \
         if (key_size > 24) {                                                                                                       \
-            ctx->keys[i] = expand_key(ctx->keys[i - key_size / 16],                                                                \
-                                      _mm_shuffle_epi32(_mm_aeskeygenassist_si128(ctx->keys[i - 1], R), _MM_SHUFFLE(2, 2, 2, 2))); \
+            ctx->keys.m128[i] =                                                                                                    \
+                expand_key(ctx->keys.m128[i - key_size / 16],                                                                      \
+                           _mm_shuffle_epi32(_mm_aeskeygenassist_si128(ctx->keys.m128[i - 1], R), _MM_SHUFFLE(2, 2, 2, 2)));       \
             ++i;                                                                                                                   \
         }                                                                                                                          \
-    } while (0)
-    EXPAND(0x1);
-    EXPAND(0x2);
-    EXPAND(0x4);
-    EXPAND(0x8);
-    EXPAND(0x10);
-    EXPAND(0x20);
-    EXPAND(0x40);
-    EXPAND(0x80);
-    EXPAND(0x1b);
-    EXPAND(0x36);
+    }
+        EXPAND(0x1);
+        EXPAND(0x2);
+        EXPAND(0x4);
+        EXPAND(0x8);
+        EXPAND(0x10);
+        EXPAND(0x20);
+        EXPAND(0x40);
+        EXPAND(0x80);
+        EXPAND(0x1b);
+        EXPAND(0x36);
 #undef EXPAND
-Done:
-    assert(i == ctx->rounds);
+    }
+
+    /* convert to keys.m256 if avx256 is used */
+    if (ctx->avx256) {
+        size_t i = ctx->rounds;
+        do {
+            ctx->keys.m256[i] = _mm256_broadcastsi128_si256(ctx->keys.m128[i]);
+        } while (i-- != 0);
+    }
 }
 
 void ptls_fusion_aesecb_dispose(ptls_fusion_aesecb_context_t *ctx)
@@ -789,36 +906,65 @@ static size_t aesgcm_calc_ghash_cnt(size_t capacity)
 
 static void setup_one_ghash_entry(ptls_fusion_aesgcm_context_t *ctx)
 {
-    if (ctx->ghash_cnt != 0)
-        ctx->ghash[ctx->ghash_cnt].H = gfmul(ctx->ghash[ctx->ghash_cnt - 1].H, ctx->ghash[0].H);
+    __m128i *H, *r, *Hprev, H0;
 
-    __m128i r = _mm_shuffle_epi32(ctx->ghash[ctx->ghash_cnt].H, 78);
-    r = _mm_xor_si128(r, ctx->ghash[ctx->ghash_cnt].H);
-    ctx->ghash[ctx->ghash_cnt].r = r;
+    if (ctx->ecb.avx256) {
+#define GET_SLOT(i, mem) (&ctx->ghash256[(i) / 2].mem[(i) % 2 == 0])
+        H = GET_SLOT(ctx->ghash_cnt, H);
+        r = GET_SLOT(ctx->ghash_cnt, r);
+        Hprev = ctx->ghash_cnt == 0 ? NULL : GET_SLOT(ctx->ghash_cnt - 1, H);
+#undef GET_SLOT
+        H0 = ctx->ghash256[0].H[1];
+    } else {
+        H = &ctx->ghash128[ctx->ghash_cnt].H;
+        r = &ctx->ghash128[ctx->ghash_cnt].r;
+        Hprev = ctx->ghash_cnt == 0 ? NULL : &ctx->ghash128[ctx->ghash_cnt - 1].H;
+        H0 = ctx->ghash128[0].H;
+    }
+
+    if (Hprev != NULL)
+        *H = gfmul(*Hprev, H0);
+
+    *r = _mm_shuffle_epi32(*H, 78);
+    *r = _mm_xor_si128(*r, *H);
 
     ++ctx->ghash_cnt;
 }
 
-ptls_fusion_aesgcm_context_t *ptls_fusion_aesgcm_new(const void *key, size_t key_size, size_t capacity)
+static ptls_fusion_aesgcm_context_t *new_aesgcm(const void *key, size_t key_size, size_t capacity, int avx256)
 {
     ptls_fusion_aesgcm_context_t *ctx;
     size_t ghash_cnt = aesgcm_calc_ghash_cnt(capacity);
+    if (avx256 && ghash_cnt % 2 != 0)
+        ++ghash_cnt;
 
-    if ((ctx = malloc(sizeof(*ctx) + sizeof(ctx->ghash[0]) * ghash_cnt)) == NULL)
+    PTLS_BUILD_ASSERT(sizeof(ctx->ghash128[0]) * 2 == sizeof(ctx->ghash256[0]));
+    if ((ctx = aligned_alloc(32, sizeof(*ctx) + sizeof(ctx->ghash128[0]) * ghash_cnt)) == NULL)
         return NULL;
 
-    ptls_fusion_aesecb_init(&ctx->ecb, 1, key, key_size);
+    ptls_fusion_aesecb_init(&ctx->ecb, 1, key, key_size, avx256);
 
     ctx->capacity = capacity;
 
-    ctx->ghash[0].H = aesecb_encrypt(&ctx->ecb, _mm_setzero_si128());
-    ctx->ghash[0].H = _mm_shuffle_epi8(ctx->ghash[0].H, bswap8);
-    ctx->ghash[0].H = transformH(ctx->ghash[0].H);
+    __m128i H0 = aesecb_encrypt(&ctx->ecb, _mm_setzero_si128());
+    H0 = _mm_shuffle_epi8(H0, byteswap128);
+    H0 = transformH(H0);
+    if (ctx->ecb.avx256) {
+        ctx->ghash256[0].H[1] = H0;
+    } else {
+        ctx->ghash128[0].H = H0;
+    }
+
     ctx->ghash_cnt = 0;
     while (ctx->ghash_cnt < ghash_cnt)
         setup_one_ghash_entry(ctx);
 
     return ctx;
+}
+
+ptls_fusion_aesgcm_context_t *ptls_fusion_aesgcm_new(const void *key, size_t key_size, size_t capacity)
+{
+    return new_aesgcm(key, key_size, capacity, 0);
 }
 
 ptls_fusion_aesgcm_context_t *ptls_fusion_aesgcm_set_capacity(ptls_fusion_aesgcm_context_t *ctx, size_t capacity)
@@ -828,7 +974,7 @@ ptls_fusion_aesgcm_context_t *ptls_fusion_aesgcm_set_capacity(ptls_fusion_aesgcm
     if (ghash_cnt <= ctx->ghash_cnt)
         return ctx;
 
-    if ((ctx = realloc(ctx, sizeof(*ctx) + sizeof(ctx->ghash[0]) * ghash_cnt)) == NULL)
+    if ((ctx = realloc(ctx, sizeof(*ctx) + sizeof(ctx->ghash128[0]) * ghash_cnt)) == NULL)
         return NULL;
 
     ctx->capacity = capacity;
@@ -840,7 +986,7 @@ ptls_fusion_aesgcm_context_t *ptls_fusion_aesgcm_set_capacity(ptls_fusion_aesgcm
 
 void ptls_fusion_aesgcm_free(ptls_fusion_aesgcm_context_t *ctx)
 {
-    ptls_clear_memory(ctx->ghash, sizeof(ctx->ghash[0]) * ctx->ghash_cnt);
+    ptls_clear_memory(ctx->ghash128, sizeof(ctx->ghash128[0]) * ctx->ghash_cnt);
     ctx->ghash_cnt = 0;
     ptls_fusion_aesecb_dispose(&ctx->ecb);
     free(ctx);
@@ -869,7 +1015,7 @@ static void ctr_transform(ptls_cipher_context_t *_ctx, void *output, const void 
     ctx->is_ready = 0;
 
     if (len < 16) {
-        storen(output, len, _mm_xor_si128(_mm_loadu_si128(&ctx->bits), loadn(input, len)));
+        storen128(output, len, _mm_xor_si128(_mm_loadu_si128(&ctx->bits), loadn128(input, len)));
     } else {
         _mm_storeu_si128(output, _mm_xor_si128(_mm_loadu_si128(&ctx->bits), _mm_loadu_si128(input)));
     }
@@ -882,7 +1028,7 @@ static int aesctr_setup(ptls_cipher_context_t *_ctx, int is_enc, const void *key
     ctx->super.do_dispose = ctr_dispose;
     ctx->super.do_init = ctr_init;
     ctx->super.do_transform = ctr_transform;
-    ptls_fusion_aesecb_init(&ctx->fusion, 1, key, key_size);
+    ptls_fusion_aesecb_init(&ctx->fusion, 1, key, key_size, 0 /* probably we do not need avx256 for CTR? */);
     ctx->is_ready = 0;
 
     return 0;
@@ -967,8 +1113,8 @@ static size_t aead_do_decrypt(ptls_aead_context_t *_ctx, void *output, const voi
 static inline void aesgcm_xor_iv(ptls_aead_context_t *_ctx, const void *_bytes, size_t len)
 {
     struct aesgcm_context *ctx = (struct aesgcm_context *)_ctx;
-    __m128i xor_mask = loadn(_bytes, len);
-    xor_mask = _mm_shuffle_epi8(xor_mask, bswap8);
+    __m128i xor_mask = loadn128(_bytes, len);
+    xor_mask = _mm_shuffle_epi8(xor_mask, byteswap128);
     ctx->static_iv = _mm_xor_si128(ctx->static_iv, xor_mask);
 }
 
@@ -976,8 +1122,8 @@ static int aesgcm_setup(ptls_aead_context_t *_ctx, int is_enc, const void *key, 
 {
     struct aesgcm_context *ctx = (struct aesgcm_context *)_ctx;
 
-    ctx->static_iv = loadn(iv, PTLS_AESGCM_IV_SIZE);
-    ctx->static_iv = _mm_shuffle_epi8(ctx->static_iv, bswap8);
+    ctx->static_iv = loadn128(iv, PTLS_AESGCM_IV_SIZE);
+    ctx->static_iv = _mm_shuffle_epi8(ctx->static_iv, byteswap128);
     if (key == NULL)
         return 0;
 
@@ -990,7 +1136,7 @@ static int aesgcm_setup(ptls_aead_context_t *_ctx, int is_enc, const void *key, 
     ctx->super.do_encrypt_v = aead_do_encrypt_v;
     ctx->super.do_decrypt = aead_do_decrypt;
 
-    ctx->aesgcm = ptls_fusion_aesgcm_new(key, key_size, 1500 /* assume ordinary packet size */);
+    ctx->aesgcm = new_aesgcm(key, key_size, 1500 /* assume ordinary packet size */, 0 /* no support for avx256 yet */);
 
     return 0;
 }
@@ -1005,6 +1151,7 @@ static int aes256gcm_setup(ptls_aead_context_t *ctx, int is_enc, const void *key
     return aesgcm_setup(ctx, is_enc, key, iv, PTLS_AES256_KEY_SIZE);
 }
 
+int ptls_fusion_can_avx256 = 0;
 ptls_cipher_algorithm_t ptls_fusion_aes128ctr = {"AES128-CTR",
                                                  PTLS_AES128_KEY_SIZE,
                                                  1, // block size
@@ -1046,31 +1193,49 @@ static inline size_t calc_total_length(ptls_iovec_t *input, size_t incnt)
     return totlen;
 }
 
+static inline void write_remaining_bytes(uint8_t *dst, const uint8_t *src, const uint8_t *end)
+{
+    /* Write in 64-byte chunks, using NT store instructions. Last partial block, if any, is written to cache, as that cache line
+     * would likely be read when the next TLS record is being built. */
+
+    for (; end - src >= 64; dst += 64, src += 64) {
+        _mm256_stream_si256((void *)dst, _mm256_load_si256((void *)src));
+        _mm256_stream_si256((void *)(dst + 32), _mm256_load_si256((void *)(src + 32)));
+    }
+    _mm_sfence(); /* weakly ordered writes have to be synced before being passed to NIC */
+    if (src != end) {
+        for (; end - src >= 16; dst += 16, src += 16)
+            _mm_store_si128((void *)dst, _mm_load_si128((void *)src));
+        if (src != end)
+            storen128((void *)dst, end - src, loadn128((void *)src, end - src));
+    }
+}
+
 NO_SANITIZE_ADDRESS
-static void fastls_encrypt_v(struct st_ptls_aead_context_t *_ctx, void *_output, ptls_iovec_t *input, size_t incnt, uint64_t seq,
-                             const void *_aad, size_t aadlen)
+static void fastls_encrypt_v128(struct st_ptls_aead_context_t *_ctx, void *_output, ptls_iovec_t *input, size_t incnt, uint64_t seq,
+                                const void *_aad, size_t aadlen)
 {
 /* init the bits (we can always run in full), but use the last slot for calculating ek0, if possible */
 #define AESECB6_INIT()                                                                                                             \
     do {                                                                                                                           \
         ctr = _mm_add_epi64(ctr, one8);                                                                                            \
-        bits0 = _mm_shuffle_epi8(ctr, bswap8);                                                                                     \
+        bits0 = _mm_shuffle_epi8(ctr, byteswap128);                                                                                \
         ctr = _mm_add_epi64(ctr, one8);                                                                                            \
-        bits1 = _mm_shuffle_epi8(ctr, bswap8);                                                                                     \
+        bits1 = _mm_shuffle_epi8(ctr, byteswap128);                                                                                \
         ctr = _mm_add_epi64(ctr, one8);                                                                                            \
-        bits2 = _mm_shuffle_epi8(ctr, bswap8);                                                                                     \
+        bits2 = _mm_shuffle_epi8(ctr, byteswap128);                                                                                \
         ctr = _mm_add_epi64(ctr, one8);                                                                                            \
-        bits3 = _mm_shuffle_epi8(ctr, bswap8);                                                                                     \
+        bits3 = _mm_shuffle_epi8(ctr, byteswap128);                                                                                \
         ctr = _mm_add_epi64(ctr, one8);                                                                                            \
-        bits4 = _mm_shuffle_epi8(ctr, bswap8);                                                                                     \
+        bits4 = _mm_shuffle_epi8(ctr, byteswap128);                                                                                \
         if (PTLS_LIKELY(srclen > 16 * 5) || src_vecleft != 0) {                                                                    \
             ctr = _mm_add_epi64(ctr, one8);                                                                                        \
-            bits5 = _mm_shuffle_epi8(ctr, bswap8);                                                                                 \
+            bits5 = _mm_shuffle_epi8(ctr, byteswap128);                                                                            \
         } else {                                                                                                                   \
             bits5 = ek0;                                                                                                           \
             state |= STATE_EK0_READY;                                                                                              \
         }                                                                                                                          \
-        __m128i k = ctx->ecb.keys[0];                                                                                              \
+        __m128i k = ctx->ecb.keys.m128[0];                                                                                         \
         bits0 = _mm_xor_si128(bits0, k);                                                                                           \
         bits1 = _mm_xor_si128(bits1, k);                                                                                           \
         bits2 = _mm_xor_si128(bits2, k);                                                                                           \
@@ -1082,7 +1247,7 @@ static void fastls_encrypt_v(struct st_ptls_aead_context_t *_ctx, void *_output,
 /* aes block update */
 #define AESECB6_UPDATE(i)                                                                                                          \
     do {                                                                                                                           \
-        __m128i k = ctx->ecb.keys[i];                                                                                              \
+        __m128i k = ctx->ecb.keys.m128[i];                                                                                         \
         bits0 = _mm_aesenc_si128(bits0, k);                                                                                        \
         bits1 = _mm_aesenc_si128(bits1, k);                                                                                        \
         bits2 = _mm_aesenc_si128(bits2, k);                                                                                        \
@@ -1094,7 +1259,7 @@ static void fastls_encrypt_v(struct st_ptls_aead_context_t *_ctx, void *_output,
 /* aesenclast */
 #define AESECB6_FINAL(i)                                                                                                           \
     do {                                                                                                                           \
-        __m128i k = ctx->ecb.keys[i];                                                                                              \
+        __m128i k = ctx->ecb.keys.m128[i];                                                                                         \
         bits0 = _mm_aesenclast_si128(bits0, k);                                                                                    \
         bits1 = _mm_aesenclast_si128(bits1, k);                                                                                    \
         bits2 = _mm_aesenclast_si128(bits2, k);                                                                                    \
@@ -1131,12 +1296,12 @@ static void fastls_encrypt_v(struct st_ptls_aead_context_t *_ctx, void *_output,
     /* setup ctr, retain Ek(0), len(A) | len(C) to be fed into GCM */
     __m128i ctr = calc_counter(agctx, seq);
     ctr = _mm_insert_epi32(ctr, 1, 0);
-    __m128i ek0 = _mm_shuffle_epi8(ctr, bswap8);
-    __m128i ac = _mm_shuffle_epi8(_mm_set_epi32(0, (int)aadlen * 8, 0, (int)calc_total_length(input, incnt) * 8), bswap8);
+    __m128i ek0 = _mm_shuffle_epi8(ctr, byteswap128);
+    __m128i ac = _mm_shuffle_epi8(_mm_set_epi32(0, (int)aadlen * 8, 0, (int)calc_total_length(input, incnt) * 8), byteswap128);
 
     ptls_fusion_aesgcm_context_t *ctx = agctx->aesgcm;
     __m128i bits0, bits1, bits2, bits3, bits4, bits5 = _mm_setzero_si128();
-    struct ptls_fusion_gfmul_state gstate = {0};
+    struct ptls_fusion_gfmul_state128 gstate = {0};
 
     /* find the first non-empty vec */
     const uint8_t *src = NULL;
@@ -1153,37 +1318,37 @@ static void fastls_encrypt_v(struct st_ptls_aead_context_t *_ctx, void *_output,
     AESECB6_UPDATE(1);
     AESECB6_UPDATE(2);
     if (PTLS_LIKELY(aadlen != 0)) {
-        struct ptls_fusion_aesgcm_ghash_precompute *ghash_precompute;
+        struct ptls_fusion_aesgcm_ghash_precompute128 *ghash_precompute;
         while (PTLS_UNLIKELY(aadlen >= 6 * 16)) {
-            ghash_precompute = ctx->ghash + 6;
-            gfmul_firststep(&gstate, _mm_loadu_si128((void *)aad), --ghash_precompute);
+            ghash_precompute = ctx->ghash128 + 6;
+            gfmul_firststep128(&gstate, _mm_loadu_si128((void *)aad), --ghash_precompute);
             aad += 16;
             aadlen -= 16;
             for (int i = 1; i < 6; ++i) {
-                gfmul_nextstep(&gstate, _mm_loadu_si128((void *)aad), --ghash_precompute);
+                gfmul_nextstep128(&gstate, _mm_loadu_si128((void *)aad), --ghash_precompute);
                 aad += 16;
                 aadlen -= 16;
             }
-            gfmul_reduce(&gstate);
+            gfmul_reduce128(&gstate);
         }
         if (PTLS_LIKELY(aadlen != 0)) {
-            ghash_precompute = ctx->ghash + (aadlen + 15) / 16;
+            ghash_precompute = ctx->ghash128 + (aadlen + 15) / 16;
             if (PTLS_UNLIKELY(aadlen >= 16)) {
-                gfmul_firststep(&gstate, _mm_loadu_si128((void *)aad), --ghash_precompute);
+                gfmul_firststep128(&gstate, _mm_loadu_si128((void *)aad), --ghash_precompute);
                 aad += 16;
                 aadlen -= 16;
                 while (aadlen >= 16) {
-                    gfmul_nextstep(&gstate, _mm_loadu_si128((void *)aad), --ghash_precompute);
+                    gfmul_nextstep128(&gstate, _mm_loadu_si128((void *)aad), --ghash_precompute);
                     aad += 16;
                     aadlen -= 16;
                 }
                 if (PTLS_LIKELY(aadlen != 0))
-                    gfmul_nextstep(&gstate, loadn(aad, aadlen), --ghash_precompute);
+                    gfmul_nextstep128(&gstate, loadn128(aad, aadlen), --ghash_precompute);
             } else {
-                gfmul_firststep(&gstate, loadn(aad, aadlen), --ghash_precompute);
+                gfmul_firststep128(&gstate, loadn128(aad, aadlen), --ghash_precompute);
             }
-            assert(ctx->ghash == ghash_precompute);
-            gfmul_reduce(&gstate);
+            assert(ctx->ghash128 == ghash_precompute);
+            gfmul_reduce128(&gstate);
         }
     }
     for (size_t i = 3; i < ctx->ecb.rounds; ++i)
@@ -1270,21 +1435,21 @@ static void fastls_encrypt_v(struct st_ptls_aead_context_t *_ctx, void *_output,
             /* Next 96-byte block starts here. Run AES and ghash in while writing output using non-temporal stores in 64-byte
              * blocks. */
             AESECB6_INIT();
-            struct ptls_fusion_aesgcm_ghash_precompute *ghash_precompute = ctx->ghash + 6;
-            gfmul_firststep(&gstate, _mm_loadu_si128((void *)(encp - 6 * 16)), --ghash_precompute);
+            struct ptls_fusion_aesgcm_ghash_precompute128 *ghash_precompute = ctx->ghash128 + 6;
+            gfmul_firststep128(&gstate, _mm_loadu_si128((void *)(encp - 6 * 16)), --ghash_precompute);
             AESECB6_UPDATE(1);
-            gfmul_nextstep(&gstate, _mm_loadu_si128((void *)(encp - 5 * 16)), --ghash_precompute);
+            gfmul_nextstep128(&gstate, _mm_loadu_si128((void *)(encp - 5 * 16)), --ghash_precompute);
             AESECB6_UPDATE(2);
-            gfmul_nextstep(&gstate, _mm_loadu_si128((void *)(encp - 4 * 16)), --ghash_precompute);
+            gfmul_nextstep128(&gstate, _mm_loadu_si128((void *)(encp - 4 * 16)), --ghash_precompute);
             AESECB6_UPDATE(3);
             _mm256_stream_si256((void *)output, _mm256_load_si256((void *)encbuf));
             _mm256_stream_si256((void *)(output + 32), _mm256_load_si256((void *)(encbuf + 32)));
             AESECB6_UPDATE(4);
-            gfmul_nextstep(&gstate, _mm_loadu_si128((void *)(encp - 3 * 16)), --ghash_precompute);
+            gfmul_nextstep128(&gstate, _mm_loadu_si128((void *)(encp - 3 * 16)), --ghash_precompute);
             AESECB6_UPDATE(5);
-            gfmul_nextstep(&gstate, _mm_loadu_si128((void *)(encp - 2 * 16)), --ghash_precompute);
+            gfmul_nextstep128(&gstate, _mm_loadu_si128((void *)(encp - 2 * 16)), --ghash_precompute);
             AESECB6_UPDATE(6);
-            gfmul_nextstep(&gstate, _mm_loadu_si128((void *)(encp - 1 * 16)), --ghash_precompute);
+            gfmul_nextstep128(&gstate, _mm_loadu_si128((void *)(encp - 1 * 16)), --ghash_precompute);
             AESECB6_UPDATE(7);
             if ((state & STATE_COPY_128B) != 0) {
                 _mm256_stream_si256((void *)(output + 64), _mm256_load_si256((void *)(encbuf + 64)));
@@ -1307,8 +1472,8 @@ static void fastls_encrypt_v(struct st_ptls_aead_context_t *_ctx, void *_output,
                 for (size_t i = 10; PTLS_LIKELY(i < ctx->ecb.rounds); ++i)
                     AESECB6_UPDATE(i);
             }
-            assert(ctx->ghash == ghash_precompute);
-            gfmul_reduce(&gstate);
+            assert(ctx->ghash128 == ghash_precompute);
+            gfmul_reduce128(&gstate);
             AESECB6_FINAL(ctx->ecb.rounds);
         }
     }
@@ -1321,62 +1486,361 @@ static void fastls_encrypt_v(struct st_ptls_aead_context_t *_ctx, void *_output,
         _mm_storeu_si128((void *)(encbuf + ac_off), ac);
         size_t blocks = ((encp - encbuf) - remaining_ghash_from + 15) / 16 + 1; /* round up, +1 for AC */
         assert(blocks <= 7);
-        struct ptls_fusion_aesgcm_ghash_precompute *ghash_precompute = ctx->ghash + blocks;
-        gfmul_firststep(&gstate, _mm_loadu_si128((void *)(encbuf + remaining_ghash_from)), --ghash_precompute);
+        struct ptls_fusion_aesgcm_ghash_precompute128 *ghash_precompute = ctx->ghash128 + blocks;
+        gfmul_firststep128(&gstate, _mm_loadu_si128((void *)(encbuf + remaining_ghash_from)), --ghash_precompute);
         remaining_ghash_from += 16;
-        while (ghash_precompute != ctx->ghash) {
-            gfmul_nextstep(&gstate, _mm_loadu_si128((void *)(encbuf + remaining_ghash_from)), --ghash_precompute);
+        while (ghash_precompute != ctx->ghash128) {
+            gfmul_nextstep128(&gstate, _mm_loadu_si128((void *)(encbuf + remaining_ghash_from)), --ghash_precompute);
             remaining_ghash_from += 16;
         }
-        gfmul_reduce(&gstate);
+        gfmul_reduce128(&gstate);
     }
 
     /* Calculate EK0, if in the unlikely case on not been done yet. When encoding in full size (16K), EK0 will be ready. */
     if (PTLS_UNLIKELY((state & STATE_EK0_READY) == 0)) {
-        bits5 = _mm_xor_si128(ek0, ctx->ecb.keys[0]);
+        bits5 = _mm_xor_si128(ek0, ctx->ecb.keys.m128[0]);
         for (size_t i = 1; i < ctx->ecb.rounds; ++i)
-            bits5 = _mm_aesenc_si128(bits5, ctx->ecb.keys[i]);
-        bits5 = _mm_aesenclast_si128(bits5, ctx->ecb.keys[ctx->ecb.rounds]);
+            bits5 = _mm_aesenc_si128(bits5, ctx->ecb.keys.m128[i]);
+        bits5 = _mm_aesenclast_si128(bits5, ctx->ecb.keys.m128[ctx->ecb.rounds]);
     }
 
     /* append tag to encbuf */
-    _mm_storeu_si128((void *)encp, gfmul_get_tag(&gstate, bits5));
+    _mm_storeu_si128((void *)encp, gfmul_get_tag128(&gstate, bits5));
     encp += 16;
 
-    { /* Write encbuf, using NT store instructions in 64-byte chunks. Last partial block, if any, is written to cache, as that cache
-       * line would likely be read when the next TLS record is being built. */
-        const uint8_t *s = encbuf;
-        uint8_t *d = output;
-        for (; encp - s >= 64; d += 64, s += 64) {
-            _mm256_stream_si256((void *)d, _mm256_load_si256((void *)s));
-            _mm256_stream_si256((void *)(d + 32), _mm256_load_si256((void *)(s + 32)));
+    /* write remaining bytes */
+    write_remaining_bytes(output, encbuf, encp);
+
+#undef AESECB6_INIT
+#undef AESECB6_UPDATE
+#undef AESECB6_FINAL
+#undef STATE_EK0_READY
+#undef STATE_COPY_128B
+}
+
+NO_SANITIZE_ADDRESS
+static void fastls_encrypt_v256(struct st_ptls_aead_context_t *_ctx, void *_output, ptls_iovec_t *input, size_t incnt, uint64_t seq,
+                                const void *_aad, size_t aadlen)
+{
+/* init the bits (we can always run in full), but use the last slot for calculating ek0, if possible */
+#define AESECB6_INIT()                                                                                                             \
+    do {                                                                                                                           \
+        ctr = _mm256_add_epi64(ctr, incr128x2);                                                                                    \
+        bits0 = _mm256_shuffle_epi8(ctr, byteswap256);                                                                             \
+        ctr = _mm256_add_epi64(ctr, incr128x2);                                                                                    \
+        bits1 = _mm256_shuffle_epi8(ctr, byteswap256);                                                                             \
+        ctr = _mm256_add_epi64(ctr, incr128x2);                                                                                    \
+        bits2 = _mm256_shuffle_epi8(ctr, byteswap256);                                                                             \
+        ctr = _mm256_add_epi64(ctr, incr128x2);                                                                                    \
+        bits3 = _mm256_shuffle_epi8(ctr, byteswap256);                                                                             \
+        ctr = _mm256_add_epi64(ctr, incr128x2);                                                                                    \
+        bits4 = _mm256_shuffle_epi8(ctr, byteswap256);                                                                             \
+        ctr = _mm256_add_epi64(ctr, incr128x2);                                                                                    \
+        bits5 = _mm256_shuffle_epi8(ctr, byteswap256);                                                                             \
+        if (PTLS_UNLIKELY(srclen <= 32 * 6 - 16) && src_vecleft == 0) {                                                            \
+            bits5 = _mm256_insertf128_si256(bits5, ek0, 1);                                                                        \
+            state |= STATE_EK0_READY;                                                                                              \
+        }                                                                                                                          \
+        __m256i k = ctx->ecb.keys.m256[0];                                                                                         \
+        bits0 = _mm256_xor_si256(bits0, k);                                                                                        \
+        bits1 = _mm256_xor_si256(bits1, k);                                                                                        \
+        bits2 = _mm256_xor_si256(bits2, k);                                                                                        \
+        bits3 = _mm256_xor_si256(bits3, k);                                                                                        \
+        bits4 = _mm256_xor_si256(bits4, k);                                                                                        \
+        bits5 = _mm256_xor_si256(bits5, k);                                                                                        \
+    } while (0)
+
+/* aes block update */
+#define AESECB6_UPDATE(i)                                                                                                          \
+    do {                                                                                                                           \
+        __m256i k = ctx->ecb.keys.m256[i];                                                                                         \
+        bits0 = _mm256_aesenc_epi128(bits0, k);                                                                                    \
+        bits1 = _mm256_aesenc_epi128(bits1, k);                                                                                    \
+        bits2 = _mm256_aesenc_epi128(bits2, k);                                                                                    \
+        bits3 = _mm256_aesenc_epi128(bits3, k);                                                                                    \
+        bits4 = _mm256_aesenc_epi128(bits4, k);                                                                                    \
+        bits5 = _mm256_aesenc_epi128(bits5, k);                                                                                    \
+    } while (0)
+
+/* aesenclast */
+#define AESECB6_FINAL(i)                                                                                                           \
+    do {                                                                                                                           \
+        __m256i k = ctx->ecb.keys.m256[i];                                                                                         \
+        bits0 = _mm256_aesenclast_epi128(bits0, k);                                                                                \
+        bits1 = _mm256_aesenclast_epi128(bits1, k);                                                                                \
+        bits2 = _mm256_aesenclast_epi128(bits2, k);                                                                                \
+        bits3 = _mm256_aesenclast_epi128(bits3, k);                                                                                \
+        bits4 = _mm256_aesenclast_epi128(bits4, k);                                                                                \
+        bits5 = _mm256_aesenclast_epi128(bits5, k);                                                                                \
+    } while (0)
+
+    struct aesgcm_context *agctx = (void *)_ctx;
+    uint8_t *output = _output;
+    const uint8_t *aad = _aad;
+
+#define STATE_EK0_READY 0x1
+    int32_t state = 0;
+
+    /* Bytes are written here first then written using NT store instructions, 64 bytes at a time. */
+    uint8_t encbuf[32 * 9] __attribute__((aligned(32))), *encp;
+
+    /* `encbuf` should be large enough to store up to 63-bytes of unaligned bytes, 6 16-byte AES blocks, plus AEAD tag that is
+     * append to the ciphertext before writing the bytes to main memory using NT store instructions. */
+    PTLS_BUILD_ASSERT(sizeof(encbuf) >= 64 + 6 * 32 + 16);
+
+    /* determine `num_bytes_write_delayed` as well as initializing `encbuf`, adjusting `output` */
+    if ((encp = encbuf + ((uintptr_t)output & 63)) != encbuf) {
+        _mm256_store_si256((void *)encbuf, _mm256_load_si256((void *)(output - (encp - encbuf))));
+        _mm256_store_si256((void *)(encbuf + 32), _mm256_load_si256((void *)(output - (encp - encbuf) + 32)));
+        output -= encp - encbuf;
+    }
+
+    /* setup ctr, retaining Ek(0), len(A) | len(C) to be fed into GCM */
+    __m256i ctr = _mm256_broadcastsi128_si256(calc_counter(agctx, seq));
+    ctr = _mm256_insert_epi32(ctr, 1, 4);
+    __m128i ek0 = _mm_shuffle_epi8(_mm256_castsi256_si128(_mm256_permute2f128_si256(ctr, ctr, 0x81)), byteswap128);
+    __m128i ac = _mm_shuffle_epi8(_mm_set_epi32(0, (int)aadlen * 8, 0, (int)calc_total_length(input, incnt) * 8), byteswap128);
+
+    ptls_fusion_aesgcm_context_t *ctx = agctx->aesgcm;
+    __m256i bits0, bits1, bits2, bits3, bits4, bits5 = _mm256_setzero_si256();
+    struct ptls_fusion_gfmul_state256 gstate = {0};
+
+    /* find the first non-empty vec */
+    const uint8_t *src = NULL;
+    size_t srclen = 0, src_vecleft = incnt;
+    while (srclen == 0 && src_vecleft != 0) {
+        src = (void *)input[0].base;
+        srclen = input[0].len;
+        ++input;
+        --src_vecleft;
+    }
+
+    /* Prepare first 6 blocks of bit stream, at the same time calculating ghash of AAD. */
+    AESECB6_INIT();
+    AESECB6_UPDATE(1);
+    AESECB6_UPDATE(2);
+    if (PTLS_LIKELY(aadlen != 0)) {
+        union ptls_fusion_aesgcm_ghash_precompute256 *ghash_precompute;
+        while (PTLS_UNLIKELY(aadlen >= 6 * 32)) {
+            ghash_precompute = ctx->ghash256 + 6;
+            gfmul_firststep256(&gstate, _mm256_loadu_si256((void *)aad), 0, --ghash_precompute);
+            aad += 32;
+            aadlen -= 32;
+            for (int i = 1; i < 6; ++i) {
+                gfmul_nextstep256(&gstate, _mm256_loadu_si256((void *)aad), --ghash_precompute);
+                aad += 32;
+                aadlen -= 32;
+            }
+            gfmul_reduce256(&gstate);
         }
-        _mm_sfence(); /* weakly ordered writes have to be synced before being passed to NIC */
-        if (s != encp) {
-            for (; encp - s >= 16; d += 16, s += 16)
-                _mm_store_si128((void *)d, _mm_load_si128((void *)s));
-            if (s != encp)
-                storen((void *)d, encp - s, loadn((void *)s, encp - s));
+        if (PTLS_LIKELY(aadlen != 0)) {
+            ghash_precompute = ctx->ghash256 + (aadlen + 31) / 32;
+            if (PTLS_UNLIKELY(aadlen >= 32)) {
+                if (aadlen % 32 == 0 || aadlen % 32 > 16) {
+                    gfmul_firststep256(&gstate, _mm256_loadu_si256((void *)aad), 0, --ghash_precompute);
+                    aad += 32;
+                    aadlen -= 32;
+                } else {
+                    gfmul_firststep256(&gstate, _mm256_loadu_si256((void *)aad), 1, --ghash_precompute);
+                    aad += 16;
+                    aadlen -= 16;
+                }
+                while (aadlen >= 32) {
+                    gfmul_nextstep256(&gstate, _mm256_loadu_si256((void *)aad), --ghash_precompute);
+                    aad += 32;
+                    aadlen -= 32;
+                }
+                if (PTLS_LIKELY(aadlen != 0)) {
+                    assert(aadlen > 16);
+                    gfmul_nextstep256(&gstate, loadn256(aad, aadlen), --ghash_precompute);
+                }
+            } else {
+                gfmul_firststep256(&gstate, loadn256(aad, aadlen), aadlen <= 16, --ghash_precompute);
+            }
+            assert(ctx->ghash256 == ghash_precompute);
+            gfmul_reduce256(&gstate);
         }
     }
+    for (size_t i = 3; i < ctx->ecb.rounds; ++i)
+        AESECB6_UPDATE(i);
+    AESECB6_FINAL(ctx->ecb.rounds);
+
+    /* Main loop. This loop:
+     *  1. using current keystream (bits0..bits5), xors a up to 6 * 16 bytes and writes to encbuf,
+     *  2. then if there is no more data to be encrypted, exit the loop, otherwise,
+     *  3. calculate ghash of the blocks being written to encbuf,
+     *  4. calculate next 6 * 16 bytes of keystream,
+     *  5. writes encbuf in 64-byte blocks
+     * When exitting the loop, `remaining_ghash_from` represents the offset within `encbuf` from where ghash remains to be
+     * calculated. */
+    size_t remaining_ghash_from = encp - encbuf;
+    if (srclen != 0) {
+        while (1) {
+            /* apply the bit stream to input, writing to encbuf */
+            if (PTLS_LIKELY(srclen >= 6 * 32)) {
+#define APPLY(i) _mm256_storeu_si256((void *)(encp + i * 32), _mm256_xor_si256(_mm256_loadu_si256((void *)(src + i * 32)), bits##i))
+                APPLY(0);
+                APPLY(1);
+                APPLY(2);
+                APPLY(3);
+                APPLY(4);
+                APPLY(5);
+#undef APPLY
+                encp += 6 * 32;
+                src += 6 * 32;
+                srclen -= 6 * 32;
+                if (PTLS_UNLIKELY(srclen == 0)) {
+                    if (src_vecleft == 0) {
+                        remaining_ghash_from = (encp - encbuf) - 6 * 32;
+                        break;
+                    }
+                    src = (void *)input[0].base;
+                    srclen = input[0].len;
+                    ++input;
+                    --src_vecleft;
+                }
+            } else {
+                /* slow path, load at most 6 * 32 bytes to encbuf then encrypt in-place */
+                size_t bytes_copied = 0;
+                do {
+                    if (srclen >= 32 && bytes_copied < 5 * 32) {
+                        _mm256_storeu_si256((void *)(encp + bytes_copied), _mm256_loadu_si256((void *)src));
+                        bytes_copied += 32;
+                        src += 32;
+                        srclen -= 32;
+                    } else {
+                        encp[bytes_copied++] = *src++;
+                        --srclen;
+                    }
+                    if (PTLS_UNLIKELY(srclen == 0)) {
+                        if (src_vecleft == 0) {
+                            break;
+                        } else {
+                            src = (void *)input[0].base;
+                            srclen = input[0].len;
+                            ++input;
+                            --src_vecleft;
+                        }
+                    }
+                } while (bytes_copied < 6 * 32);
+#define APPLY(i)                                                                                                                   \
+    _mm256_storeu_si256((void *)(encp + i * 32), _mm256_xor_si256(_mm256_loadu_si256((void *)(encp + i * 32)), bits##i))
+                APPLY(0);
+                APPLY(1);
+                APPLY(2);
+                APPLY(3);
+                APPLY(4);
+                APPLY(5);
+#undef APPLY
+                encp += bytes_copied;
+                if (PTLS_UNLIKELY(srclen == 0)) {
+                    /* Calculate amonut of data left to be ghashed, as well as zero-clearing the remainedr of partial block, as it
+                     * will be fed into ghash. */
+                    remaining_ghash_from = (encp - encbuf) - bytes_copied;
+                    if ((bytes_copied & 15) != 0)
+                        _mm_storeu_si128((void *)encp, _mm_setzero_si128());
+                    break;
+                }
+            }
+
+            /* Next 96-byte block starts here. Run AES and ghash in parallel while writing output using non-temporal store
+             * instructions. */
+            AESECB6_INIT();
+            union ptls_fusion_aesgcm_ghash_precompute256 *ghash_precompute = ctx->ghash256 + 6;
+            gfmul_firststep256(&gstate, _mm256_loadu_si256((void *)(encp - 6 * 32)), 0, --ghash_precompute);
+            AESECB6_UPDATE(1);
+            gfmul_nextstep256(&gstate, _mm256_loadu_si256((void *)(encp - 5 * 32)), --ghash_precompute);
+            AESECB6_UPDATE(2);
+            gfmul_nextstep256(&gstate, _mm256_loadu_si256((void *)(encp - 4 * 32)), --ghash_precompute);
+            AESECB6_UPDATE(3);
+            gfmul_nextstep256(&gstate, _mm256_loadu_si256((void *)(encp - 3 * 32)), --ghash_precompute);
+            AESECB6_UPDATE(4);
+            _mm256_stream_si256((void *)output, _mm256_load_si256((void *)encbuf));
+            _mm256_stream_si256((void *)(output + 32), _mm256_load_si256((void *)(encbuf + 32)));
+            _mm256_stream_si256((void *)(output + 64), _mm256_load_si256((void *)(encbuf + 64)));
+            _mm256_stream_si256((void *)(output + 96), _mm256_load_si256((void *)(encbuf + 96)));
+            _mm256_stream_si256((void *)(output + 128), _mm256_load_si256((void *)(encbuf + 128)));
+            _mm256_stream_si256((void *)(output + 160), _mm256_load_si256((void *)(encbuf + 160)));
+            AESECB6_UPDATE(5);
+            gfmul_nextstep256(&gstate, _mm256_loadu_si256((void *)(encp - 2 * 32)), --ghash_precompute);
+            AESECB6_UPDATE(6);
+            gfmul_nextstep256(&gstate, _mm256_loadu_si256((void *)(encp - 1 * 32)), --ghash_precompute);
+            output += 192;
+            encp -= 192;
+            AESECB6_UPDATE(7);
+            _mm256_store_si256((void *)encbuf, _mm256_load_si256((void *)(encbuf + 192)));
+            AESECB6_UPDATE(8);
+            _mm256_store_si256((void *)(encbuf + 32), _mm256_load_si256((void *)(encbuf + 224)));
+            AESECB6_UPDATE(9);
+            if (PTLS_UNLIKELY(ctx->ecb.rounds != 10)) {
+                for (size_t i = 10; PTLS_LIKELY(i < ctx->ecb.rounds); ++i)
+                    AESECB6_UPDATE(i);
+            }
+            assert(ctx->ghash256 == ghash_precompute);
+            gfmul_reduce256(&gstate);
+            AESECB6_FINAL(ctx->ecb.rounds);
+        }
+    }
+
+    /* Now, All the encrypted bits are built in encbuf. Calculate AEAD tag and append to encbuf. */
+
+    { /* Run ghash against the remaining bytes, after appending `ac` (i.e., len(A) | len(C)). At this point, we might be ghashing 7
+       * blocks at once. */
+        size_t ac_off = remaining_ghash_from + ((encp - encbuf) - remaining_ghash_from + 15) / 16 * 16;
+        _mm_storeu_si128((void *)(encbuf + ac_off), ac);
+        size_t blocks = ((encp - encbuf) - remaining_ghash_from + 15) / 16 + 1; /* round up, +1 for AC */
+        assert(blocks <= 13);
+        union ptls_fusion_aesgcm_ghash_precompute256 *ghash_precompute = ctx->ghash256 + blocks / 2;
+        if (blocks % 2 != 0) {
+            gfmul_firststep256(&gstate, _mm256_loadu_si256((void *)(encbuf + remaining_ghash_from)), 1, ghash_precompute);
+            remaining_ghash_from += 16;
+        } else {
+            gfmul_firststep256(&gstate, _mm256_loadu_si256((void *)(encbuf + remaining_ghash_from)), 0, --ghash_precompute);
+            remaining_ghash_from += 32;
+        }
+        while (ghash_precompute != ctx->ghash256) {
+            gfmul_nextstep256(&gstate, _mm256_loadu_si256((void *)(encbuf + remaining_ghash_from)), --ghash_precompute);
+            remaining_ghash_from += 32;
+        }
+        gfmul_reduce256(&gstate);
+    }
+
+    /* Calculate EK0, if in the unlikely case on not been done yet. When encoding in full size (16K), EK0 will be ready. */
+    if (PTLS_UNLIKELY((state & STATE_EK0_READY) == 0)) {
+        bits5 = _mm256_insertf128_si256(bits5, ek0, 1);
+        bits5 = _mm256_xor_si256(bits5, ctx->ecb.keys.m256[0]);
+        for (size_t i = 1; i < ctx->ecb.rounds; ++i)
+            bits5 = _mm256_aesenc_epi128(bits5, ctx->ecb.keys.m256[i]);
+        bits5 = _mm256_aesenclast_epi128(bits5, ctx->ecb.keys.m256[ctx->ecb.rounds]);
+    }
+
+    /* append tag to encbuf */
+    _mm_storeu_si128((void *)encp,
+                     gfmul_get_tag256(&gstate, _mm256_castsi256_si128(_mm256_permute2f128_si256(bits5, bits5, 0x11))));
+    encp += 16;
+
+    /* write remaining bytes */
+    write_remaining_bytes(output, encbuf, encp);
 }
 
 static int fastls_setup(ptls_aead_context_t *_ctx, int is_enc, const void *key, const void *iv, size_t key_size)
 {
     struct aesgcm_context *ctx = (struct aesgcm_context *)_ctx;
 
-    ctx->static_iv = loadn(iv, PTLS_AESGCM_IV_SIZE);
-    ctx->static_iv = _mm_shuffle_epi8(ctx->static_iv, bswap8);
+    ctx->static_iv = loadn128(iv, PTLS_AESGCM_IV_SIZE);
+    ctx->static_iv = _mm_shuffle_epi8(ctx->static_iv, byteswap128);
     if (key == NULL)
         return 0;
 
     ctx->super.dispose_crypto = aesgcm_dispose_crypto;
     ctx->super.do_xor_iv = aesgcm_xor_iv;
     ctx->super.do_encrypt = ptls_aead__do_encrypt;
-    ctx->super.do_encrypt_v = fastls_encrypt_v;
+    ctx->super.do_encrypt_v = ptls_fusion_can_avx256 ? fastls_encrypt_v256 : fastls_encrypt_v128;
     ctx->super.do_decrypt = NULL; /* FIXME */
 
-    ctx->aesgcm = ptls_fusion_aesgcm_new(key, key_size, 7 * 16 /* 6 blocks at once, plus len(A) | len(C) that we might append */);
+    ctx->aesgcm = new_aesgcm(key, key_size,
+                             7 * (ptls_fusion_can_avx256 ? 32 : 16), // 6 blocks at once, plus len(A) | len(C) that we might append
+                             ptls_fusion_can_avx256);
 
     return 0;
 }
@@ -1435,11 +1899,16 @@ int ptls_fusion_is_supported_by_cpu(void)
         leaf1_ecx = cpu_info[2];
 
         if (/* PCLMUL */ (leaf1_ecx & (1 << 5)) != 0 && /* AES */ (leaf1_ecx & (1 << 25)) != 0) {
-            uint32_t leaf7_ebx;
+            uint32_t leaf7_ebx, leaf7_ecx;
             __cpuid(cpu_info, 7);
             leaf7_ebx = cpu_info[1];
+            leaf7_ecx = cpu_info[2];
 
             is_supported = /* AVX2 */ (leaf7_ebx & (1 << 5)) != 0;
+
+            /* enable 256-bit mode if possible */
+            if (is_supported && (leaf7_ecx & 0x600) != 0 && !ptls_fusion_avx256)
+                ptls_fusion_can_avx256 = 1;
         }
     }
 
@@ -1448,7 +1917,7 @@ int ptls_fusion_is_supported_by_cpu(void)
 #else
 int ptls_fusion_is_supported_by_cpu(void)
 {
-    unsigned leaf1_ecx, leaf7_ebx;
+    unsigned leaf1_ecx, leaf7_ebx, leaf7_ecx;
 
     { /* GCC-specific code to obtain CPU features */
         unsigned leaf_cnt;
@@ -1456,7 +1925,7 @@ int ptls_fusion_is_supported_by_cpu(void)
         if (leaf_cnt < 7)
             return 0;
         __asm__("cpuid" : "=c"(leaf1_ecx) : "a"(1) : "ebx", "edx");
-        __asm__("cpuid" : "=b"(leaf7_ebx) : "a"(7), "c"(0) : "edx");
+        __asm__("cpuid" : "=b"(leaf7_ebx), "=c"(leaf7_ecx) : "a"(7), "c"(0) : "edx");
     }
 
     /* AVX2 */
@@ -1468,6 +1937,10 @@ int ptls_fusion_is_supported_by_cpu(void)
     /* PCLMUL */
     if ((leaf1_ecx & (1 << 1)) == 0)
         return 0;
+
+    /* enable 256-bit mode if possible */
+    if ((leaf7_ecx & 0x600) != 0 && !ptls_fusion_can_avx256)
+        ptls_fusion_can_avx256 = 1;
 
     return 1;
 }

--- a/lib/fusion.c
+++ b/lib/fusion.c
@@ -1975,14 +1975,16 @@ static void non_temporal_encrypt_v256(struct st_ptls_aead_context_t *_ctx, void 
                         --srclen;
                     }
                     if (PTLS_UNLIKELY(srclen == 0)) {
-                        if (src_vecleft == 0) {
-                            break;
-                        } else {
+                        do {
+                            if (src_vecleft == 0)
+                                break;
                             src = (void *)input[0].base;
                             srclen = input[0].len;
                             ++input;
                             --src_vecleft;
-                        }
+                        } while (srclen == 0);
+                        if (srclen == 0)
+                            break;
                     }
                 } while (bytes_copied < 6 * 32);
 #define APPLY(i)                                                                                                                   \

--- a/lib/fusion.c
+++ b/lib/fusion.c
@@ -59,6 +59,10 @@
 #define NO_SANITIZE_ADDRESS
 #endif
 
+#ifdef _WINDOWS
+#define aligned_alloc(a, s) _aligned_malloc((s), (a))
+#endif
+
 struct ptls_fusion_aesgcm_context {
     ptls_fusion_aesecb_context_t ecb;
     size_t capacity;

--- a/lib/fusion.c
+++ b/lib/fusion.c
@@ -1472,14 +1472,16 @@ static void non_temporal_encrypt_v128(struct st_ptls_aead_context_t *_ctx, void 
                         --srclen;
                     }
                     if (PTLS_UNLIKELY(srclen == 0)) {
-                        if (src_vecleft == 0) {
-                            break;
-                        } else {
+                        do {
+                            if (src_vecleft == 0)
+                                break;
                             src = (void *)input[0].base;
                             srclen = input[0].len;
                             ++input;
                             --src_vecleft;
-                        }
+                        } while (srclen == 0);
+                        if (srclen == 0)
+                            break;
                     }
                 } while (bytes_copied < 6 * 16);
 #define APPLY(i) _mm_storeu_si128((void *)(encp + i * 16), _mm_xor_si128(_mm_loadu_si128((void *)(encp + i * 16)), bits##i))

--- a/lib/fusion.c
+++ b/lib/fusion.c
@@ -318,7 +318,7 @@ static inline __m128i gfmul_get_tag256(struct ptls_fusion_gfmul_state256 *gstate
 
 static inline __m128i aesecb_encrypt(ptls_fusion_aesecb_context_t *ctx, __m128i v)
 {
-#define ROUNDKEY(i) (ctx->avx256 ? _mm256_castsi256_si128(ctx->keys.m256[i]) : ctx->keys.m128[i])
+#define ROUNDKEY(i) (ctx->aesni256 ? _mm256_castsi256_si128(ctx->keys.m256[i]) : ctx->keys.m128[i])
 
     v = _mm_xor_si128(v, ROUNDKEY(0));
     for (size_t i = 1; i < ctx->rounds; ++i)
@@ -851,7 +851,7 @@ static __m128i expand_key(__m128i key, __m128i temp)
     return key;
 }
 
-void ptls_fusion_aesecb_init(ptls_fusion_aesecb_context_t *ctx, int is_enc, const void *key, size_t key_size, int avx256)
+void ptls_fusion_aesecb_init(ptls_fusion_aesecb_context_t *ctx, int is_enc, const void *key, size_t key_size, int aesni256)
 {
     assert(is_enc && "decryption is not supported (yet)");
 
@@ -868,7 +868,7 @@ void ptls_fusion_aesecb_init(ptls_fusion_aesecb_context_t *ctx, int is_enc, cons
         assert(!"invalid key size; AES128 / AES256 are supported");
         break;
     }
-    ctx->avx256 = avx256;
+    ctx->aesni256 = aesni256;
 
     /* load and expand keys using keys.m128 */
     ctx->keys.m128[i++] = _mm_loadu_si128((__m128i *)key);
@@ -903,8 +903,8 @@ void ptls_fusion_aesecb_init(ptls_fusion_aesecb_context_t *ctx, int is_enc, cons
 #undef EXPAND
     }
 
-    /* convert to keys.m256 if avx256 is used */
-    if (ctx->avx256) {
+    /* convert to keys.m256 if aesni256 is used */
+    if (ctx->aesni256) {
         size_t i = ctx->rounds;
         do {
             ctx->keys.m256[i] = _mm256_broadcastsi128_si256(ctx->keys.m128[i]);
@@ -937,7 +937,7 @@ static void setup_one_ghash_entry(ptls_fusion_aesgcm_context_t *ctx)
 {
     __m128i *H, *r, *Hprev, H0;
 
-    if (ctx->ecb.avx256) {
+    if (ctx->ecb.aesni256) {
         struct ptls_fusion_aesgcm_context256 *ctx256 = (void *)ctx;
 #define GET_SLOT(i, mem) (&ctx256->ghash[(i) / 2].mem[(i) % 2 == 0])
         H = GET_SLOT(ctx->ghash_cnt, H);
@@ -962,11 +962,11 @@ static void setup_one_ghash_entry(ptls_fusion_aesgcm_context_t *ctx)
     ++ctx->ghash_cnt;
 }
 
-static size_t calc_aesgcm_context_size(size_t *ghash_cnt, int avx256)
+static size_t calc_aesgcm_context_size(size_t *ghash_cnt, int aesni256)
 {
     size_t sz;
 
-    if (avx256) {
+    if (aesni256) {
         if (*ghash_cnt % 2 != 0)
             ++*ghash_cnt;
         sz = offsetof(struct ptls_fusion_aesgcm_context256, ghash) +
@@ -978,22 +978,22 @@ static size_t calc_aesgcm_context_size(size_t *ghash_cnt, int avx256)
     return sz;
 }
 
-static ptls_fusion_aesgcm_context_t *new_aesgcm(const void *key, size_t key_size, size_t capacity, int avx256)
+static ptls_fusion_aesgcm_context_t *new_aesgcm(const void *key, size_t key_size, size_t capacity, int aesni256)
 {
     ptls_fusion_aesgcm_context_t *ctx;
-    size_t ghash_cnt = aesgcm_calc_ghash_cnt(capacity), ctx_size = calc_aesgcm_context_size(&ghash_cnt, avx256);
+    size_t ghash_cnt = aesgcm_calc_ghash_cnt(capacity), ctx_size = calc_aesgcm_context_size(&ghash_cnt, aesni256);
 
     if ((ctx = aligned_alloc(32, ctx_size)) == NULL)
         return NULL;
 
-    ptls_fusion_aesecb_init(&ctx->ecb, 1, key, key_size, avx256);
+    ptls_fusion_aesecb_init(&ctx->ecb, 1, key, key_size, aesni256);
 
     ctx->capacity = capacity;
 
     __m128i H0 = aesecb_encrypt(&ctx->ecb, _mm_setzero_si128());
     H0 = _mm_shuffle_epi8(H0, byteswap128);
     H0 = transformH(H0);
-    if (ctx->ecb.avx256) {
+    if (ctx->ecb.aesni256) {
         ((struct ptls_fusion_aesgcm_context256 *)ctx)->ghash[0].H[1] = H0;
     } else {
         ((struct ptls_fusion_aesgcm_context128 *)ctx)->ghash[0].H = H0;
@@ -1018,7 +1018,7 @@ ptls_fusion_aesgcm_context_t *ptls_fusion_aesgcm_set_capacity(ptls_fusion_aesgcm
     if (ghash_cnt <= ctx->ghash_cnt)
         return ctx;
 
-    size_t ctx_size = calc_aesgcm_context_size(&ghash_cnt, ctx->ecb.avx256);
+    size_t ctx_size = calc_aesgcm_context_size(&ghash_cnt, ctx->ecb.aesni256);
     ptls_fusion_aesgcm_context_t *newp;
     if ((newp = aligned_alloc(32, ctx_size)) == NULL)
         return NULL;
@@ -1035,7 +1035,7 @@ ptls_fusion_aesgcm_context_t *ptls_fusion_aesgcm_set_capacity(ptls_fusion_aesgcm
 
 void ptls_fusion_aesgcm_free(ptls_fusion_aesgcm_context_t *ctx)
 {
-    ptls_clear_memory(ctx, calc_aesgcm_context_size(&ctx->ghash_cnt, ctx->ecb.avx256));
+    ptls_clear_memory(ctx, calc_aesgcm_context_size(&ctx->ghash_cnt, ctx->ecb.aesni256));
     /* skip ptls_fusion_aesecb_dispose, based on the knowledge that it does not allocate memory elsewhere */
 
     free(ctx);
@@ -1077,7 +1077,7 @@ static int aesctr_setup(ptls_cipher_context_t *_ctx, int is_enc, const void *key
     ctx->super.do_dispose = ctr_dispose;
     ctx->super.do_init = ctr_init;
     ctx->super.do_transform = ctr_transform;
-    ptls_fusion_aesecb_init(&ctx->fusion, 1, key, key_size, 0 /* probably we do not need avx256 for CTR? */);
+    ptls_fusion_aesecb_init(&ctx->fusion, 1, key, key_size, 0 /* probably we do not need aesni256 for CTR? */);
     ctx->is_ready = 0;
 
     return 0;
@@ -1185,7 +1185,7 @@ static int aesgcm_setup(ptls_aead_context_t *_ctx, int is_enc, const void *key, 
     ctx->super.do_encrypt_v = aead_do_encrypt_v;
     ctx->super.do_decrypt = aead_do_decrypt;
 
-    ctx->aesgcm = new_aesgcm(key, key_size, 1500 /* assume ordinary packet size */, 0 /* no support for avx256 yet */);
+    ctx->aesgcm = new_aesgcm(key, key_size, 1500 /* assume ordinary packet size */, 0 /* no support for aesni256 yet */);
 
     return 0;
 }
@@ -1200,7 +1200,7 @@ static int aes256gcm_setup(ptls_aead_context_t *ctx, int is_enc, const void *key
     return aesgcm_setup(ctx, is_enc, key, iv, PTLS_AES256_KEY_SIZE);
 }
 
-int ptls_fusion_can_avx256 = 0;
+int ptls_fusion_can_aesni256 = 0;
 ptls_cipher_algorithm_t ptls_fusion_aes128ctr = {"AES128-CTR",
                                                  PTLS_AES128_KEY_SIZE,
                                                  1, // block size
@@ -2090,7 +2090,7 @@ static void non_temporal_encrypt_v256(struct st_ptls_aead_context_t *_ctx, void 
 static int non_temporal_setup(ptls_aead_context_t *_ctx, int is_enc, const void *key, const void *iv, size_t key_size)
 {
     struct aesgcm_context *ctx = (struct aesgcm_context *)_ctx;
-    int avx256 = is_enc && ptls_fusion_can_avx256;
+    int aesni256 = is_enc && ptls_fusion_can_aesni256;
 
     ctx->static_iv = loadn128(iv, PTLS_AESGCM_IV_SIZE);
     ctx->static_iv = _mm_shuffle_epi8(ctx->static_iv, byteswap128);
@@ -2104,18 +2104,19 @@ static int non_temporal_setup(ptls_aead_context_t *_ctx, int is_enc, const void 
     ctx->super.do_encrypt_final = NULL;
     if (is_enc) {
         ctx->super.do_encrypt = ptls_aead__do_encrypt;
-        ctx->super.do_encrypt_v = avx256 ? non_temporal_encrypt_v256 : non_temporal_encrypt_v128;
+        ctx->super.do_encrypt_v = aesni256 ? non_temporal_encrypt_v256 : non_temporal_encrypt_v128;
         ctx->super.do_decrypt = NULL;
     } else {
-        assert(!avx256);
+        assert(!aesni256);
         ctx->super.do_encrypt = NULL;
         ctx->super.do_encrypt_v = NULL;
         ctx->super.do_decrypt = non_temporal_decrypt128;
     }
 
-    ctx->aesgcm = new_aesgcm(key, key_size,
-                             7 * (ptls_fusion_can_avx256 ? 32 : 16), // 6 blocks at once, plus len(A) | len(C) that we might append
-                             avx256);
+    ctx->aesgcm =
+        new_aesgcm(key, key_size,
+                   7 * (ptls_fusion_can_aesni256 ? 32 : 16), // 6 blocks at once, plus len(A) | len(C) that we might append
+                   aesni256);
 
     return 0;
 }
@@ -2184,8 +2185,8 @@ int ptls_fusion_is_supported_by_cpu(void)
             is_supported = /* AVX2 */ (leaf7_ebx & (1 << 5)) != 0;
 
             /* enable 256-bit mode if possible */
-            if (is_supported && (leaf7_ecx & 0x600) != 0 && !ptls_fusion_can_avx256)
-                ptls_fusion_can_avx256 = 1;
+            if (is_supported && (leaf7_ecx & 0x600) != 0 && !ptls_fusion_can_aesni256)
+                ptls_fusion_can_aesni256 = 1;
         }
     }
 
@@ -2216,8 +2217,8 @@ int ptls_fusion_is_supported_by_cpu(void)
         return 0;
 
     /* enable 256-bit mode if possible */
-    if ((leaf7_ecx & 0x600) != 0 && !ptls_fusion_can_avx256)
-        ptls_fusion_can_avx256 = 1;
+    if ((leaf7_ecx & 0x600) != 0 && !ptls_fusion_can_aesni256)
+        ptls_fusion_can_aesni256 = 1;
 
     return 1;
 }

--- a/lib/fusion.c
+++ b/lib/fusion.c
@@ -1221,7 +1221,7 @@ static void fastls_encrypt_v(struct st_ptls_aead_context_t *_ctx, void *_output,
                 /* slow path, load at most 6 * 16 bytes to encbuf then encrypt in-place */
                 size_t bytes_copied = 0;
                 do {
-                    if (srclen >= 16 && bytes_copied < 5 * 16) {
+                    if (srclen >= 16) {
                         _mm_storeu_si128((void *)(encp + bytes_copied), _mm_loadu_si128((void *)src));
                         bytes_copied += 16;
                         src += 16;

--- a/lib/fusion.c
+++ b/lib/fusion.c
@@ -17,7 +17,7 @@
  * All other work, including modifications to the `transformH` function is
  * covered by the following MIT license:
  *
- * Copyright (c) 2020 Fastly, Kazuho Oku
+ * Copyright (c) 2020-2022 Fastly, Kazuho Oku
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to

--- a/lib/fusion.c
+++ b/lib/fusion.c
@@ -1067,10 +1067,8 @@ static void fastls_encrypt_v(struct st_ptls_aead_context_t *_ctx, void *_output,
             ctr = _mm_add_epi64(ctr, one8);                                                                                        \
             bits5 = _mm_shuffle_epi8(ctr, bswap8);                                                                                 \
         } else {                                                                                                                   \
-            if ((state & STATE_EK0_READY) == 0) {                                                                                  \
-                bits5 = ek0;                                                                                                       \
-                state |= STATE_EK0_READY;                                                                                          \
-            }                                                                                                                      \
+            bits5 = ek0;                                                                                                           \
+            state |= STATE_EK0_READY;                                                                                              \
         }                                                                                                                          \
         __m128i k = ctx->ecb.keys[0];                                                                                              \
         bits0 = _mm_xor_si128(bits0, k);                                                                                           \

--- a/lib/fusion.c
+++ b/lib/fusion.c
@@ -1221,7 +1221,7 @@ static void fastls_encrypt_v(struct st_ptls_aead_context_t *_ctx, void *_output,
                 /* slow path, load at most 6 * 16 bytes to encbuf then encrypt in-place */
                 size_t bytes_copied = 0;
                 do {
-                    if (srclen >= 16) {
+                    if (srclen >= 16 && bytes_copied < 5 * 16) {
                         _mm_storeu_si128((void *)(encp + bytes_copied), _mm_loadu_si128((void *)src));
                         bytes_copied += 16;
                         src += 16;

--- a/lib/fusion.c
+++ b/lib/fusion.c
@@ -347,7 +347,7 @@ static inline __m256i loadn256(const void *p, size_t l)
     if (PTLS_LIKELY(mod4k < 4096 - 32) || mod4k + l > 4096) {
         v = _mm256_loadu_si256(p);
     } else if (l > 16) {
-        __m128i first16 = _mm_loadu_si128(p), second16 = loadn128((uint8_t *)(p + 16), l - 16);
+        __m128i first16 = _mm_loadu_si128(p), second16 = loadn128((uint8_t *)p + 16, l - 16);
         v = _mm256_permute2f128_si256(_mm256_castsi128_si256(first16), _mm256_castsi128_si256(second16), 0x20);
     } else if (l == 16) {
         v = _mm256_castsi128_si256(_mm_loadu_si128(p));
@@ -1925,7 +1925,7 @@ int ptls_fusion_is_supported_by_cpu(void)
             is_supported = /* AVX2 */ (leaf7_ebx & (1 << 5)) != 0;
 
             /* enable 256-bit mode if possible */
-            if (is_supported && (leaf7_ecx & 0x600) != 0 && !ptls_fusion_avx256)
+            if (is_supported && (leaf7_ecx & 0x600) != 0 && !ptls_fusion_can_avx256)
                 ptls_fusion_can_avx256 = 1;
         }
     }

--- a/lib/fusion.c
+++ b/lib/fusion.c
@@ -1238,11 +1238,10 @@ static void fastls_encrypt_v(struct st_ptls_aead_context_t *_ctx, void *output, 
                 AESECB6_UPDATE(i);
                 gfmul_nextstep(&gstate, _mm_load_si128((void *)(encbuf + encbuf_size + (i - 6) * 16)), --ghash_precompute);
             }
-            AESECB6_UPDATE(6);
             _mm256_store_si256((void *)output, _mm256_load_si256((void *)encbuf));
             _mm256_store_si256((void *)(output + 32), _mm256_load_si256((void *)(encbuf + 32)));
+            AESECB6_UPDATE(6);
             AESECB6_UPDATE(7);
-            AESECB6_UPDATE(8);
             if (encbuf_size >= 128) {
                 _mm256_store_si256((void *)(output + 64), _mm256_load_si256((void *)(encbuf + 64)));
                 _mm256_store_si256((void *)(output + 96), _mm256_load_si256((void *)(encbuf + 96)));
@@ -1256,7 +1255,7 @@ static void fastls_encrypt_v(struct st_ptls_aead_context_t *_ctx, void *output, 
                 _mm256_store_si256((void *)encbuf, _mm256_load_si256((void *)encbuf + 64));
                 _mm256_store_si256((void *)encbuf + 32, _mm256_load_si256((void *)encbuf + 96));
             }
-            for (size_t i = 9; i < ctx->ecb.rounds; ++i)
+            for (size_t i = 8; i < ctx->ecb.rounds; ++i)
                 AESECB6_UPDATE(i);
             assert(ctx->ghash == ghash_precompute);
             gfmul_reduce(&gstate);

--- a/lib/fusion.c
+++ b/lib/fusion.c
@@ -1163,7 +1163,7 @@ static void fastls_encrypt_v(struct st_ptls_aead_context_t *_ctx, void *output, 
             /* apply the bit stream to input, writing to encbuf */
             if (PTLS_LIKELY(srclen >= 6 * 16)) {
 #define APPLY(i)                                                                                                                   \
-    _mm_store_si128((void *)(encbuf + encbuf_size + i * 16), _mm_xor_si128(_mm_loadu_si128((void *)(src + i * 16)), bits##i))
+    _mm_storeu_si128((void *)(encbuf + encbuf_size + i * 16), _mm_xor_si128(_mm_loadu_si128((void *)(src + i * 16)), bits##i))
                 APPLY(0);
                 APPLY(1);
                 APPLY(2);
@@ -1189,7 +1189,7 @@ static void fastls_encrypt_v(struct st_ptls_aead_context_t *_ctx, void *output, 
                 size_t bytes_copied = 0;
                 do {
                     if (srclen >= 16 && bytes_copied < 5 * 80) {
-                        _mm_store_si128((void *)(encbuf + encbuf_size + bytes_copied), _mm_loadu_si128((void *)src));
+                        _mm_storeu_si128((void *)(encbuf + encbuf_size + bytes_copied), _mm_loadu_si128((void *)src));
                         bytes_copied += 16;
                         src += 16;
                         srclen -= 16;
@@ -1209,8 +1209,8 @@ static void fastls_encrypt_v(struct st_ptls_aead_context_t *_ctx, void *output, 
                     }
                 } while (bytes_copied < 6 * 16);
 #define APPLY(i)                                                                                                                   \
-    _mm_store_si128((void *)(encbuf + encbuf_size + i * 16),                                                                       \
-                    _mm_xor_si128(_mm_load_si128((void *)(encbuf + encbuf_size + i * 16)), bits##i))
+    _mm_storeu_si128((void *)(encbuf + encbuf_size + i * 16),                                                                      \
+                     _mm_xor_si128(_mm_loadu_si128((void *)(encbuf + encbuf_size + i * 16)), bits##i))
                 APPLY(0);
                 APPLY(1);
                 APPLY(2);
@@ -1223,7 +1223,7 @@ static void fastls_encrypt_v(struct st_ptls_aead_context_t *_ctx, void *output, 
                     /* Calculate amonut of data left to be ghashed, as well as zero-clearing the remainedr of partial block, as it
                      * will be fed into ghash. */
                     remaining_ghash_from = encbuf_size - bytes_copied;
-                    if ((encbuf_size & 15) != 0)
+                    if ((bytes_copied & 15) != 0)
                         _mm_storeu_si128((void *)(encbuf + encbuf_size), _mm_setzero_si128());
                     break;
                 }
@@ -1233,10 +1233,10 @@ static void fastls_encrypt_v(struct st_ptls_aead_context_t *_ctx, void *output, 
              * blocks. */
             AESECB6_INIT();
             struct ptls_fusion_aesgcm_ghash_precompute *ghash_precompute = ctx->ghash + 6;
-            gfmul_firststep(&gstate, _mm_load_si128((void *)encbuf + encbuf_size - 6 * 16), --ghash_precompute);
+            gfmul_firststep(&gstate, _mm_loadu_si128((void *)encbuf + encbuf_size - 6 * 16), --ghash_precompute);
             for (size_t i = 1; i <= 5; ++i) {
                 AESECB6_UPDATE(i);
-                gfmul_nextstep(&gstate, _mm_load_si128((void *)(encbuf + encbuf_size + (i - 6) * 16)), --ghash_precompute);
+                gfmul_nextstep(&gstate, _mm_loadu_si128((void *)(encbuf + encbuf_size + (i - 6) * 16)), --ghash_precompute);
             }
             _mm256_stream_si256((void *)output, _mm256_load_si256((void *)encbuf));
             _mm256_stream_si256((void *)(output + 32), _mm256_load_si256((void *)(encbuf + 32)));
@@ -1267,14 +1267,15 @@ static void fastls_encrypt_v(struct st_ptls_aead_context_t *_ctx, void *output, 
 
     { /* Run ghash against the remaining bytes, after appending `ac` (i.e., len(A) | len(C)). At this point, we might be ghashing 7
        * blocks at once. */
-        _mm_store_si128((void *)(encbuf + (encbuf_size + 15) / 16 * 16), ac);
+        size_t ac_off = remaining_ghash_from + (encbuf_size - remaining_ghash_from + 15) / 16 * 16;
+        _mm_storeu_si128((void *)(encbuf + ac_off), ac);
         size_t blocks = (encbuf_size - remaining_ghash_from + 15) / 16 + 1; /* round up, +1 for AC */
         assert(blocks <= 7);
         struct ptls_fusion_aesgcm_ghash_precompute *ghash_precompute = ctx->ghash + blocks;
-        gfmul_firststep(&gstate, _mm_load_si128((void *)(encbuf + remaining_ghash_from)), --ghash_precompute);
+        gfmul_firststep(&gstate, _mm_loadu_si128((void *)(encbuf + remaining_ghash_from)), --ghash_precompute);
         remaining_ghash_from += 16;
         while (ghash_precompute != ctx->ghash) {
-            gfmul_nextstep(&gstate, _mm_load_si128((void *)(encbuf + remaining_ghash_from)), --ghash_precompute);
+            gfmul_nextstep(&gstate, _mm_loadu_si128((void *)(encbuf + remaining_ghash_from)), --ghash_precompute);
             remaining_ghash_from += 16;
         }
         gfmul_reduce(&gstate);

--- a/lib/fusion.c
+++ b/lib/fusion.c
@@ -1264,8 +1264,10 @@ static void fastls_encrypt_v(struct st_ptls_aead_context_t *_ctx, void *output, 
                 AESECB6_UPDATE(8);
             }
             AESECB6_UPDATE(9);
-            for (size_t i = 10; i < ctx->ecb.rounds; ++i)
-                AESECB6_UPDATE(i);
+            if (PTLS_UNLIKELY(ctx->ecb.rounds != 10)) {
+                for (size_t i = 10; PTLS_LIKELY(i < ctx->ecb.rounds); ++i)
+                    AESECB6_UPDATE(i);
+            }
             assert(ctx->ghash == ghash_precompute);
             gfmul_reduce(&gstate);
             AESECB6_FINAL(ctx->ecb.rounds);

--- a/lib/fusion.c
+++ b/lib/fusion.c
@@ -334,6 +334,7 @@ static inline __m128i loadn_end_of_page(const void *p, size_t l)
     return _mm_shuffle_epi8(_mm_load_si128((const __m128i *)((uintptr_t)p - shift)), pattern);
 }
 
+NO_SANITIZE_ADDRESS
 static inline __m128i loadn128(const void *p, size_t l)
 {
     __m128i v, mask = _mm_loadu_si128((__m128i *)(loadn_mask + 32 - l));
@@ -349,6 +350,7 @@ static inline __m128i loadn128(const void *p, size_t l)
     return v;
 }
 
+NO_SANITIZE_ADDRESS
 static inline __m256i loadn256(const void *p, size_t l)
 {
     __m256i v, mask = _mm256_loadu_si256((__m256i *)(loadn_mask + 32 - l));

--- a/lib/fusion.c
+++ b/lib/fusion.c
@@ -1665,36 +1665,31 @@ static size_t non_temporal_decrypt128(ptls_aead_context_t *_ctx, void *_output, 
 
     /* Main loop. Operate in full blocks (6 * 16 bytes). */
     while (PTLS_LIKELY(inlen >= 6 * 16)) {
-        uint8_t keystream[6 * 16] __attribute__((aligned(16)));
-        _mm_store_si128((void *)keystream, bits0);
-        _mm_store_si128((void *)(keystream + 16), bits1);
-        _mm_store_si128((void *)(keystream + 32), bits2);
-        _mm_store_si128((void *)(keystream + 48), bits3);
-        _mm_store_si128((void *)(keystream + 64), bits4);
-        _mm_store_si128((void *)(keystream + 80), bits5);
+#define MERGE_BITS(x, y) _mm256_permute2f128_si256(_mm256_castsi128_si256(x), _mm256_castsi128_si256(y), 0x20)
+        __m256i ks0 = MERGE_BITS(bits0, bits1), ks2 = MERGE_BITS(bits2, bits3), ks4 = MERGE_BITS(bits4, bits5);
+#undef MERGE_BITS
 #define APPLY(i)                                                                                                                   \
     do {                                                                                                                           \
-        __m128i b = _mm_loadu_si128((void *)input + i * 16);                                                                       \
-        _mm_storeu_si128((void *)(output + i * 16), _mm_xor_si128(_mm_load_si128((void *)(keystream + i * 16)), b));               \
+        __m256i bb = _mm256_loadu_si256((void *)(input + i * 16));                                                                 \
+        _mm256_storeu_si256((void *)(output + i * 16), _mm256_xor_si256(ks##i, bb));                                               \
+        __m128i b0 = _mm256_castsi256_si128(bb), b1 = _mm256_castsi256_si128(_mm256_permute2f128_si256(bb, bb, 0x81));             \
         if (i == 0) {                                                                                                              \
-            gfmul_firststep128(&gstate, b, ctx->ghash + 5 - i);                                                                    \
+            gfmul_firststep128(&gstate, b0, ctx->ghash + 5 - i);                                                                   \
         } else {                                                                                                                   \
-            gfmul_nextstep128(&gstate, b, ctx->ghash + 5 - i);                                                                     \
+            gfmul_nextstep128(&gstate, b0, ctx->ghash + 5 - i);                                                                    \
         }                                                                                                                          \
+        gfmul_nextstep128(&gstate, b1, ctx->ghash + 4 - i);                                                                        \
     } while (0)
         AESECB6_INIT();
         AESECB6_UPDATE(1);
         APPLY(0);
         AESECB6_UPDATE(2);
-        APPLY(1);
         AESECB6_UPDATE(3);
         APPLY(2);
         AESECB6_UPDATE(4);
-        APPLY(3);
         AESECB6_UPDATE(5);
         APPLY(4);
         AESECB6_UPDATE(6);
-        APPLY(5);
         AESECB6_UPDATE(7);
         gfmul_reduce128(&gstate);
         AESECB6_UPDATE(8);

--- a/lib/fusion.c
+++ b/lib/fusion.c
@@ -1238,13 +1238,13 @@ static void fastls_encrypt_v(struct st_ptls_aead_context_t *_ctx, void *output, 
                 AESECB6_UPDATE(i);
                 gfmul_nextstep(&gstate, _mm_load_si128((void *)(encbuf + encbuf_size + (i - 6) * 16)), --ghash_precompute);
             }
-            _mm256_store_si256((void *)output, _mm256_load_si256((void *)encbuf));
-            _mm256_store_si256((void *)(output + 32), _mm256_load_si256((void *)(encbuf + 32)));
+            _mm256_stream_si256((void *)output, _mm256_load_si256((void *)encbuf));
+            _mm256_stream_si256((void *)(output + 32), _mm256_load_si256((void *)(encbuf + 32)));
             AESECB6_UPDATE(6);
             AESECB6_UPDATE(7);
             if (encbuf_size >= 128) {
-                _mm256_store_si256((void *)(output + 64), _mm256_load_si256((void *)(encbuf + 64)));
-                _mm256_store_si256((void *)(output + 96), _mm256_load_si256((void *)(encbuf + 96)));
+                _mm256_stream_si256((void *)(output + 64), _mm256_load_si256((void *)(encbuf + 64)));
+                _mm256_stream_si256((void *)(output + 96), _mm256_load_si256((void *)(encbuf + 96)));
                 output += 128;
                 encbuf_size -= 128;
                 _mm256_store_si256((void *)encbuf, _mm256_load_si256((void *)encbuf + 128));

--- a/lib/fusion.c
+++ b/lib/fusion.c
@@ -1019,8 +1019,12 @@ ptls_fusion_aesgcm_context_t *ptls_fusion_aesgcm_set_capacity(ptls_fusion_aesgcm
         return ctx;
 
     size_t ctx_size = calc_aesgcm_context_size(&ghash_cnt, ctx->ecb.avx256);
-    if ((ctx = realloc(ctx, ctx_size)) == NULL)
+    ptls_fusion_aesgcm_context_t *newp;
+    if ((newp = aligned_alloc(32, ctx_size)) == NULL)
         return NULL;
+    memcpy(newp, ctx, ctx_size);
+    free(ctx);
+    ctx = newp;
 
     ctx->capacity = capacity;
     while (ghash_cnt < ctx->ghash_cnt)

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -1593,6 +1593,7 @@ ptls_aead_algorithm_t ptls_openssl_aes128gcm = {"AES128-GCM",
                                                 PTLS_AES128_KEY_SIZE,
                                                 PTLS_AESGCM_IV_SIZE,
                                                 PTLS_AESGCM_TAG_SIZE,
+                                                0,
                                                 sizeof(struct aead_crypto_context_t),
                                                 aead_aes128gcm_setup_crypto};
 ptls_cipher_algorithm_t ptls_openssl_aes256ecb = {
@@ -1609,6 +1610,7 @@ ptls_aead_algorithm_t ptls_openssl_aes256gcm = {"AES256-GCM",
                                                 PTLS_AES256_KEY_SIZE,
                                                 PTLS_AESGCM_IV_SIZE,
                                                 PTLS_AESGCM_TAG_SIZE,
+                                                0,
                                                 sizeof(struct aead_crypto_context_t),
                                                 aead_aes256gcm_setup_crypto};
 ptls_hash_algorithm_t ptls_openssl_sha256 = {PTLS_SHA256_BLOCK_SIZE, PTLS_SHA256_DIGEST_SIZE, sha256_create,
@@ -1635,6 +1637,7 @@ ptls_aead_algorithm_t ptls_openssl_chacha20poly1305 = {"CHACHA20-POLY1305",
                                                        PTLS_CHACHA20_KEY_SIZE,
                                                        PTLS_CHACHA20POLY1305_IV_SIZE,
                                                        PTLS_CHACHA20POLY1305_TAG_SIZE,
+                                                       0,
                                                        sizeof(struct aead_crypto_context_t),
                                                        aead_chacha20poly1305_setup_crypto};
 ptls_cipher_suite_t ptls_openssl_chacha20poly1305sha256 = {.id = PTLS_CIPHER_SUITE_CHACHA20_POLY1305_SHA256,

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -509,8 +509,13 @@ static uint64_t ntoh64(const uint8_t *src)
 void ptls_buffer__release_memory(ptls_buffer_t *buf)
 {
     ptls_clear_memory(buf->base, buf->off);
-    if (buf->is_allocated)
+    if (buf->is_allocated) {
+#ifdef _WINDOWS
+        _aligned_free(buf->base);
+#else
         free(buf->base);
+#endif
+    }
 }
 
 int ptls_buffer_reserve(ptls_buffer_t *buf, size_t delta)
@@ -526,8 +531,13 @@ int ptls_buffer_reserve(ptls_buffer_t *buf, size_t delta)
         while (new_capacity < buf->off + delta) {
             new_capacity *= 2;
         }
+#ifdef _WINDOWS
+        if ((newp = _aligned_malloc(new_capacity, PTLS_SIZEOF_CACHE_LINE)) == NULL)
+            return PTLS_ERROR_NO_MEMORY;
+#else
         if (posix_memalign(&newp, PTLS_SIZEOF_CACHE_LINE, new_capacity) != 0)
             return PTLS_ERROR_NO_MEMORY;
+#endif
         memcpy(newp, buf->base, buf->off);
         ptls_buffer__release_memory(buf);
         buf->base = newp;

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -519,14 +519,14 @@ int ptls_buffer_reserve(ptls_buffer_t *buf, size_t delta)
         return PTLS_ERROR_NO_MEMORY;
 
     if (PTLS_MEMORY_DEBUG || buf->capacity < buf->off + delta) {
-        uint8_t *newp;
+        void *newp;
         size_t new_capacity = buf->capacity;
         if (new_capacity < 1024)
             new_capacity = 1024;
         while (new_capacity < buf->off + delta) {
             new_capacity *= 2;
         }
-        if ((newp = malloc(new_capacity)) == NULL)
+        if (posix_memalign(&newp, PTLS_SIZEOF_CACHE_LINE, new_capacity) != 0)
             return PTLS_ERROR_NO_MEMORY;
         memcpy(newp, buf->base, buf->off);
         ptls_buffer__release_memory(buf);

--- a/lib/ptlsbcrypt.c
+++ b/lib/ptlsbcrypt.c
@@ -786,6 +786,7 @@ ptls_aead_algorithm_t ptls_bcrypt_aes128gcm = {"AES128-GCM",
                                                PTLS_AES128_KEY_SIZE,
                                                PTLS_AESGCM_IV_SIZE,
                                                PTLS_AESGCM_TAG_SIZE,
+                                               0,
                                                sizeof(struct ptls_bcrypt_aead_context_t),
                                                ptls_bcrypt_aead_setup_crypto_aesgcm};
 
@@ -797,6 +798,7 @@ ptls_aead_algorithm_t ptls_bcrypt_aes256gcm = {"AES256-GCM",
                                                PTLS_AES256_KEY_SIZE,
                                                PTLS_AESGCM_IV_SIZE,
                                                PTLS_AESGCM_TAG_SIZE,
+                                               0,
                                                sizeof(struct ptls_bcrypt_aead_context_t),
                                                ptls_bcrypt_aead_setup_crypto_aesgcm};
 

--- a/picotls.xcodeproj/project.pbxproj
+++ b/picotls.xcodeproj/project.pbxproj
@@ -1286,7 +1286,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
-				OTHER_CFLAGS = "-march=native";
+				OTHER_CFLAGS = (
+					"-march=native",
+					"-mvaes",
+					"-mvpclmulqdq",
+				);
 				OTHER_LDFLAGS = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -1296,7 +1300,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
-				OTHER_CFLAGS = "-march=native";
+				OTHER_CFLAGS = (
+					"-march=native",
+					"-mvaes",
+					"-mvpclmulqdq",
+				);
 				OTHER_LDFLAGS = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};

--- a/t/fusion.c
+++ b/t/fusion.c
@@ -456,7 +456,7 @@ static void test_aesgcm(void)
 
 static void test_fastls(void)
 {
-    test_generated(&ptls_fastls_aes128gcm, &ptls_minicrypto_aes128gcm, 0);
+    test_generated(&ptls_non_temporal_aes128gcm, &ptls_minicrypto_aes128gcm, 0);
 }
 
 int main(int argc, char **argv)

--- a/t/fusion.c
+++ b/t/fusion.c
@@ -475,7 +475,7 @@ int main(int argc, char **argv)
     subtest("gcm-capacity", gcm_capacity);
     subtest("gcm-test-vectors", gcm_test_vectors);
     subtest("gcm-iv96", gcm_iv96);
-    subtest("aesgcm", test_aesgcm);
+    // subtest("aesgcm", test_aesgcm);
     subtest("fastls128", test_fastls);
 
     if (can256bit) {

--- a/t/fusion.c
+++ b/t/fusion.c
@@ -338,7 +338,7 @@ int main(int argc, char **argv)
     subtest("gcm-capacity", gcm_capacity);
     subtest("gcm-test-vectors", gcm_test_vectors);
     subtest("gcm-iv96", gcm_iv96);
-    subtest("aesgcm", test_aesgcm);
+    //subtest("aesgcm", test_aesgcm);
     subtest("fastls", test_fastls);
 
     return done_testing();

--- a/t/fusion.c
+++ b/t/fusion.c
@@ -110,12 +110,14 @@ static void test_gfmul(void)
         static const char input[32] = "deaddeadbeefbeef"; /* latter 16-byte is NUL */
         __m128i hash;
         if (ctx->ecb.avx256) {
-            struct ptls_fusion_gfmul_state256 state = {};
+            struct ptls_fusion_gfmul_state256 state;
+            state.lo = _mm256_setzero_si256();
             gfmul_firststep256(&state, _mm256_loadu_si256((void *)input), 1, ctx->ghash256);
             gfmul_reduce256(&state);
             hash = _mm256_castsi256_si128(state.lo);
         } else {
-            struct ptls_fusion_gfmul_state128 state = {};
+            struct ptls_fusion_gfmul_state128 state;
+            state.lo = _mm_setzero_si128();
             gfmul_firststep128(&state, _mm_loadu_si128((void *)input), ctx->ghash128);
             gfmul_reduce128(&state);
             hash = state.lo;
@@ -127,12 +129,14 @@ static void test_gfmul(void)
         static const char input[32] = "Lorem ipsum dolor sit amet, con";
         __m128i hash;
         if (ctx->ecb.avx256) {
-            struct ptls_fusion_gfmul_state256 state = {};
+            struct ptls_fusion_gfmul_state256 state;
+            state.lo = _mm256_setzero_si256();
             gfmul_firststep256(&state, _mm256_loadu_si256((void *)input), 0, ctx->ghash256);
             gfmul_reduce256(&state);
             hash = _mm256_castsi256_si128(state.lo);
         } else {
-            struct ptls_fusion_gfmul_state128 state = {};
+            struct ptls_fusion_gfmul_state128 state;
+            state.lo = _mm_setzero_si128();
             gfmul_firststep128(&state, _mm_loadu_si128((void *)input), ctx->ghash128 + 1);
             gfmul_nextstep128(&state, _mm_loadu_si128((void *)(input + 16)), ctx->ghash128);
             gfmul_reduce128(&state);
@@ -145,13 +149,15 @@ static void test_gfmul(void)
         static const char input[64] = "The quick brown fox jumps over the lazy dog.";
         __m128i hash;
         if (ctx->ecb.avx256) {
-            struct ptls_fusion_gfmul_state256 state = {};
+            struct ptls_fusion_gfmul_state256 state;
+            state.lo = _mm256_setzero_si256();
             gfmul_firststep256(&state, _mm256_loadu_si256((void *)input), 1, ctx->ghash256 + 1);
             gfmul_nextstep256(&state, _mm256_loadu_si256((void *)(input + 16)), ctx->ghash256);
             gfmul_reduce256(&state);
             hash = _mm256_castsi256_si128(state.lo);
         } else {
-            struct ptls_fusion_gfmul_state128 state = {};
+            struct ptls_fusion_gfmul_state128 state;
+            state.lo = _mm_setzero_si128();
             gfmul_firststep128(&state, _mm_loadu_si128((void *)input), ctx->ghash128 + 2);
             gfmul_nextstep128(&state, _mm_loadu_si128((void *)(input + 16)), ctx->ghash128 + 1);
             gfmul_nextstep128(&state, _mm_loadu_si128((void *)(input + 32)), ctx->ghash128);
@@ -165,7 +171,8 @@ static void test_gfmul(void)
         static const char input[80] = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor ";
         __m128i hash;
         if (ctx->ecb.avx256) {
-            struct ptls_fusion_gfmul_state256 state = {};
+            struct ptls_fusion_gfmul_state256 state;
+            state.lo = _mm256_setzero_si256();
             gfmul_firststep256(&state, _mm256_loadu_si256((void *)input), 0, ctx->ghash256 + 1);
             gfmul_nextstep256(&state, _mm256_loadu_si256((void *)(input + 32)), ctx->ghash256);
             gfmul_reduce256(&state);
@@ -173,7 +180,8 @@ static void test_gfmul(void)
             gfmul_reduce256(&state);
             hash = _mm256_castsi256_si128(state.lo);
         } else {
-            struct ptls_fusion_gfmul_state128 state = {};
+            struct ptls_fusion_gfmul_state128 state;
+            state.lo = _mm_setzero_si128();
             gfmul_firststep128(&state, _mm_loadu_si128((void *)input), ctx->ghash128 + 3);
             gfmul_nextstep128(&state, _mm_loadu_si128((void *)(input + 16)), ctx->ghash128 + 2);
             gfmul_nextstep128(&state, _mm_loadu_si128((void *)(input + 32)), ctx->ghash128 + 1);
@@ -191,7 +199,8 @@ static void test_gfmul(void)
             "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut la";
         __m128i hash;
         if (ctx->ecb.avx256) {
-            struct ptls_fusion_gfmul_state256 state = {};
+            struct ptls_fusion_gfmul_state256 state;
+            state.lo = _mm256_setzero_si256();
             gfmul_firststep256(&state, _mm256_loadu_si256((void *)input), 0, ctx->ghash256 + 1);
             gfmul_nextstep256(&state, _mm256_loadu_si256((void *)(input + 32)), ctx->ghash256);
             gfmul_reduce256(&state);
@@ -199,7 +208,8 @@ static void test_gfmul(void)
             gfmul_reduce256(&state);
             hash = _mm256_castsi256_si128(state.lo);
         } else {
-            struct ptls_fusion_gfmul_state128 state = {};
+            struct ptls_fusion_gfmul_state128 state;
+            state.lo = _mm_setzero_si128();
             gfmul_firststep128(&state, _mm_loadu_si128((void *)input), ctx->ghash128 + 3);
             gfmul_nextstep128(&state, _mm_loadu_si128((void *)(input + 16)), ctx->ghash128 + 2);
             gfmul_nextstep128(&state, _mm_loadu_si128((void *)(input + 32)), ctx->ghash128 + 1);

--- a/t/fusion.c
+++ b/t/fusion.c
@@ -338,7 +338,7 @@ int main(int argc, char **argv)
     subtest("gcm-capacity", gcm_capacity);
     subtest("gcm-test-vectors", gcm_test_vectors);
     subtest("gcm-iv96", gcm_iv96);
-    //subtest("aesgcm", test_aesgcm);
+    subtest("aesgcm", test_aesgcm);
     subtest("fastls", test_fastls);
 
     return done_testing();

--- a/t/fusion.c
+++ b/t/fusion.c
@@ -475,7 +475,7 @@ int main(int argc, char **argv)
     subtest("gcm-capacity", gcm_capacity);
     subtest("gcm-test-vectors", gcm_test_vectors);
     subtest("gcm-iv96", gcm_iv96);
-    // subtest("aesgcm", test_aesgcm);
+    subtest("aesgcm", test_aesgcm);
     subtest("fastls128", test_fastls);
 
     if (can256bit) {

--- a/t/fusion.c
+++ b/t/fusion.c
@@ -467,9 +467,10 @@ static void test_aesgcm(void)
     subtest("aes256gcm-iv96", test_generated_aes256_iv96);
 }
 
-static void test_fastls(void)
+static void test_non_temporal(void)
 {
     test_generated(&ptls_non_temporal_aes128gcm, &ptls_minicrypto_aes128gcm, 0);
+    test_generated(&ptls_minicrypto_aes128gcm, &ptls_non_temporal_aes128gcm, 0);
 }
 
 int main(int argc, char **argv)
@@ -489,12 +490,12 @@ int main(int argc, char **argv)
     subtest("gcm-test-vectors", gcm_test_vectors);
     subtest("gcm-iv96", gcm_iv96);
     subtest("aesgcm", test_aesgcm);
-    subtest("fastls128", test_fastls);
+    subtest("non-temporal128", test_non_temporal);
 
     if (can256bit) {
         ptls_fusion_can_avx256 = 1;
         subtest("gfmul256", test_gfmul);
-        subtest("fastls256", test_fastls);
+        subtest("non-temporal256", test_non_temporal);
         ptls_fusion_can_avx256 = 0;
     } else {
         note("gfmul256: skipping, CPU does not support 256-bit aes / clmul");


### PR DESCRIPTION
This PR implements "non-temporal aes-gcm" engine, that uses non-temporal store instructions when emitting encrypted bytes. When doing zero-copy to NIC, use of ordinary store instructions requires 2x the main memory bandwidth compared to what is actually being sent, because when an ordinary store instruction is issued against an uncached memory location, the CPU has to read that cache line into cache before updating part of that line (note: L3 cache is so small compared to the sum of the send buffers for all the connections inflight). By using non-temporal store instructions, the new engine avoids this read ("read-for-ownership" in terms of MOESI).

ToDo:
* [x] Add more tests (like unaligned output).
* [x] Use 256-bit AESNI / CLMUL instructions when available (Zen 3).
* [x] Suppress false positives found by ASAN. The engine works on 64-byte lines. If either edge of the supplied output buffer is not aligned to 64-byte, the engine reads the 64-byte line covering the edge, modifies the necessary bytes, then write back the entire line.
* [x] Implement decrypt side. It's a bit slower than OpenSSL with GCC, bit faster with clang.

Builds on top of #385.

![non-temporal aes-gcm engine (encrypt; commit 9f8e12ae)](https://user-images.githubusercontent.com/41567/167744223-1beb2f0c-cd63-42a2-b804-df005d3acbcb.png)

Older result: as of e0caecc, aes128gcm (16KB block) throughput, compared to openssl (ubuntu 20.04):
||gcc (nt on)|gcc (nt off<sup>1</sup>)|clang (nt on)|clang (nt off)|
|:--:|--:|--:|--:|--:|
|Core i5 9400|84.1%|95.8%|91.1%|92.2%|
|Ryzen 7 4750G|97.9%|101.8%|97.3%|101.2%|

*: "nt off" indicates that non-temporal store instructions (`_mm_stream_si256`) were replaced by ordinary stores (`_mm_store_si256`).