### PR TITLE
vectorized encrypt API

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -1551,10 +1551,8 @@ inline void ptls_aead__do_encrypt_v(ptls_aead_context_t *ctx, void *_output, ptl
     uint8_t *output = _output;
 
     ctx->do_encrypt_init(ctx, seq, aad, aadlen);
-    for (size_t i = 0; i < incnt; ++i) {
-        ctx->do_encrypt_update(ctx, output, input[i].base, input[i].len);
-        output += input[i].len;
-    }
+    for (size_t i = 0; i < incnt; ++i)
+        output += ctx->do_encrypt_update(ctx, output, input[i].base, input[i].len);
     ctx->do_encrypt_final(ctx, output);
 }
 

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -343,13 +343,12 @@ typedef struct st_ptls_aead_context_t {
     /* field above this line must not be altered by the crypto binding */
     void (*dispose_crypto)(struct st_ptls_aead_context_t *ctx);
     void (*do_xor_iv)(struct st_ptls_aead_context_t *ctx, const void *bytes, size_t len);
-    void (*do_encrypt_init)(struct st_ptls_aead_context_t *ctx, uint64_t seq, const void *aad, size_t aadlen);
-    size_t (*do_encrypt_update)(struct st_ptls_aead_context_t *ctx, void *output, const void *input, size_t inlen);
-    size_t (*do_encrypt_final)(struct st_ptls_aead_context_t *ctx, void *output);
     void (*do_encrypt)(struct st_ptls_aead_context_t *ctx, void *output, const void *input, size_t inlen, uint64_t seq,
-                       const void *aad, size_t aadlen, ptls_aead_supplementary_encryption_t *supp);
+                       ptls_iovec_t aad, ptls_aead_supplementary_encryption_t *supp);
+    void (*do_encrypt_v)(struct st_ptls_aead_context_t *ctx, void *output, ptls_iovec_t *input, size_t incnt, uint64_t seq,
+                         ptls_iovec_t aad);
     size_t (*do_decrypt)(struct st_ptls_aead_context_t *ctx, void *output, const void *input, size_t inlen, uint64_t seq,
-                         const void *aad, size_t aadlen);
+                         ptls_iovec_t aad);
 } ptls_aead_context_t;
 
 /**
@@ -1296,26 +1295,21 @@ void ptls_aead_free(ptls_aead_context_t *ctx);
  */
 static void ptls_aead_xor_iv(ptls_aead_context_t *ctx, const void *bytes, size_t len);
 /**
- *
+ * Encrypts one AEAD block, given input and output vectors.
  */
 static size_t ptls_aead_encrypt(ptls_aead_context_t *ctx, void *output, const void *input, size_t inlen, uint64_t seq,
                                 const void *aad, size_t aadlen);
+/**
+ * Encrypts one AEAD block, as well as one block of ECB (for QUIC / DTLS packet number encryption). Depending on the AEAD engine
+ * being used, the two operations might run simultaneously.
+ */
 static void ptls_aead_encrypt_s(ptls_aead_context_t *ctx, void *output, const void *input, size_t inlen, uint64_t seq,
                                 const void *aad, size_t aadlen, ptls_aead_supplementary_encryption_t *supp);
 /**
- * initializes the internal state of the encryptor
+ * Encrypts one AEAD block, given a vector of vectors.
  */
-static void ptls_aead_encrypt_init(ptls_aead_context_t *ctx, uint64_t seq, const void *aad, size_t aadlen);
-/**
- * encrypts the input and updates the GCM state
- * @return number of bytes emitted to output
- */
-static size_t ptls_aead_encrypt_update(ptls_aead_context_t *ctx, void *output, const void *input, size_t inlen);
-/**
- * emits buffered data (if any) and the GCM tag
- * @return number of bytes emitted to output
- */
-static size_t ptls_aead_encrypt_final(ptls_aead_context_t *ctx, void *output);
+static void ptls_aead_encrypt_v(ptls_aead_context_t *ctx, void *output, ptls_iovec_t *input, size_t incnt, uint64_t seq,
+                                ptls_iovec_t aad);
 /**
  * decrypts an AEAD record
  * @return number of bytes emitted to output if successful, or SIZE_MAX if the input is invalid (e.g. broken MAC)
@@ -1357,7 +1351,7 @@ void ptls_aead__build_iv(ptls_aead_algorithm_t *algo, uint8_t *iv, const uint8_t
  *
  */
 static void ptls_aead__do_encrypt(ptls_aead_context_t *ctx, void *output, const void *input, size_t inlen, uint64_t seq,
-                                  const void *aad, size_t aadlen, ptls_aead_supplementary_encryption_t *supp);
+                                  ptls_iovec_t aad, ptls_aead_supplementary_encryption_t *supp);
 /**
  * internal
  */
@@ -1484,37 +1478,28 @@ inline void ptls_aead_xor_iv(ptls_aead_context_t *ctx, const void *bytes, size_t
 inline size_t ptls_aead_encrypt(ptls_aead_context_t *ctx, void *output, const void *input, size_t inlen, uint64_t seq,
                                 const void *aad, size_t aadlen)
 {
-    ctx->do_encrypt(ctx, output, input, inlen, seq, aad, aadlen, NULL);
+    ctx->do_encrypt(ctx, output, input, inlen, seq, ptls_iovec_init(aad, aadlen), NULL);
     return inlen + ctx->algo->tag_size;
 }
 
 inline void ptls_aead_encrypt_s(ptls_aead_context_t *ctx, void *output, const void *input, size_t inlen, uint64_t seq,
                                 const void *aad, size_t aadlen, ptls_aead_supplementary_encryption_t *supp)
 {
-    ctx->do_encrypt(ctx, output, input, inlen, seq, aad, aadlen, supp);
+    ctx->do_encrypt(ctx, output, input, inlen, seq, ptls_iovec_init(aad, aadlen), supp);
 }
 
-inline void ptls_aead_encrypt_init(ptls_aead_context_t *ctx, uint64_t seq, const void *aad, size_t aadlen)
+inline void ptls_aead_encrypt_v(ptls_aead_context_t *ctx, void *output, ptls_iovec_t *input, size_t incnt, uint64_t seq,
+                                ptls_iovec_t aad)
 {
-    ctx->do_encrypt_init(ctx, seq, aad, aadlen);
-}
-
-inline size_t ptls_aead_encrypt_update(ptls_aead_context_t *ctx, void *output, const void *input, size_t inlen)
-{
-    return ctx->do_encrypt_update(ctx, output, input, inlen);
-}
-
-inline size_t ptls_aead_encrypt_final(ptls_aead_context_t *ctx, void *output)
-{
-    return ctx->do_encrypt_final(ctx, output);
+    ctx->do_encrypt_v(ctx, output, input, incnt, seq, aad);
 }
 
 inline void ptls_aead__do_encrypt(ptls_aead_context_t *ctx, void *output, const void *input, size_t inlen, uint64_t seq,
-                                  const void *aad, size_t aadlen, ptls_aead_supplementary_encryption_t *supp)
+                                  ptls_iovec_t aad, ptls_aead_supplementary_encryption_t *supp)
 {
-    ctx->do_encrypt_init(ctx, seq, aad, aadlen);
-    ctx->do_encrypt_update(ctx, output, input, inlen);
-    ctx->do_encrypt_final(ctx, (uint8_t *)output + inlen);
+    ptls_iovec_t invec = ptls_iovec_init(input, inlen);
+
+    ptls_aead_encrypt_v(ctx, output, &invec, 1, seq, aad);
 
     if (supp != NULL) {
         ptls_cipher_init(supp->ctx, supp->input);
@@ -1526,7 +1511,7 @@ inline void ptls_aead__do_encrypt(ptls_aead_context_t *ctx, void *output, const 
 inline size_t ptls_aead_decrypt(ptls_aead_context_t *ctx, void *output, const void *input, size_t inlen, uint64_t seq,
                                 const void *aad, size_t aadlen)
 {
-    return ctx->do_decrypt(ctx, output, input, inlen, seq, aad, aadlen);
+    return ctx->do_decrypt(ctx, output, input, inlen, seq, ptls_iovec_init(aad, aadlen));
 }
 
 #define ptls_define_hash(name, ctx_type, init_func, update_func, final_func)                                                       \

--- a/lib/cifra/aes-common.h
+++ b/lib/cifra/aes-common.h
@@ -111,25 +111,33 @@ static inline void aesgcm_dispose_crypto(ptls_aead_context_t *_ctx)
     ptls_clear_memory((uint8_t *)ctx + sizeof(ctx->super), sizeof(*ctx) - sizeof(ctx->super));
 }
 
-static void aesgcm_encrypt_v(struct st_ptls_aead_context_t *_ctx, void *output, ptls_iovec_t *input, size_t incnt, uint64_t seq,
-                             ptls_iovec_t aad)
+static inline void aesgcm_encrypt_init(ptls_aead_context_t *_ctx, uint64_t seq, const void *aad, size_t aadlen)
 {
     struct aesgcm_context_t *ctx = (struct aesgcm_context_t *)_ctx;
     uint8_t iv[PTLS_AES_BLOCK_SIZE];
 
     ptls_aead__build_iv(ctx->super.algo, iv, ctx->static_iv, seq);
-    cf_gcm_encrypt_init(&cf_aes, &ctx->aes, &ctx->gcm, aad.base, aad.len, iv, PTLS_AESGCM_IV_SIZE);
+    cf_gcm_encrypt_init(&cf_aes, &ctx->aes, &ctx->gcm, aad, aadlen, iv, PTLS_AESGCM_IV_SIZE);
+}
 
-    for (size_t i = 0; i < incnt; ++i) {
-        cf_gcm_encrypt_update(&ctx->gcm, input[i].base, input[i].len, output);
-        output += input[i].len;
-    }
+static inline size_t aesgcm_encrypt_update(ptls_aead_context_t *_ctx, void *output, const void *input, size_t inlen)
+{
+    struct aesgcm_context_t *ctx = (struct aesgcm_context_t *)_ctx;
+
+    cf_gcm_encrypt_update(&ctx->gcm, input, inlen, output);
+    return inlen;
+}
+
+static inline size_t aesgcm_encrypt_final(ptls_aead_context_t *_ctx, void *output)
+{
+    struct aesgcm_context_t *ctx = (struct aesgcm_context_t *)_ctx;
 
     cf_gcm_encrypt_final(&ctx->gcm, output, PTLS_AESGCM_TAG_SIZE);
+    return PTLS_AESGCM_TAG_SIZE;
 }
 
 static inline size_t aesgcm_decrypt(ptls_aead_context_t *_ctx, void *output, const void *input, size_t inlen, uint64_t seq,
-                                    ptls_iovec_t aad)
+                                    const void *aad, size_t aadlen)
 {
     struct aesgcm_context_t *ctx = (struct aesgcm_context_t *)_ctx;
     uint8_t iv[PTLS_AES_BLOCK_SIZE];
@@ -139,8 +147,8 @@ static inline size_t aesgcm_decrypt(ptls_aead_context_t *_ctx, void *output, con
     size_t tag_offset = inlen - PTLS_AESGCM_TAG_SIZE;
 
     ptls_aead__build_iv(ctx->super.algo, iv, ctx->static_iv, seq);
-    if (cf_gcm_decrypt(&cf_aes, &ctx->aes, input, tag_offset, aad.base, aad.len, iv, PTLS_AESGCM_IV_SIZE,
-                       (uint8_t *)input + tag_offset, PTLS_AESGCM_TAG_SIZE, output) != 0)
+    if (cf_gcm_decrypt(&cf_aes, &ctx->aes, input, tag_offset, aad, aadlen, iv, PTLS_AESGCM_IV_SIZE, (uint8_t *)input + tag_offset,
+                       PTLS_AESGCM_TAG_SIZE, output) != 0)
         return SIZE_MAX;
 
     return tag_offset;
@@ -162,10 +170,16 @@ static inline int aead_aesgcm_setup_crypto(ptls_aead_context_t *_ctx, int is_enc
     ctx->super.dispose_crypto = aesgcm_dispose_crypto;
     ctx->super.do_xor_iv = aesgcm_xor_iv;
     if (is_enc) {
+        ctx->super.do_encrypt_init = aesgcm_encrypt_init;
+        ctx->super.do_encrypt_update = aesgcm_encrypt_update;
+        ctx->super.do_encrypt_final = aesgcm_encrypt_final;
         ctx->super.do_encrypt = ptls_aead__do_encrypt;
-        ctx->super.do_encrypt_v = aesgcm_encrypt_v;
+        ctx->super.do_encrypt_v = ptls_aead__do_encrypt_v;
         ctx->super.do_decrypt = NULL;
     } else {
+        ctx->super.do_encrypt_init = NULL;
+        ctx->super.do_encrypt_update = NULL;
+        ctx->super.do_encrypt_final = NULL;
         ctx->super.do_encrypt = NULL;
         ctx->super.do_encrypt_v = NULL;
         ctx->super.do_decrypt = aesgcm_decrypt;

--- a/lib/cifra/chacha20.c
+++ b/lib/cifra/chacha20.c
@@ -103,9 +103,8 @@ static void chacha20poly1305_finalize(struct chacha20poly1305_context_t *ctx, ui
     cf_poly1305_finish(&ctx->poly, tag);
 }
 
-static void chacha20poly1305_init(ptls_aead_context_t *_ctx, uint64_t seq, const void *aad, size_t aadlen)
+static void chacha20poly1305_initialize(struct chacha20poly1305_context_t *ctx, uint64_t seq, ptls_iovec_t aad)
 {
-    struct chacha20poly1305_context_t *ctx = (struct chacha20poly1305_context_t *)_ctx;
     uint8_t tmpbuf[64];
 
     /* init chacha */
@@ -120,38 +119,36 @@ static void chacha20poly1305_init(ptls_aead_context_t *_ctx, uint64_t seq, const
     ptls_clear_memory(tmpbuf, sizeof(tmpbuf));
 
     /* aad */
-    if (aadlen != 0) {
-        cf_poly1305_update(&ctx->poly, aad, aadlen);
-        chacha20poly1305_encrypt_pad(&ctx->poly, aadlen);
+    if (aad.len != 0) {
+        cf_poly1305_update(&ctx->poly, aad.base, aad.len);
+        chacha20poly1305_encrypt_pad(&ctx->poly, aad.len);
     }
 
-    ctx->aadlen = aadlen;
+    ctx->aadlen = aad.len;
     ctx->textlen = 0;
 }
 
-static size_t chacha20poly1305_encrypt_update(ptls_aead_context_t *_ctx, void *output, const void *input, size_t inlen)
+static void chacha20poly1305_encrypt_v(struct st_ptls_aead_context_t *_ctx, void *output, ptls_iovec_t *input, size_t incnt,
+                                       uint64_t seq, ptls_iovec_t aad)
 {
     struct chacha20poly1305_context_t *ctx = (struct chacha20poly1305_context_t *)_ctx;
 
-    cf_chacha20_cipher(&ctx->chacha, input, output, inlen);
-    cf_poly1305_update(&ctx->poly, output, inlen);
-    ctx->textlen += inlen;
+    chacha20poly1305_initialize(ctx, seq, aad);
 
-    return inlen;
-}
-
-static size_t chacha20poly1305_encrypt_final(ptls_aead_context_t *_ctx, void *output)
-{
-    struct chacha20poly1305_context_t *ctx = (struct chacha20poly1305_context_t *)_ctx;
+    for (size_t i = 0; i < incnt; ++i) {
+        cf_chacha20_cipher(&ctx->chacha, input[i].base, output, input[i].len);
+        cf_poly1305_update(&ctx->poly, output, input[i].len);
+        output += input[i].len;
+        ctx->textlen += input[i].len;
+    }
 
     chacha20poly1305_finalize(ctx, output);
 
     ptls_clear_memory(&ctx->chacha, sizeof(ctx->chacha));
-    return PTLS_CHACHA20POLY1305_TAG_SIZE;
 }
 
 static size_t chacha20poly1305_decrypt(ptls_aead_context_t *_ctx, void *output, const void *input, size_t inlen, uint64_t seq,
-                                       const void *aad, size_t aadlen)
+                                       ptls_iovec_t aad)
 {
     struct chacha20poly1305_context_t *ctx = (struct chacha20poly1305_context_t *)_ctx;
     uint8_t tag[PTLS_CHACHA20POLY1305_TAG_SIZE];
@@ -160,7 +157,7 @@ static size_t chacha20poly1305_decrypt(ptls_aead_context_t *_ctx, void *output, 
     if (inlen < sizeof(tag))
         return SIZE_MAX;
 
-    chacha20poly1305_init(&ctx->super, seq, aad, aadlen);
+    chacha20poly1305_initialize(ctx, seq, aad);
 
     cf_poly1305_update(&ctx->poly, input, inlen - sizeof(tag));
     ctx->textlen = inlen - sizeof(tag);
@@ -195,15 +192,12 @@ static int aead_chacha20poly1305_setup_crypto(ptls_aead_context_t *_ctx, int is_
     ctx->super.dispose_crypto = chacha20poly1305_dispose_crypto;
     ctx->super.do_xor_iv = chacha20poly1305_xor_iv;
     if (is_enc) {
-        ctx->super.do_encrypt_init = chacha20poly1305_init;
-        ctx->super.do_encrypt_update = chacha20poly1305_encrypt_update;
-        ctx->super.do_encrypt_final = chacha20poly1305_encrypt_final;
         ctx->super.do_encrypt = ptls_aead__do_encrypt;
+        ctx->super.do_encrypt_v = chacha20poly1305_encrypt_v;
         ctx->super.do_decrypt = NULL;
     } else {
-        ctx->super.do_encrypt_init = NULL;
-        ctx->super.do_encrypt_update = NULL;
-        ctx->super.do_encrypt_final = NULL;
+        ctx->super.do_encrypt = NULL;
+        ctx->super.do_encrypt_v = NULL;
         ctx->super.do_decrypt = chacha20poly1305_decrypt;
     }
 

--- a/lib/fusion.c
+++ b/lib/fusion.c
@@ -878,6 +878,23 @@ static void aesgcm_dispose_crypto(ptls_aead_context_t *_ctx)
     ptls_fusion_aesgcm_free(ctx->aesgcm);
 }
 
+static void aead_do_encrypt_init(ptls_aead_context_t *_ctx, uint64_t seq, const void *aad, size_t aadlen)
+{
+    assert(!"FIXME");
+}
+
+static size_t aead_do_encrypt_update(ptls_aead_context_t *_ctx, void *output, const void *input, size_t inlen)
+{
+    assert(!"FIXME");
+    return SIZE_MAX;
+}
+
+static size_t aead_do_encrypt_final(ptls_aead_context_t *_ctx, void *_output)
+{
+    assert(!"FIXME");
+    return SIZE_MAX;
+}
+
 static inline __m128i calc_counter(struct aesgcm_context *ctx, uint64_t seq)
 {
     __m128i ctr = _mm_setzero_si128();
@@ -888,23 +905,23 @@ static inline __m128i calc_counter(struct aesgcm_context *ctx, uint64_t seq)
 }
 
 void aead_do_encrypt(struct st_ptls_aead_context_t *_ctx, void *output, const void *input, size_t inlen, uint64_t seq,
-                     ptls_iovec_t aad, ptls_aead_supplementary_encryption_t *supp)
+                     const void *aad, size_t aadlen, ptls_aead_supplementary_encryption_t *supp)
 {
     struct aesgcm_context *ctx = (void *)_ctx;
 
-    if (inlen + aad.len > ctx->aesgcm->capacity)
-        ctx->aesgcm = ptls_fusion_aesgcm_set_capacity(ctx->aesgcm, inlen + aad.len);
-    ptls_fusion_aesgcm_encrypt(ctx->aesgcm, output, input, inlen, calc_counter(ctx, seq), aad.base, aad.len, supp);
+    if (inlen + aadlen > ctx->aesgcm->capacity)
+        ctx->aesgcm = ptls_fusion_aesgcm_set_capacity(ctx->aesgcm, inlen + aadlen);
+    ptls_fusion_aesgcm_encrypt(ctx->aesgcm, output, input, inlen, calc_counter(ctx, seq), aad, aadlen, supp);
 }
 
 static void aead_do_encrypt_v(struct st_ptls_aead_context_t *ctx, void *output, ptls_iovec_t *input, size_t incnt, uint64_t seq,
-                              ptls_iovec_t aad)
+                              const void *aad, size_t aadlen)
 {
     assert(!"FIXME");
 }
 
 static size_t aead_do_decrypt(ptls_aead_context_t *_ctx, void *output, const void *input, size_t inlen, uint64_t seq,
-                              ptls_iovec_t aad)
+                              const void *aad, size_t aadlen)
 {
     struct aesgcm_context *ctx = (void *)_ctx;
 
@@ -912,9 +929,9 @@ static size_t aead_do_decrypt(ptls_aead_context_t *_ctx, void *output, const voi
         return SIZE_MAX;
 
     size_t enclen = inlen - 16;
-    if (enclen + aad.len > ctx->aesgcm->capacity)
-        ctx->aesgcm = ptls_fusion_aesgcm_set_capacity(ctx->aesgcm, enclen + aad.len);
-    if (!ptls_fusion_aesgcm_decrypt(ctx->aesgcm, output, input, enclen, calc_counter(ctx, seq), aad.base, aad.len,
+    if (enclen + aadlen > ctx->aesgcm->capacity)
+        ctx->aesgcm = ptls_fusion_aesgcm_set_capacity(ctx->aesgcm, enclen + aadlen);
+    if (!ptls_fusion_aesgcm_decrypt(ctx->aesgcm, output, input, enclen, calc_counter(ctx, seq), aad, aadlen,
                                     (const uint8_t *)input + enclen))
         return SIZE_MAX;
     return enclen;
@@ -939,6 +956,9 @@ static int aesgcm_setup(ptls_aead_context_t *_ctx, int is_enc, const void *key, 
 
     ctx->super.dispose_crypto = aesgcm_dispose_crypto;
     ctx->super.do_xor_iv = aesgcm_xor_iv;
+    ctx->super.do_encrypt_init = aead_do_encrypt_init;
+    ctx->super.do_encrypt_update = aead_do_encrypt_update;
+    ctx->super.do_encrypt_final = aead_do_encrypt_final;
     ctx->super.do_encrypt = aead_do_encrypt;
     ctx->super.do_encrypt_v = aead_do_encrypt_v;
     ctx->super.do_decrypt = aead_do_decrypt;

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -889,38 +889,53 @@ static void aead_xor_iv(ptls_aead_context_t *_ctx, const void *_bytes, size_t le
         ctx->static_iv[i] ^= bytes[i];
 }
 
-static void aead_do_encrypt_v(struct st_ptls_aead_context_t *_ctx, void *output, ptls_iovec_t *input, size_t incnt, uint64_t seq,
-                              ptls_iovec_t aad)
+static void aead_do_encrypt_init(ptls_aead_context_t *_ctx, uint64_t seq, const void *aad, size_t aadlen)
 {
     struct aead_crypto_context_t *ctx = (struct aead_crypto_context_t *)_ctx;
     uint8_t iv[PTLS_MAX_IV_SIZE];
-    int blocklen, ret;
+    int ret;
 
     ptls_aead__build_iv(ctx->super.algo, iv, ctx->static_iv, seq);
     ret = EVP_EncryptInit_ex(ctx->evp_ctx, NULL, NULL, NULL, iv);
     assert(ret);
 
-    if (aad.len != 0) {
+    if (aadlen != 0) {
         int blocklen;
-        ret = EVP_EncryptUpdate(ctx->evp_ctx, NULL, &blocklen, aad.base, (int)aad.len);
+        ret = EVP_EncryptUpdate(ctx->evp_ctx, NULL, &blocklen, aad, (int)aadlen);
         assert(ret);
     }
+}
 
-    for (size_t i = 0; i < incnt; ++i) {
-        ret = EVP_EncryptUpdate(ctx->evp_ctx, output, &blocklen, input[i].base, (int)input[i].len);
-        assert(ret);
-        output += blocklen;
-    }
+static size_t aead_do_encrypt_update(ptls_aead_context_t *_ctx, void *output, const void *input, size_t inlen)
+{
+    struct aead_crypto_context_t *ctx = (struct aead_crypto_context_t *)_ctx;
+    int blocklen, ret;
 
-    ret = EVP_EncryptFinal_ex(ctx->evp_ctx, output, &blocklen);
+    ret = EVP_EncryptUpdate(ctx->evp_ctx, output, &blocklen, input, (int)inlen);
     assert(ret);
-    output += blocklen;
-    ret = EVP_CIPHER_CTX_ctrl(ctx->evp_ctx, EVP_CTRL_GCM_GET_TAG, (int)ctx->super.algo->tag_size, output);
+
+    return blocklen;
+}
+
+static size_t aead_do_encrypt_final(ptls_aead_context_t *_ctx, void *_output)
+{
+    struct aead_crypto_context_t *ctx = (struct aead_crypto_context_t *)_ctx;
+    uint8_t *output = _output;
+    size_t off = 0, tag_size = ctx->super.algo->tag_size;
+    int blocklen, ret;
+
+    ret = EVP_EncryptFinal_ex(ctx->evp_ctx, output + off, &blocklen);
     assert(ret);
+    off += blocklen;
+    ret = EVP_CIPHER_CTX_ctrl(ctx->evp_ctx, EVP_CTRL_GCM_GET_TAG, (int)tag_size, output + off);
+    assert(ret);
+    off += tag_size;
+
+    return off;
 }
 
 static size_t aead_do_decrypt(ptls_aead_context_t *_ctx, void *_output, const void *input, size_t inlen, uint64_t seq,
-                              ptls_iovec_t aad)
+                              const void *aad, size_t aadlen)
 {
     struct aead_crypto_context_t *ctx = (struct aead_crypto_context_t *)_ctx;
     uint8_t *output = _output, iv[PTLS_MAX_IV_SIZE];
@@ -933,8 +948,8 @@ static size_t aead_do_decrypt(ptls_aead_context_t *_ctx, void *_output, const vo
     ptls_aead__build_iv(ctx->super.algo, iv, ctx->static_iv, seq);
     ret = EVP_DecryptInit_ex(ctx->evp_ctx, NULL, NULL, NULL, iv);
     assert(ret);
-    if (aad.len != 0) {
-        ret = EVP_DecryptUpdate(ctx->evp_ctx, NULL, &blocklen, aad.base, (int)aad.len);
+    if (aadlen != 0) {
+        ret = EVP_DecryptUpdate(ctx->evp_ctx, NULL, &blocklen, aad, (int)aadlen);
         assert(ret);
     }
     ret = EVP_DecryptUpdate(ctx->evp_ctx, output + off, &blocklen, input, (int)(inlen - tag_size));
@@ -961,10 +976,16 @@ static int aead_setup_crypto(ptls_aead_context_t *_ctx, int is_enc, const void *
     ctx->super.dispose_crypto = aead_dispose_crypto;
     ctx->super.do_xor_iv = aead_xor_iv;
     if (is_enc) {
+        ctx->super.do_encrypt_init = aead_do_encrypt_init;
+        ctx->super.do_encrypt_update = aead_do_encrypt_update;
+        ctx->super.do_encrypt_final = aead_do_encrypt_final;
         ctx->super.do_encrypt = ptls_aead__do_encrypt;
-        ctx->super.do_encrypt_v = aead_do_encrypt_v;
+        ctx->super.do_encrypt_v = ptls_aead__do_encrypt_v;
         ctx->super.do_decrypt = NULL;
     } else {
+        ctx->super.do_encrypt_init = NULL;
+        ctx->super.do_encrypt_update = NULL;
+        ctx->super.do_encrypt_final = NULL;
         ctx->super.do_encrypt = NULL;
         ctx->super.do_encrypt_v = NULL;
         ctx->super.do_decrypt = aead_do_decrypt;

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -638,16 +638,13 @@ static void build_aad(uint8_t aad[5], size_t reclen)
 static size_t aead_encrypt(struct st_ptls_traffic_protection_t *ctx, void *output, const void *input, size_t inlen,
                            uint8_t content_type)
 {
+    ptls_iovec_t invec[2] = {ptls_iovec_init(input, inlen), ptls_iovec_init(&content_type, 1)};
     uint8_t aad[5];
-    size_t off = 0;
 
     build_aad(aad, inlen + 1 + ctx->aead->algo->tag_size);
-    ptls_aead_encrypt_init(ctx->aead, ctx->seq++, aad, sizeof(aad));
-    off += ptls_aead_encrypt_update(ctx->aead, ((uint8_t *)output) + off, input, inlen);
-    off += ptls_aead_encrypt_update(ctx->aead, ((uint8_t *)output) + off, &content_type, 1);
-    off += ptls_aead_encrypt_final(ctx->aead, ((uint8_t *)output) + off);
+    ptls_aead_encrypt_v(ctx->aead, output, invec, PTLS_ELEMENTSOF(invec), ctx->seq++, ptls_iovec_init(aad, sizeof(aad)));
 
-    return off;
+    return inlen + 1 + ctx->aead->algo->tag_size;
 }
 
 static int aead_decrypt(struct st_ptls_traffic_protection_t *ctx, void *output, size_t *outlen, const void *input, size_t inlen)

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -642,7 +642,7 @@ static size_t aead_encrypt(struct st_ptls_traffic_protection_t *ctx, void *outpu
     uint8_t aad[5];
 
     build_aad(aad, inlen + 1 + ctx->aead->algo->tag_size);
-    ptls_aead_encrypt_v(ctx->aead, output, invec, PTLS_ELEMENTSOF(invec), ctx->seq++, ptls_iovec_init(aad, sizeof(aad)));
+    ptls_aead_encrypt_v(ctx->aead, output, invec, PTLS_ELEMENTSOF(invec), ctx->seq++, aad, sizeof(aad));
 
     return inlen + 1 + ctx->aead->algo->tag_size;
 }

--- a/lib/ptlsbcrypt.c
+++ b/lib/ptlsbcrypt.c
@@ -545,12 +545,15 @@ static int ptls_bcrypt_aead_setup_crypto(ptls_aead_context_t *_ctx, int is_enc, 
             ctx->super.do_encrypt_update = ptls_bcrypt_aead_do_encrypt_update;
             ctx->super.do_encrypt_final = ptls_bcrypt_aead_do_encrypt_final;
             ctx->super.do_encrypt = ptls_bcrypt_do_encrypt;
+            ctx->super.do_encrypt_v = ptls_aead__do_encrypt_v;
         } else {
             ctx->super.dispose_crypto = ptls_bcrypt_aead_dispose_crypto;
             ctx->super.do_decrypt = ptls_bcrypt_aead_do_decrypt;
             ctx->super.do_encrypt_init = NULL;
             ctx->super.do_encrypt_update = NULL;
             ctx->super.do_encrypt_final = NULL;
+            ctx->super.do_encrypt = NULL;
+            ctx->super.do_encrypt_v = NULL;
         }
         return 0;
     } else {

--- a/t/picotls.c
+++ b/t/picotls.c
@@ -168,8 +168,12 @@ static void test_ciphersuite(ptls_cipher_suite_t *cs1, ptls_cipher_suite_t *cs2)
     /* encrypt */
     c = ptls_aead_new(cs1->aead, cs1->hash, 1, traffic_secret, NULL);
     assert(c != NULL);
-    enc1len = ptls_aead_encrypt(c, enc1, src1, strlen(src1), 0, NULL, 0);
-    enc2len = ptls_aead_encrypt(c, enc2, src2, strlen(src2), 1, NULL, 0);
+    ptls_aead_encrypt_init(c, 0, NULL, 0);
+    enc1len = ptls_aead_encrypt_update(c, enc1, src1, strlen(src1));
+    enc1len += ptls_aead_encrypt_final(c, enc1 + enc1len);
+    ptls_aead_encrypt_init(c, 1, NULL, 0);
+    enc2len = ptls_aead_encrypt_update(c, enc2, src2, strlen(src2));
+    enc2len += ptls_aead_encrypt_final(c, enc2 + enc2len);
     ptls_aead_free(c);
 
     c = ptls_aead_new(cs2->aead, cs2->hash, 0, traffic_secret, NULL);
@@ -203,7 +207,9 @@ static void test_aad_ciphersuite(ptls_cipher_suite_t *cs1, ptls_cipher_suite_t *
     /* encrypt */
     c = ptls_aead_new(cs1->aead, cs1->hash, 1, traffic_secret, NULL);
     assert(c != NULL);
-    enclen = ptls_aead_encrypt(c, enc, src, strlen(src), 123, aad, strlen(aad));
+    ptls_aead_encrypt_init(c, 123, aad, strlen(aad));
+    enclen = ptls_aead_encrypt_update(c, enc, src, strlen(src));
+    enclen += ptls_aead_encrypt_final(c, enc + enclen);
     ptls_aead_free(c);
 
     /* decrypt */
@@ -230,7 +236,9 @@ static void test_aad96_ciphersuite(ptls_cipher_suite_t *cs1, ptls_cipher_suite_t
     c = ptls_aead_new(cs1->aead, cs1->hash, 1, traffic_secret, NULL);
     assert(c != NULL);
     ptls_aead_xor_iv(c, seq32, sizeof(seq32));
-    enclen = ptls_aead_encrypt(c, enc, src, strlen(src), 123, aad, strlen(aad));
+    ptls_aead_encrypt_init(c, 123, aad, strlen(aad));
+    enclen = ptls_aead_encrypt_update(c, enc, src, strlen(src));
+    enclen += ptls_aead_encrypt_final(c, enc + enclen);
     ptls_aead_free(c);
 
     /* decrypt */

--- a/t/picotls.c
+++ b/t/picotls.c
@@ -168,12 +168,8 @@ static void test_ciphersuite(ptls_cipher_suite_t *cs1, ptls_cipher_suite_t *cs2)
     /* encrypt */
     c = ptls_aead_new(cs1->aead, cs1->hash, 1, traffic_secret, NULL);
     assert(c != NULL);
-    ptls_aead_encrypt_init(c, 0, NULL, 0);
-    enc1len = ptls_aead_encrypt_update(c, enc1, src1, strlen(src1));
-    enc1len += ptls_aead_encrypt_final(c, enc1 + enc1len);
-    ptls_aead_encrypt_init(c, 1, NULL, 0);
-    enc2len = ptls_aead_encrypt_update(c, enc2, src2, strlen(src2));
-    enc2len += ptls_aead_encrypt_final(c, enc2 + enc2len);
+    enc1len = ptls_aead_encrypt(c, enc1, src1, strlen(src1), 0, NULL, 0);
+    enc2len = ptls_aead_encrypt(c, enc2, src2, strlen(src2), 1, NULL, 0);
     ptls_aead_free(c);
 
     c = ptls_aead_new(cs2->aead, cs2->hash, 0, traffic_secret, NULL);
@@ -207,9 +203,7 @@ static void test_aad_ciphersuite(ptls_cipher_suite_t *cs1, ptls_cipher_suite_t *
     /* encrypt */
     c = ptls_aead_new(cs1->aead, cs1->hash, 1, traffic_secret, NULL);
     assert(c != NULL);
-    ptls_aead_encrypt_init(c, 123, aad, strlen(aad));
-    enclen = ptls_aead_encrypt_update(c, enc, src, strlen(src));
-    enclen += ptls_aead_encrypt_final(c, enc + enclen);
+    enclen = ptls_aead_encrypt(c, enc, src, strlen(src), 123, aad, strlen(aad));
     ptls_aead_free(c);
 
     /* decrypt */
@@ -236,9 +230,7 @@ static void test_aad96_ciphersuite(ptls_cipher_suite_t *cs1, ptls_cipher_suite_t
     c = ptls_aead_new(cs1->aead, cs1->hash, 1, traffic_secret, NULL);
     assert(c != NULL);
     ptls_aead_xor_iv(c, seq32, sizeof(seq32));
-    ptls_aead_encrypt_init(c, 123, aad, strlen(aad));
-    enclen = ptls_aead_encrypt_update(c, enc, src, strlen(src));
-    enclen += ptls_aead_encrypt_final(c, enc + enclen);
+    enclen = ptls_aead_encrypt(c, enc, src, strlen(src), 123, aad, strlen(aad));
     ptls_aead_free(c);
 
     /* decrypt */


### PR DESCRIPTION
At the moment, the encrypt API provided by picotls only receives one `ptl_iovec_t`, which in turn produces an AEAD record. This leads to inefficiency when multiple fragments of data has to be sent concatenated.

To give an example, HTTP/2 implementations typically split HTTP response into small chunks, prepending HTTP/2 frame headers to each of those chunks, before they pass them to the TLS stack. At the moment, HTTP/2 implementations have to either:
* a) build a flat image that has the HTTP/2 frame headers and chunks of response being concatenated, or
* b) call `ptls_send` for encrypting the HTTP/2 frame header, then make a separate call for encrypting the response chunk.

_a_ is inefficient when the implementation already has the response buffered in memory, because an extra copy would be required to concatenate the HTTP/2 frame header and the chunk of the response. _b_ is inefficient due to generating a tiny TLS record that contains only the HTTP/2 frame header, not to mention the privacy aspect of leaking information through how things are chunked.

To address this problem, this pull request attempts to introduce a variant of `ptls_send` function that accepts a vector of buffers as input.

At the moment, this PR also replaces the  init -> update -> final API at the AEAD layer with a new vectorized API as well. The rationale is that vectorized APIs are expected to provide better performance (as they can be integrated tighter to the encrypting code, see #384). But we can probably keep the existing ones deprecated.