### PR TITLE
show progress to prevent GitHub Actions killing CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           - name: "Linux / OpenSSL 1.1.1 + ASan & UBSan"
             command: make -f misc/docker-ci.mk CMAKE_ARGS='-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_FLAGS=-fsanitize=address,undefined -DCMAKE_CXX_FLAGS=-fsanitize=address,undefined' CHECK_ENVS='ASAN_OPTIONS=detect_leaks=0 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1'
 
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v2
       with:

--- a/t/fusion.c
+++ b/t/fusion.c
@@ -392,6 +392,10 @@ static void test_generated(void)
     const int nb_runs = 10000;
 #endif
     for (i = 0; i < nb_runs; ++i) {
+        if (i % 100 == 0) {
+            fputc('.', stderr);
+            fflush(stderr);
+        }
         /* generate input using RNG */
         uint8_t key[32], iv[12], seq32[4], aadlen, textlen;
         uint64_t seq;
@@ -446,11 +450,16 @@ static void test_generated(void)
         }
     }
 
+    fputc('\n', stderr);
+    fflush(stderr);
+
     ok(1);
     ptls_cipher_free(rand);
     return;
 
 Fail:
+    fputc('\n', stderr);
+    fflush(stderr);
     note("mismatch at index=%d", i);
     ok(0);
 }


### PR DESCRIPTION
In https://github.com/h2o/picotls/pull/398#issuecomment-1179993518, @huitema says:
> On the tests: I observed yesterday that my simple PR was failing sometimes, because some tasks were taking too long -- especially the ASAN/UBSAN runs. You may want to use a reduced set of tests for the ASAN/UBSAN action.

I agree, we need a progress bar, otherwise GitHub Actions thinks the test has stalled.