### PR TITLE
Asynchronous signing

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -614,7 +614,7 @@ PTLS_CALLBACK_TYPE(int, emit_certificate, ptls_t *tls, ptls_message_emitter_t *e
  * When `ptls_t` is disposed of while the async operation is in flight, `*cancel_cb` will be invoked. The backend should abort the
  * calculation and free any temporary data allocated for that calculation.
  */
-PTLS_CALLBACK_TYPE(int, sign_certificate, ptls_t *tls, void (**cb)(void *sign_ctx), void **sign_certificate_ctx,
+PTLS_CALLBACK_TYPE(int, sign_certificate, ptls_t *tls, void (**cancel_cb)(void *sign_ctx), void **sign_certificate_ctx,
                    uint16_t *selected_algorithm, ptls_buffer_t *output, ptls_iovec_t input, const uint16_t *algorithms, size_t num_algorithms);
 /**
  * after receiving Certificate, the core calls the callback to verify the certificate chain and to obtain a pointer to a

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -610,8 +610,9 @@ PTLS_CALLBACK_TYPE(int, emit_certificate, ptls_t *tls, ptls_message_emitter_t *e
  * that point, the application should call `ptls_handshake`, which in turn would invoke this callback once again. The callback then
  * fills `*selected_algorithm` and `output` with the signature being generated. Note that `algorithms` and `num_algorithms` are
  * provided only when the callback is called for the first time. The callback can store arbitrary pointer specific to each signature
- * generation in `*sign_ctx`. `*cb` can be set as an opportunity to cancel any asynchronous operation or free any temporary
- * data allocated for the callback.
+ * generation in `*sign_ctx`.
+ * When `ptls_t` is disposed of while the async operation is in flight, `*cancel_cb` will be invoked. The backend should abort the
+ * calculation and free any temporary data allocated for that calculation.
  */
 PTLS_CALLBACK_TYPE(int, sign_certificate, ptls_t *tls, void (**cb)(void *sign_ctx), void **sign_certificate_ctx,
                    uint16_t *selected_algorithm, ptls_buffer_t *output, ptls_iovec_t input, const uint16_t *algorithms, size_t num_algorithms);

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -787,10 +787,6 @@ struct st_ptls_context_t {
      */
     unsigned server_cipher_preference : 1;
     /**
-     * boolean indicating if handshaking should be asynchronous
-     */
-    unsigned async_handshake : 1;
-    /**
      *
      */
     ptls_encrypt_ticket_t *encrypt_ticket;

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -1164,6 +1164,10 @@ ptls_context_t *ptls_get_context(ptls_t *tls);
  */
 void ptls_set_context(ptls_t *tls, ptls_context_t *ctx);
 /**
+ * get the sign ctx
+ */
+void *ptls_get_sign_ctx(ptls_t *tls);
+/**
  * returns the client-random
  */
 ptls_iovec_t ptls_get_client_random(ptls_t *tls);

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -1164,9 +1164,9 @@ ptls_context_t *ptls_get_context(ptls_t *tls);
  */
 void ptls_set_context(ptls_t *tls, ptls_context_t *ctx);
 /**
- * get the sign ctx
+ * get the signature context
  */
-void *ptls_get_sign_ctx(ptls_t *tls);
+void *ptls_get_sign_context(ptls_t *tls);
 /**
  * returns the client-random
  */

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -786,6 +786,10 @@ struct st_ptls_context_t {
      */
     unsigned server_cipher_preference : 1;
     /**
+     * boolean indicating if handshaking should be asynchronous
+     */
+    unsigned async_handshake : 1;
+    /**
      *
      */
     ptls_encrypt_ticket_t *encrypt_ticket;

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -610,10 +610,11 @@ PTLS_CALLBACK_TYPE(int, emit_certificate, ptls_t *tls, ptls_message_emitter_t *e
  * that point, the application should call `ptls_handshake`, which in turn would invoke this callback once again. The callback then
  * fills `*selected_algorithm` and `output` with the signature being generated. Note that `algorithms` and `num_algorithms` are
  * provided only when the callback is called for the first time. The callback can store arbitrary pointer specific to each signature
- * generation in `*sign_ctx`.
+ * generation in `*sign_ctx`. `*cb` can be set as an opportunity to cancel any asynchronous operation or free any temporary
+ * data allocated for the callback.
  */
-PTLS_CALLBACK_TYPE(int, sign_certificate, ptls_t *tls, void **sign_certificate_ctx, uint16_t *selected_algorithm, ptls_buffer_t *output, ptls_iovec_t input,
-                   const uint16_t *algorithms, size_t num_algorithms);
+PTLS_CALLBACK_TYPE(int, sign_certificate, ptls_t *tls, void (**cb)(void *sign_ctx), void **sign_certificate_ctx,
+                   uint16_t *selected_algorithm, ptls_buffer_t *output, ptls_iovec_t input, const uint16_t *algorithms, size_t num_algorithms);
 /**
  * after receiving Certificate, the core calls the callback to verify the certificate chain and to obtain a pointer to a
  * callback that should be used for verifying CertificateVerify. If an error occurs between a successful return from this

--- a/include/picotls/openssl.h
+++ b/include/picotls/openssl.h
@@ -39,6 +39,12 @@ extern "C" {
 #endif
 #endif
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100010L && !defined(LIBRESSL_VERSION_NUMBER)
+#if !defined(OPENSSL_NO_ASYNC)
+#define PTLS_OPENSSL_HAVE_ASYNC 1
+#endif
+#endif
+
 extern ptls_key_exchange_algorithm_t ptls_openssl_secp256r1;
 #ifdef NID_secp384r1
 #define PTLS_OPENSSL_HAVE_SECP384R1 1
@@ -91,7 +97,9 @@ void ptls_openssl_random_bytes(void *buf, size_t len);
  * constructs a key exchange context. pkey's reference count is incremented.
  */
 int ptls_openssl_create_key_exchange(ptls_key_exchange_context_t **ctx, EVP_PKEY *pkey);
+#ifdef PTLS_OPENSSL_HAVE_ASYNC
 int ptls_openssl_get_async_fd(ptls_t *ptls);
+#endif
 
 struct st_ptls_openssl_signature_scheme_t {
     uint16_t scheme_id;

--- a/include/picotls/openssl.h
+++ b/include/picotls/openssl.h
@@ -91,7 +91,7 @@ void ptls_openssl_random_bytes(void *buf, size_t len);
  * constructs a key exchange context. pkey's reference count is incremented.
  */
 int ptls_openssl_create_key_exchange(ptls_key_exchange_context_t **ctx, EVP_PKEY *pkey);
-int ptls_openssl_get_async_fd();
+int ptls_openssl_get_async_fd(ptls_t *ptls);
 
 struct st_ptls_openssl_signature_scheme_t {
     uint16_t scheme_id;

--- a/include/picotls/openssl.h
+++ b/include/picotls/openssl.h
@@ -110,6 +110,10 @@ typedef struct st_ptls_openssl_sign_certificate_t {
     ptls_sign_certificate_t super;
     EVP_PKEY *key;
     const struct st_ptls_openssl_signature_scheme_t *schemes; /* terminated by .scheme_id == UINT16_MAX */
+    /**
+     * boolean indicating if signing should be asynchronous
+     */
+    unsigned async : 1;
 } ptls_openssl_sign_certificate_t;
 
 int ptls_openssl_init_sign_certificate(ptls_openssl_sign_certificate_t *self, EVP_PKEY *key);

--- a/include/picotls/openssl.h
+++ b/include/picotls/openssl.h
@@ -91,6 +91,7 @@ void ptls_openssl_random_bytes(void *buf, size_t len);
  * constructs a key exchange context. pkey's reference count is incremented.
  */
 int ptls_openssl_create_key_exchange(ptls_key_exchange_context_t **ctx, EVP_PKEY *pkey);
+int ptls_openssl_get_async_fd();
 
 struct st_ptls_openssl_signature_scheme_t {
     uint16_t scheme_id;

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -767,7 +767,7 @@ static int do_sign_final(void *vargs)
 }
 
 static int do_sign(EVP_PKEY *key, const struct st_ptls_openssl_signature_scheme_t *scheme, ptls_buffer_t *outbuf,
-                   ptls_iovec_t input, void (**cb)(void *sign_ctx), void **sign_ctx, int is_async)
+                   ptls_iovec_t input, void (**cancel_cb)(void *sign_ctx), void **sign_ctx, int is_async)
 {
     const EVP_MD *md = scheme->scheme_md != NULL ? scheme->scheme_md() : NULL;
     int pkey_id = EVP_PKEY_id(key);
@@ -857,8 +857,8 @@ static int do_sign(EVP_PKEY *key, const struct st_ptls_openssl_signature_scheme_
                     goto Exit;
                 case ASYNC_PAUSE: {
                     ret = PTLS_ERROR_ASYNC_OPERATION;
-                    if (cb != NULL)
-                        *cb = async_sign_cancel;
+                    assert(cancel_cb == NULL);
+                    *cancel_cb = async_sign_cancel;
                     return ret;
                 }
                 case ASYNC_NO_JOBS:
@@ -897,8 +897,8 @@ static int do_sign(EVP_PKEY *key, const struct st_ptls_openssl_signature_scheme_
 Exit:
     if (sign_ctx != NULL)
         *sign_ctx = NULL;
-    if (cb != NULL)
-        *cb = NULL;
+    if (cancel_cb != NULL)
+        *cancel_cb = NULL;
     sign_ctx_destroy(args);
     if (ctx != NULL)
         EVP_MD_CTX_destroy(ctx);
@@ -1196,7 +1196,7 @@ static const struct st_ptls_openssl_signature_scheme_t *match_scheme(const struc
     }
     return scheme;
 }
-static int sign_certificate(ptls_sign_certificate_t *_self, ptls_t *tls, void (**cb)(void *sign_ctx), void **sign_ctx,
+static int sign_certificate(ptls_sign_certificate_t *_self, ptls_t *tls, void (**cancel_cb)(void *sign_ctx), void **sign_ctx,
                             uint16_t *selected_algorithm, ptls_buffer_t *outbuf, ptls_iovec_t input, const uint16_t *algorithms,
                             size_t num_algorithms)
 {
@@ -1229,7 +1229,7 @@ static int sign_certificate(ptls_sign_certificate_t *_self, ptls_t *tls, void (*
 
 Exit:
     *selected_algorithm = scheme->scheme_id;
-    return do_sign(self->key, scheme, outbuf, input, cb, sign_ctx, is_async);
+    return do_sign(self->key, scheme, outbuf, input, cancel_cb, sign_ctx, is_async);
 }
 
 static X509 *to_x509(ptls_iovec_t vec)

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -42,6 +42,7 @@
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 #include <openssl/x509_vfy.h>
+#include <openssl/async.h>
 #include "picotls.h"
 #include "picotls/openssl.h"
 
@@ -694,77 +695,139 @@ int ptls_openssl_create_key_exchange(ptls_key_exchange_context_t **ctx, EVP_PKEY
     }
 }
 
-static int do_sign(EVP_PKEY *key, const struct st_ptls_openssl_signature_scheme_t *scheme, ptls_buffer_t *outbuf,
-                   ptls_iovec_t input)
-{
-    EVP_MD_CTX *ctx = NULL;
-    const EVP_MD *md = scheme->scheme_md != NULL ? scheme->scheme_md() : NULL;
-    EVP_PKEY_CTX *pkey_ctx;
+static ASYNC_WAIT_CTX *waitctx = NULL;
+static ASYNC_JOB *job = NULL;
+
+struct sign_ctx {
+    const struct st_ptls_openssl_signature_scheme_t *scheme;
+    EVP_MD_CTX *ctx;
+    unsigned char *sigret;
     size_t siglen;
+};
+
+int ptls_openssl_get_async_fd()
+{
+    int fds[1];
+    size_t numfds;
+    ASYNC_WAIT_CTX_get_all_fds(waitctx, NULL, &numfds);
+    assert(numfds == 1);
+    ASYNC_WAIT_CTX_get_all_fds(waitctx, fds, &numfds);
+    return fds[0];
+}
+
+static int async_sign(void *vargs)
+{
+    struct sign_ctx *args = vargs;
+    return EVP_DigestSignFinal(args->ctx, args->sigret, &args->siglen);
+}
+
+static int do_sign(EVP_PKEY *key, const struct st_ptls_openssl_signature_scheme_t *scheme, ptls_buffer_t *outbuf,
+                   ptls_iovec_t input, void **sign_ctx)
+{
+    const EVP_MD *md = scheme->scheme_md != NULL ? scheme->scheme_md() : NULL;
     int ret;
 
-    if ((ctx = EVP_MD_CTX_create()) == NULL) {
-        ret = PTLS_ERROR_NO_MEMORY;
-        goto Exit;
-    }
+    struct sign_ctx *args = *sign_ctx;
+    if (args->ctx == NULL) {
+        EVP_PKEY_CTX *pkey_ctx;
+        if ((args->ctx = EVP_MD_CTX_create()) == NULL) {
+            ret = PTLS_ERROR_NO_MEMORY;
+            goto Exit;
+        }
 
-    if (EVP_DigestSignInit(ctx, &pkey_ctx, md, NULL, key) != 1) {
-        ret = PTLS_ERROR_LIBRARY;
-        goto Exit;
+        if (EVP_DigestSignInit(args->ctx, &pkey_ctx, md, NULL, key) != 1) {
+            ret = PTLS_ERROR_LIBRARY;
+            goto Exit;
+        }
+
+#if PTLS_OPENSSL_HAVE_ED25519
+        if (EVP_PKEY_id(key) == EVP_PKEY_ED25519) {
+            /* ED25519 requires the use of the all-at-once function that appeared in OpenSSL 1.1.1, hence different path */
+            if (EVP_DigestSign(args->ctx, NULL, &args->siglen, input.base, input.len) != 1) {
+                ret = PTLS_ERROR_LIBRARY;
+                goto Exit;
+            }
+            if ((ret = ptls_buffer_reserve(outbuf, args->siglen)) != 0)
+                goto Exit;
+            if (EVP_DigestSign(args->ctx, outbuf->base + outbuf->off, &args->siglen, input.base, input.len) != 1) {
+                ret = PTLS_ERROR_LIBRARY;
+                goto Exit;
+            }
+        } else
+#endif
+        {
+            if (EVP_PKEY_id(key) == EVP_PKEY_RSA) {
+                if (EVP_PKEY_CTX_set_rsa_padding(pkey_ctx, RSA_PKCS1_PSS_PADDING) != 1) {
+                    ret = PTLS_ERROR_LIBRARY;
+                    goto Exit;
+                }
+                if (EVP_PKEY_CTX_set_rsa_pss_saltlen(pkey_ctx, -1) != 1) {
+                    ret = PTLS_ERROR_LIBRARY;
+                    goto Exit;
+                }
+                if (EVP_PKEY_CTX_set_rsa_mgf1_md(pkey_ctx, md) != 1) {
+                    ret = PTLS_ERROR_LIBRARY;
+                    goto Exit;
+                }
+            }
+            if (EVP_DigestSignUpdate(args->ctx, input.base, input.len) != 1) {
+                ret = PTLS_ERROR_LIBRARY;
+                goto Exit;
+            }
+
+            if (EVP_DigestSignFinal(args->ctx, NULL, &args->siglen) != 1) {
+                ret = PTLS_ERROR_LIBRARY;
+                goto Exit;
+            }
+        }
     }
 
 #if PTLS_OPENSSL_HAVE_ED25519
     if (EVP_PKEY_id(key) == EVP_PKEY_ED25519) {
-        /* ED25519 requires the use of the all-at-once function that appeared in OpenSSL 1.1.1, hence different path */
-        if (EVP_DigestSign(ctx, NULL, &siglen, input.base, input.len) != 1) {
-            ret = PTLS_ERROR_LIBRARY;
-            goto Exit;
-        }
-        if ((ret = ptls_buffer_reserve(outbuf, siglen)) != 0)
-            goto Exit;
-        if (EVP_DigestSign(ctx, outbuf->base + outbuf->off, &siglen, input.base, input.len) != 1) {
-            ret = PTLS_ERROR_LIBRARY;
-            goto Exit;
-        }
+        // signing is complete as ED25519 is one-shot
     } else
 #endif
     {
-        if (EVP_PKEY_id(key) == EVP_PKEY_RSA) {
-            if (EVP_PKEY_CTX_set_rsa_padding(pkey_ctx, RSA_PKCS1_PSS_PADDING) != 1) {
-                ret = PTLS_ERROR_LIBRARY;
-                goto Exit;
+        if ((ret = ptls_buffer_reserve(outbuf, args->siglen)) != 0)
+            goto Exit;
+
+        args->sigret = outbuf->base + outbuf->off;
+
+        if (ASYNC_get_current_job() == NULL) {
+            if (waitctx == NULL) {
+                waitctx = ASYNC_WAIT_CTX_new();
             }
-            if (EVP_PKEY_CTX_set_rsa_pss_saltlen(pkey_ctx, -1) != 1) {
-                ret = PTLS_ERROR_LIBRARY;
-                goto Exit;
+
+            // start async sign
+            switch (ASYNC_start_job(&job, waitctx, &ret, async_sign, args, sizeof(struct sign_ctx)))
+            {
+                case ASYNC_ERR:
+                    ret = PTLS_ERROR_LIBRARY;
+                    goto Exit;
+                case ASYNC_PAUSE: {
+                    ret = PTLS_ERROR_ASYNC_OPERATION;
+                    return ret;
+                }
+                case ASYNC_NO_JOBS:
+                    ret = PTLS_ERROR_LIBRARY;
+                    goto Exit;
+                case ASYNC_FINISH:
+                    job = NULL;
+                    break;
+                default:
+                    ret = PTLS_ERROR_LIBRARY;
+                    goto Exit;
             }
-            if (EVP_PKEY_CTX_set_rsa_mgf1_md(pkey_ctx, md) != 1) {
-                ret = PTLS_ERROR_LIBRARY;
-                goto Exit;
-            }
-        }
-        if (EVP_DigestSignUpdate(ctx, input.base, input.len) != 1) {
-            ret = PTLS_ERROR_LIBRARY;
-            goto Exit;
-        }
-        if (EVP_DigestSignFinal(ctx, NULL, &siglen) != 1) {
-            ret = PTLS_ERROR_LIBRARY;
-            goto Exit;
-        }
-        if ((ret = ptls_buffer_reserve(outbuf, siglen)) != 0)
-            goto Exit;
-        if (EVP_DigestSignFinal(ctx, outbuf->base + outbuf->off, &siglen) != 1) {
-            ret = PTLS_ERROR_LIBRARY;
-            goto Exit;
         }
     }
 
-    outbuf->off += siglen;
+    outbuf->off += args->siglen;
 
     ret = 0;
 Exit:
-    if (ctx != NULL)
-        EVP_MD_CTX_destroy(ctx);
+    if (args->ctx != NULL) {
+        EVP_MD_CTX_destroy(args->ctx);
+    }
     return ret;
 }
 
@@ -1044,24 +1107,47 @@ ptls_define_hash(sha256, SHA256_CTX, SHA256_Init, SHA256_Update, _sha256_final);
 #define _sha384_final(ctx, md) SHA384_Final((md), (ctx))
 ptls_define_hash(sha384, SHA512_CTX, SHA384_Init, SHA384_Update, _sha384_final);
 
-static int sign_certificate(ptls_sign_certificate_t *_self, ptls_t *tls, uint16_t *selected_algorithm, ptls_buffer_t *outbuf,
+static int sign_certificate(ptls_sign_certificate_t *_self, ptls_t *tls, void **sign_ctx, uint16_t *selected_algorithm, ptls_buffer_t *outbuf,
                             ptls_iovec_t input, const uint16_t *algorithms, size_t num_algorithms)
 {
     ptls_openssl_sign_certificate_t *self = (ptls_openssl_sign_certificate_t *)_self;
     const struct st_ptls_openssl_signature_scheme_t *scheme;
 
-    /* select the algorithm (driven by server-side preference of `self->schemes`) */
-    for (scheme = self->schemes; scheme->scheme_id != UINT16_MAX; ++scheme) {
-        size_t i;
-        for (i = 0; i != num_algorithms; ++i)
-            if (algorithms[i] == scheme->scheme_id)
-                goto Found;
+    struct sign_ctx *args;
+    if (*sign_ctx == NULL) {
+        args = malloc(sizeof(*args));
+        memset(args, 0, sizeof(*args));
+
+        // first invocation, get scheme
+        for (scheme = self->schemes; scheme->scheme_id != UINT16_MAX; ++scheme) {
+            size_t i;
+            for (i = 0; i != num_algorithms; ++i) {
+                if (algorithms[i] == scheme->scheme_id) {
+                    args->scheme = scheme;
+                    *sign_ctx = args;
+                    goto Exit;
+                }
+            }
+        }
+    } else {
+        // second invocation
+        // algorithms should be NULL, re-use cached scheme
+        assert(algorithms == NULL);
+        args = *sign_ctx;
+        scheme = args->scheme;
+        goto Exit;
     }
+
     return PTLS_ALERT_HANDSHAKE_FAILURE;
 
-Found:
+Exit:
     *selected_algorithm = scheme->scheme_id;
-    return do_sign(self->key, scheme, outbuf, input);
+    int ret = do_sign(self->key, scheme, outbuf, input, sign_ctx);
+    if (ret != PTLS_ERROR_ASYNC_OPERATION) {
+        *sign_ctx = NULL;
+        free(args);
+    }
+    return ret;
 }
 
 static X509 *to_x509(ptls_iovec_t vec)

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -711,6 +711,8 @@ static struct sign_ctx *sign_ctx_alloc(size_t siglen)
     struct sign_ctx *sign_ctx = malloc(sizeof(*sign_ctx) + siglen);
     memset(sign_ctx, 0, sizeof(*sign_ctx) + siglen);
     sign_ctx->siglen = siglen;
+    sign_ctx->waitctx = ASYNC_WAIT_CTX_new();
+
     return sign_ctx;
 }
 
@@ -821,10 +823,6 @@ static int do_sign(EVP_PKEY *key, const struct st_ptls_openssl_signature_scheme_
 #endif
     {
         if (ASYNC_get_current_job() == NULL) {
-            if (args->waitctx == NULL) {
-                args->waitctx = ASYNC_WAIT_CTX_new();
-            }
-
             // start async sign
             switch (ASYNC_start_job(&args->job, args->waitctx, &ret, async_sign, &args, sizeof(struct sign_ctx**)))
             {

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -1202,7 +1202,7 @@ static int sign_certificate(ptls_sign_certificate_t *_self, ptls_t *tls, void (*
 {
     ptls_openssl_sign_certificate_t *self = (ptls_openssl_sign_certificate_t *)_self;
     const struct st_ptls_openssl_signature_scheme_t *scheme;
-    int is_async = ptls_get_context(tls)->async_handshake == 1;
+    int is_async = self->async == 1;
 
     if (ptls_is_server(tls)) {
         assert(sign_ctx != NULL);

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -722,6 +722,11 @@ static void sign_ctx_destroy(struct sign_ctx *sign_ctx)
 
     if (sign_ctx->ctx != NULL)
         EVP_MD_CTX_destroy(sign_ctx->ctx);
+    if (sign_ctx->job != NULL) {
+        int _ret;
+        // resume the job to free resources
+        ASYNC_start_job(&sign_ctx->job, sign_ctx->waitctx, &_ret, NULL, NULL, 0);
+    }
     if (sign_ctx->waitctx != NULL)
         ASYNC_WAIT_CTX_free(sign_ctx->waitctx);
     free(sign_ctx);
@@ -738,6 +743,12 @@ int ptls_openssl_get_async_fd(ptls_t *ptls)
     return fds[0];
 }
 
+static void async_sign_cancel(void *vargs)
+{
+    struct sign_ctx *args = (struct sign_ctx *)vargs;
+    sign_ctx_destroy(args);
+}
+
 static int async_sign(void *vargs)
 {
     struct sign_ctx *args = *(struct sign_ctx **)vargs;
@@ -745,7 +756,7 @@ static int async_sign(void *vargs)
 }
 
 static int do_sign(EVP_PKEY *key, const struct st_ptls_openssl_signature_scheme_t *scheme, ptls_buffer_t *outbuf,
-                   ptls_iovec_t input, void **sign_ctx)
+                   ptls_iovec_t input, void (**cb)(void *sign_ctx), void **sign_ctx)
 {
     const EVP_MD *md = scheme->scheme_md != NULL ? scheme->scheme_md() : NULL;
     int ret;
@@ -831,6 +842,7 @@ static int do_sign(EVP_PKEY *key, const struct st_ptls_openssl_signature_scheme_
                     goto Exit;
                 case ASYNC_PAUSE: {
                     ret = PTLS_ERROR_ASYNC_OPERATION;
+                    *cb = async_sign_cancel;
                     return ret;
                 }
                 case ASYNC_NO_JOBS:
@@ -839,6 +851,7 @@ static int do_sign(EVP_PKEY *key, const struct st_ptls_openssl_signature_scheme_
                 case ASYNC_FINISH: {
                     ptls_buffer__do_pushv(outbuf, args->sig, args->siglen);
                     args->job = NULL;
+                    *cb = NULL;
                     break;
                 }
                 default:
@@ -1133,8 +1146,9 @@ ptls_define_hash(sha256, SHA256_CTX, SHA256_Init, SHA256_Update, _sha256_final);
 #define _sha384_final(ctx, md) SHA384_Final((md), (ctx))
 ptls_define_hash(sha384, SHA512_CTX, SHA384_Init, SHA384_Update, _sha384_final);
 
-static int sign_certificate(ptls_sign_certificate_t *_self, ptls_t *tls, void **sign_ctx, uint16_t *selected_algorithm, ptls_buffer_t *outbuf,
-                            ptls_iovec_t input, const uint16_t *algorithms, size_t num_algorithms)
+static int sign_certificate(ptls_sign_certificate_t *_self, ptls_t *tls, void (**cb)(void *sign_ctx), void **sign_ctx,
+                            uint16_t *selected_algorithm, ptls_buffer_t *outbuf, ptls_iovec_t input, const uint16_t *algorithms,
+                            size_t num_algorithms)
 {
     ptls_openssl_sign_certificate_t *self = (ptls_openssl_sign_certificate_t *)_self;
     const struct st_ptls_openssl_signature_scheme_t *scheme;
@@ -1162,7 +1176,7 @@ static int sign_certificate(ptls_sign_certificate_t *_self, ptls_t *tls, void **
 
 Exit:
     *selected_algorithm = scheme->scheme_id;
-    return do_sign(self->key, scheme, outbuf, input, sign_ctx);
+    return do_sign(self->key, scheme, outbuf, input, cb, sign_ctx);
 }
 
 static X509 *to_x509(ptls_iovec_t vec)

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -717,7 +717,7 @@ int ptls_openssl_get_async_fd()
 
 static int async_sign(void *vargs)
 {
-    struct sign_ctx *args = vargs;
+    struct sign_ctx *args = *(struct sign_ctx **)vargs;
     return EVP_DigestSignFinal(args->ctx, args->buf.base, &args->siglen);
 }
 
@@ -797,7 +797,7 @@ static int do_sign(EVP_PKEY *key, const struct st_ptls_openssl_signature_scheme_
             }
 
             // start async sign
-            switch (ASYNC_start_job(&job, waitctx, &ret, async_sign, args, sizeof(struct sign_ctx)))
+            switch (ASYNC_start_job(&job, waitctx, &ret, async_sign, &args, sizeof(struct sign_ctx**)))
             {
                 case ASYNC_ERR:
                     ret = PTLS_ERROR_LIBRARY;

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -770,11 +770,12 @@ static int do_sign(EVP_PKEY *key, const struct st_ptls_openssl_signature_scheme_
                    ptls_iovec_t input, void (**cb)(void *sign_ctx), void **sign_ctx)
 {
     const EVP_MD *md = scheme->scheme_md != NULL ? scheme->scheme_md() : NULL;
+    int pkey_id = EVP_PKEY_id(key);
     int ret;
 
     struct sign_ctx *args = NULL;
     EVP_MD_CTX *ctx = NULL;
-    if (*sign_ctx != NULL) {
+    if (sign_ctx != NULL && *sign_ctx != NULL) {
         args = *sign_ctx;
     } else {
         size_t siglen;
@@ -791,7 +792,7 @@ static int do_sign(EVP_PKEY *key, const struct st_ptls_openssl_signature_scheme_
         }
 
 #if PTLS_OPENSSL_HAVE_ED25519
-        if (EVP_PKEY_id(key) == EVP_PKEY_ED25519) {
+        if (pkey_id == EVP_PKEY_ED25519) {
             /* ED25519 requires the use of the all-at-once function that appeared in OpenSSL 1.1.1, hence different path */
             if (EVP_DigestSign(ctx, NULL, &siglen, input.base, input.len) != 1) {
                 ret = PTLS_ERROR_LIBRARY;
@@ -806,7 +807,7 @@ static int do_sign(EVP_PKEY *key, const struct st_ptls_openssl_signature_scheme_
         } else
 #endif
         {
-            if (EVP_PKEY_id(key) == EVP_PKEY_RSA) {
+            if (pkey_id == EVP_PKEY_RSA) {
                 if (EVP_PKEY_CTX_set_rsa_padding(pkey_ctx, RSA_PKCS1_PSS_PADDING) != 1) {
                     ret = PTLS_ERROR_LIBRARY;
                     goto Exit;
@@ -834,12 +835,13 @@ static int do_sign(EVP_PKEY *key, const struct st_ptls_openssl_signature_scheme_
             args->ctx = ctx;
             ctx = NULL;
             args->scheme = scheme;
-            *sign_ctx = args;
+            if (sign_ctx != NULL)
+                *sign_ctx = args;
         }
     }
 
 #if PTLS_OPENSSL_HAVE_ED25519
-    if (EVP_PKEY_id(key) == EVP_PKEY_ED25519) {
+    if (pkey_id == EVP_PKEY_ED25519) {
         // signing is complete as ED25519 is one-shot
     } else
 #endif
@@ -847,22 +849,26 @@ static int do_sign(EVP_PKEY *key, const struct st_ptls_openssl_signature_scheme_
 #ifdef PTLS_OPENSSL_HAVE_ASYNC
         if (ASYNC_get_current_job() == NULL) {
             // start async sign
-            switch (ASYNC_start_job(&args->job, args->waitctx, &ret, do_sign_final, &args, sizeof(struct sign_ctx**)))
+            switch (ASYNC_start_job(&args->job, args->waitctx, &ret, do_sign_final, &args, sizeof(struct sign_ctx*)))
             {
                 case ASYNC_ERR:
                     ret = PTLS_ERROR_LIBRARY;
                     goto Exit;
                 case ASYNC_PAUSE: {
                     ret = PTLS_ERROR_ASYNC_OPERATION;
-                    *cb = async_sign_cancel;
+                    if (cb != NULL)
+                        *cb = async_sign_cancel;
                     return ret;
                 }
                 case ASYNC_NO_JOBS:
                     ret = PTLS_ERROR_LIBRARY;
                     goto Exit;
                 case ASYNC_FINISH: {
-                    ptls_buffer__do_pushv(outbuf, args->sig, args->siglen);
                     args->job = NULL;
+                    if (ptls_buffer__do_pushv(outbuf, args->sig, args->siglen) != 0) {
+                        ret = PTLS_ERROR_LIBRARY;
+                        goto Exit;
+                    }
                     break;
                 }
                 default:
@@ -872,14 +878,19 @@ static int do_sign(EVP_PKEY *key, const struct st_ptls_openssl_signature_scheme_
         }
 #else
     do_sign_final(&args);
-    ptls_buffer__do_pushv(outbuf, args->sig, args->siglen);
+    if (ptls_buffer__do_pushv(outbuf, args->sig, args->siglen) != 0) {
+        ret = PTLS_ERROR_LIBRARY;
+        goto Exit;
+    }
 #endif
     }
 
     ret = 0;
 Exit:
-    *sign_ctx = NULL;
-    *cb = NULL;
+    if (sign_ctx != NULL)
+        *sign_ctx = NULL;
+    if (cb != NULL)
+        *cb = NULL;
     sign_ctx_destroy(args);
     if (ctx != NULL)
         EVP_MD_CTX_destroy(ctx);
@@ -1201,11 +1212,6 @@ static int sign_certificate(ptls_sign_certificate_t *_self, ptls_t *tls, void (*
         }
     } else {
         assert(sign_ctx == NULL);
-        // setup temporary ctx for client
-        void *tmp_sign_ctx = NULL;
-        void (*tmp_sign_ctx_cb)(void *sign_ctx);
-        sign_ctx = &tmp_sign_ctx;
-        cb = &tmp_sign_ctx_cb;
         scheme = match_scheme(self->schemes, algorithms, num_algorithms);
         goto Exit;
     }

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -698,11 +698,32 @@ int ptls_openssl_create_key_exchange(ptls_key_exchange_context_t **ctx, EVP_PKEY
 struct sign_ctx {
     const struct st_ptls_openssl_signature_scheme_t *scheme;
     EVP_MD_CTX *ctx;
-    ptls_buffer_t buf;
-    size_t siglen;
     ASYNC_WAIT_CTX *waitctx;
     ASYNC_JOB *job;
+    size_t siglen;
+    // must be last, see `sign_ctx_alloc`
+    uint8_t sig[0];
 };
+
+static struct sign_ctx *sign_ctx_alloc(size_t siglen)
+{
+    // the last member of `struct sign_ctx` is a buffer to store `siglen` bytes
+    struct sign_ctx *sign_ctx = malloc(sizeof(*sign_ctx) + siglen);
+    memset(sign_ctx, 0, sizeof(*sign_ctx) + siglen);
+    sign_ctx->siglen = siglen;
+    return sign_ctx;
+}
+
+static void sign_ctx_destroy(struct sign_ctx *sign_ctx)
+{
+    if (sign_ctx == NULL) return;
+
+    if (sign_ctx->ctx != NULL)
+        EVP_MD_CTX_destroy(sign_ctx->ctx);
+    if (sign_ctx->waitctx != NULL)
+        ASYNC_WAIT_CTX_free(sign_ctx->waitctx);
+    free(sign_ctx);
+}
 
 int ptls_openssl_get_async_fd(ptls_t *ptls)
 {
@@ -718,7 +739,7 @@ int ptls_openssl_get_async_fd(ptls_t *ptls)
 static int async_sign(void *vargs)
 {
     struct sign_ctx *args = *(struct sign_ctx **)vargs;
-    return EVP_DigestSignFinal(args->ctx, args->buf.base, &args->siglen);
+    return EVP_DigestSignFinal(args->ctx, args->sig, &args->siglen);
 }
 
 static int do_sign(EVP_PKEY *key, const struct st_ptls_openssl_signature_scheme_t *scheme, ptls_buffer_t *outbuf,
@@ -727,15 +748,20 @@ static int do_sign(EVP_PKEY *key, const struct st_ptls_openssl_signature_scheme_
     const EVP_MD *md = scheme->scheme_md != NULL ? scheme->scheme_md() : NULL;
     int ret;
 
-    struct sign_ctx *args = *sign_ctx;
-    if (args->ctx == NULL) {
+    struct sign_ctx *args = NULL;
+    EVP_MD_CTX *ctx = NULL;
+    if (*sign_ctx != NULL) {
+        args = *sign_ctx;
+    } else {
+        size_t siglen;
         EVP_PKEY_CTX *pkey_ctx;
-        if ((args->ctx = EVP_MD_CTX_create()) == NULL) {
+
+        if ((ctx = EVP_MD_CTX_create()) == NULL) {
             ret = PTLS_ERROR_NO_MEMORY;
             goto Exit;
         }
 
-        if (EVP_DigestSignInit(args->ctx, &pkey_ctx, md, NULL, key) != 1) {
+        if (EVP_DigestSignInit(ctx, &pkey_ctx, md, NULL, key) != 1) {
             ret = PTLS_ERROR_LIBRARY;
             goto Exit;
         }
@@ -743,13 +769,13 @@ static int do_sign(EVP_PKEY *key, const struct st_ptls_openssl_signature_scheme_
 #if PTLS_OPENSSL_HAVE_ED25519
         if (EVP_PKEY_id(key) == EVP_PKEY_ED25519) {
             /* ED25519 requires the use of the all-at-once function that appeared in OpenSSL 1.1.1, hence different path */
-            if (EVP_DigestSign(args->ctx, NULL, &args->siglen, input.base, input.len) != 1) {
+            if (EVP_DigestSign(ctx, NULL, &siglen, input.base, input.len) != 1) {
                 ret = PTLS_ERROR_LIBRARY;
                 goto Exit;
             }
-            if ((ret = ptls_buffer_reserve(outbuf, args->siglen)) != 0)
+            if ((ret = ptls_buffer_reserve(outbuf, siglen)) != 0)
                 goto Exit;
-            if (EVP_DigestSign(args->ctx, outbuf->base + outbuf->off, &args->siglen, input.base, input.len) != 1) {
+            if (EVP_DigestSign(ctx, outbuf->base + outbuf->off, &siglen, input.base, input.len) != 1) {
                 ret = PTLS_ERROR_LIBRARY;
                 goto Exit;
             }
@@ -770,18 +796,21 @@ static int do_sign(EVP_PKEY *key, const struct st_ptls_openssl_signature_scheme_
                     goto Exit;
                 }
             }
-            if (EVP_DigestSignUpdate(args->ctx, input.base, input.len) != 1) {
+            if (EVP_DigestSignUpdate(ctx, input.base, input.len) != 1) {
                 ret = PTLS_ERROR_LIBRARY;
                 goto Exit;
             }
 
-            if (EVP_DigestSignFinal(args->ctx, NULL, &args->siglen) != 1) {
+            if (EVP_DigestSignFinal(ctx, NULL, &siglen) != 1) {
                 ret = PTLS_ERROR_LIBRARY;
                 goto Exit;
             }
 
-            if ((ret = ptls_buffer_reserve(&args->buf, args->siglen)) != 0)
-                goto Exit;
+            args = sign_ctx_alloc(siglen);
+            args->ctx = ctx;
+            ctx = NULL;
+            args->scheme = scheme;
+            *sign_ctx = args;
         }
     }
 
@@ -810,8 +839,7 @@ static int do_sign(EVP_PKEY *key, const struct st_ptls_openssl_signature_scheme_
                     ret = PTLS_ERROR_LIBRARY;
                     goto Exit;
                 case ASYNC_FINISH: {
-                    args->buf.off += args->siglen;
-                    ptls_buffer__do_pushv(outbuf, args->buf.base, args->buf.off);
+                    ptls_buffer__do_pushv(outbuf, args->sig, args->siglen);
                     args->job = NULL;
                     break;
                 }
@@ -824,9 +852,10 @@ static int do_sign(EVP_PKEY *key, const struct st_ptls_openssl_signature_scheme_
 
     ret = 0;
 Exit:
-    if (args->ctx != NULL) {
-        EVP_MD_CTX_destroy(args->ctx);
-    }
+    *sign_ctx = NULL;
+    sign_ctx_destroy(args);
+    if (ctx != NULL)
+        EVP_MD_CTX_destroy(ctx);
     return ret;
 }
 
@@ -1112,19 +1141,13 @@ static int sign_certificate(ptls_sign_certificate_t *_self, ptls_t *tls, void **
     ptls_openssl_sign_certificate_t *self = (ptls_openssl_sign_certificate_t *)_self;
     const struct st_ptls_openssl_signature_scheme_t *scheme;
 
-    struct sign_ctx *args;
-    if (*sign_ctx == NULL) {
-        args = malloc(sizeof(*args));
-        memset(args, 0, sizeof(*args));
-        ptls_buffer_init(&args->buf, "", 0);
-
+    struct sign_ctx *args = *sign_ctx;
+    if (args == NULL) {
         // first invocation, get scheme
         for (scheme = self->schemes; scheme->scheme_id != UINT16_MAX; ++scheme) {
             size_t i;
             for (i = 0; i != num_algorithms; ++i) {
                 if (algorithms[i] == scheme->scheme_id) {
-                    args->scheme = scheme;
-                    *sign_ctx = args;
                     goto Exit;
                 }
             }
@@ -1133,7 +1156,6 @@ static int sign_certificate(ptls_sign_certificate_t *_self, ptls_t *tls, void **
         // second invocation
         // algorithms should be NULL, re-use cached scheme
         assert(algorithms == NULL);
-        args = *sign_ctx;
         scheme = args->scheme;
         goto Exit;
     }
@@ -1142,13 +1164,7 @@ static int sign_certificate(ptls_sign_certificate_t *_self, ptls_t *tls, void **
 
 Exit:
     *selected_algorithm = scheme->scheme_id;
-    int ret = do_sign(self->key, scheme, outbuf, input, sign_ctx);
-    if (ret != PTLS_ERROR_ASYNC_OPERATION) {
-        *sign_ctx = NULL;
-        ptls_buffer_dispose(&args->buf);
-        free(args);
-    }
-    return ret;
+    return do_sign(self->key, scheme, outbuf, input, sign_ctx);
 }
 
 static X509 *to_x509(ptls_iovec_t vec)

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -857,7 +857,7 @@ static int do_sign(EVP_PKEY *key, const struct st_ptls_openssl_signature_scheme_
                     goto Exit;
                 case ASYNC_PAUSE: {
                     ret = PTLS_ERROR_ASYNC_OPERATION;
-                    assert(cancel_cb == NULL);
+                    assert(*cancel_cb == NULL);
                     *cancel_cb = async_sign_cancel;
                     return ret;
                 }

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -729,7 +729,7 @@ int ptls_openssl_get_async_fd(ptls_t *ptls)
 {
     int fds[1];
     size_t numfds;
-    struct sign_ctx *args = ptls_get_sign_ctx(ptls);
+    struct sign_ctx *args = ptls_get_sign_context(ptls);
     ASYNC_WAIT_CTX_get_all_fds(args->waitctx, NULL, &numfds);
     assert(numfds == 1);
     ASYNC_WAIT_CTX_get_all_fds(args->waitctx, fds, &numfds);

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -1320,6 +1320,7 @@ Exit:
 int ptls_openssl_init_sign_certificate(ptls_openssl_sign_certificate_t *self, EVP_PKEY *key)
 {
     *self = (ptls_openssl_sign_certificate_t){{sign_certificate}};
+    self->async = 1;
 
     if ((self->schemes = lookup_signature_schemes(key)) == NULL)
         return PTLS_ERROR_INCOMPATIBLE_KEY;

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -184,6 +184,8 @@ struct st_ptls_t {
         ptls_buffer_t rec;
         ptls_buffer_t mess;
     } recvbuf;
+
+    ptls_buffer_t wbuf;
     /**
      * key schedule
      */
@@ -4426,6 +4428,7 @@ static ptls_t *new_instance(ptls_context_t *ctx, int is_server)
     tls->is_server = is_server;
     tls->send_change_cipher_spec = ctx->send_change_cipher_spec;
     tls->skip_tracing = ptls_default_skip_tracing;
+    ptls_buffer_init(&tls->wbuf, "", 0);
     return tls;
 }
 
@@ -4934,7 +4937,7 @@ int ptls_handshake(ptls_t *tls, ptls_buffer_t *_sendbuf, const void *input, size
 
     assert(tls->state < PTLS_STATE_POST_HANDSHAKE_MIN);
 
-    init_record_message_emitter(tls, &emitter, _sendbuf);
+    init_record_message_emitter(tls, &emitter, &tls->wbuf);
     size_t sendbuf_orig_off = emitter.super.buf->off;
 
     /* special handlings */
@@ -4942,10 +4945,12 @@ int ptls_handshake(ptls_t *tls, ptls_buffer_t *_sendbuf, const void *input, size
     case PTLS_STATE_CLIENT_HANDSHAKE_START: {
         assert(input == NULL || *inlen == 0);
         assert(tls->ctx->key_exchanges[0] != NULL);
-        return send_client_hello(tls, &emitter.super, properties, NULL);
+        ret = send_client_hello(tls, &emitter.super, properties, NULL);
+        goto Exit;
     }
     case PTLS_STATE_SERVER_GENERATING_CERTIFICATE_VERIFY:
-        return server_complete_handshake(tls, &emitter.super, 1, NULL);
+        ret = server_complete_handshake(tls, &emitter.super, 1, NULL);
+        goto Exit;
     default:
         break;
     }
@@ -4985,6 +4990,15 @@ int ptls_handshake(ptls_t *tls, ptls_buffer_t *_sendbuf, const void *input, size
     }
 
     *inlen -= src_end - src;
+
+Exit:
+    if (ret != PTLS_ERROR_ASYNC_OPERATION) {
+        if (tls->wbuf.off != 0) {
+            // flush internal buffer
+            ptls_buffer__do_pushv(_sendbuf, tls->wbuf.base, tls->wbuf.off);
+            ptls_buffer_dispose(&tls->wbuf);
+        }
+    }
     return ret;
 }
 

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -167,6 +167,7 @@ struct st_ptls_t {
         PTLS_STATE_CLIENT_EXPECT_FINISHED,
         PTLS_STATE_SERVER_EXPECT_CLIENT_HELLO,
         PTLS_STATE_SERVER_EXPECT_SECOND_CLIENT_HELLO,
+        PTLS_STATE_SERVER_GENERATING_CERTIFICATE_VERIFY,
         PTLS_STATE_SERVER_EXPECT_CERTIFICATE,
         PTLS_STATE_SERVER_EXPECT_CERTIFICATE_VERIFY,
         /* ptls_send can be called if the state is below here */
@@ -250,6 +251,8 @@ struct st_ptls_t {
         struct {
             uint8_t pending_traffic_secret[PTLS_MAX_DIGEST_SIZE];
             uint32_t early_data_skipped_bytes; /* if not UINT32_MAX, the server is skipping early data */
+            unsigned can_send_session_ticket : 1;
+            void *sign_certificate_ctx;
         } server;
     };
     /**
@@ -383,6 +386,8 @@ static int hkdf_expand_label(ptls_hash_algorithm_t *algo, void *output, size_t o
                              ptls_iovec_t hash_value, const char *label_prefix);
 static ptls_aead_context_t *new_aead(ptls_aead_algorithm_t *aead, ptls_hash_algorithm_t *hash, int is_enc, const void *secret,
                                      ptls_iovec_t hash_value, const char *label_prefix);
+static int server_complete_handshake(ptls_t *tls, ptls_message_emitter_t *emitter, int send_cert_verify,
+                                     struct st_ptls_signature_algorithms_t *signature_algorithms);
 
 static int is_supported_version(uint16_t v)
 {
@@ -2700,10 +2705,10 @@ Exit:
     return ret;
 }
 
-static int send_certificate_and_certificate_verify(ptls_t *tls, ptls_message_emitter_t *emitter,
-                                                   struct st_ptls_signature_algorithms_t *signature_algorithms,
-                                                   ptls_iovec_t context, const char *context_string, int push_status_request,
-                                                   const uint16_t *compress_algos, size_t num_compress_algos)
+static int send_certificate(ptls_t *tls, ptls_message_emitter_t *emitter,
+                            struct st_ptls_signature_algorithms_t *signature_algorithms,
+                            ptls_iovec_t context, int push_status_request,
+                            const uint16_t *compress_algos, size_t num_compress_algos)
 {
     int ret;
 
@@ -2728,27 +2733,44 @@ static int send_certificate_and_certificate_verify(ptls_t *tls, ptls_message_emi
         }
     }
 
-    /* build and send CertificateVerify */
-    if (tls->ctx->sign_certificate != NULL) {
-        ptls_push_message(emitter, tls->key_schedule, PTLS_HANDSHAKE_TYPE_CERTIFICATE_VERIFY, {
-            ptls_buffer_t *sendbuf = emitter->buf;
-            size_t algo_off = sendbuf->off;
-            ptls_buffer_push16(sendbuf, 0); /* filled in later */
-            ptls_buffer_push_block(sendbuf, 2, {
-                uint16_t algo;
-                uint8_t data[PTLS_MAX_CERTIFICATE_VERIFY_SIGNDATA_SIZE];
-                size_t datalen = build_certificate_verify_signdata(data, tls->key_schedule, context_string);
-                if ((ret = tls->ctx->sign_certificate->cb(tls->ctx->sign_certificate, tls, &algo, sendbuf,
-                                                          ptls_iovec_init(data, datalen), signature_algorithms->list,
-                                                          signature_algorithms->count)) != 0) {
-                    goto Exit;
-                }
-                sendbuf->base[algo_off] = (uint8_t)(algo >> 8);
-                sendbuf->base[algo_off + 1] = (uint8_t)algo;
-            });
-        });
-    }
+Exit:
+    return ret;
+}
 
+static int send_certificate_verify(ptls_t *tls, ptls_message_emitter_t *emitter,
+                                   struct st_ptls_signature_algorithms_t *signature_algorithms,
+                                   const char *context_string)
+{
+    size_t start_off = emitter->buf->off;
+    int ret;
+
+    if (tls->ctx->sign_certificate == NULL)
+        return 0;
+    /* build and send CertificateVerify */
+    ptls_push_message(emitter, tls->key_schedule, PTLS_HANDSHAKE_TYPE_CERTIFICATE_VERIFY, {
+        ptls_buffer_t *sendbuf = emitter->buf;
+        size_t algo_off = sendbuf->off;
+        ptls_buffer_push16(sendbuf, 0); /* filled in later */
+        ptls_buffer_push_block(sendbuf, 2, {
+            uint16_t algo;
+            uint8_t data[PTLS_MAX_CERTIFICATE_VERIFY_SIGNDATA_SIZE];
+            size_t datalen = build_certificate_verify_signdata(data, tls->key_schedule, context_string);
+            if ((ret = tls->ctx->sign_certificate->cb(tls->ctx->sign_certificate, tls, &tls->server.sign_certificate_ctx, &algo,
+                                                      sendbuf, ptls_iovec_init(data, datalen),
+                                                      signature_algorithms != NULL ? signature_algorithms->list : NULL,
+                                                      signature_algorithms != NULL ? signature_algorithms->count : 0)) != 0) {
+                if (ret == PTLS_ERROR_ASYNC_OPERATION) {
+                    assert(tls->is_server || !"async operation only supported on the server-side");
+                    /* Reset the output to the end of the previous handshake message. CertificateVerify will be rebuilt when the
+                     * async operation completes. */
+                    emitter->buf->off = start_off;
+                }
+                goto Exit;
+            }
+            sendbuf->base[algo_off] = (uint8_t)(algo >> 8);
+            sendbuf->base[algo_off + 1] = (uint8_t)algo;
+        });
+    });
 Exit:
     return ret;
 }
@@ -3004,9 +3026,10 @@ static int client_handle_finished(ptls_t *tls, ptls_message_emitter_t *emitter, 
             ret = PTLS_ALERT_ILLEGAL_PARAMETER;
             goto Exit;
         }
-        ret = send_certificate_and_certificate_verify(tls, emitter, &tls->client.certificate_request.signature_algorithms,
-                                                      tls->client.certificate_request.context,
-                                                      PTLS_CLIENT_CERTIFICATE_VERIFY_CONTEXT_STRING, 0, NULL, 0);
+        if ((ret = send_certificate(tls, emitter, &tls->client.certificate_request.signature_algorithms,
+                                    tls->client.certificate_request.context, 0, NULL, 0)) == 0)
+            ret = send_certificate_verify(tls, emitter, &tls->client.certificate_request.signature_algorithms,
+                                   PTLS_CLIENT_CERTIFICATE_VERIFY_CONTEXT_STRING);
         free(tls->client.certificate_request.context.base);
         tls->client.certificate_request.context = ptls_iovec_init(NULL, 0);
         if (ret != 0)
@@ -4031,6 +4054,8 @@ static int server_handle_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptl
             properties->server.selected_psk_binder.len = selected->len;
         }
     }
+    tls->server.can_send_session_ticket = ch->psk.ke_modes != 0;
+
 
     if (accept_early_data && tls->ctx->max_early_data_size != 0 && psk_index == 0) {
         if ((tls->pending_handshake_secret = malloc(PTLS_MAX_DIGEST_SIZE)) == NULL) {
@@ -4130,6 +4155,7 @@ static int server_handle_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptl
     });
 
     if (mode == HANDSHAKE_MODE_FULL) {
+        /* send certificate request if client authentication is activated */
         if (tls->ctx->require_client_authentication) {
             ptls_push_message(emitter, tls->key_schedule, PTLS_HANDSHAKE_TYPE_CERTIFICATE_REQUEST, {
                 /* certificate_request_context, this field SHALL be zero length, unless the certificate
@@ -4145,11 +4171,50 @@ static int server_handle_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptl
                     });
                 });
             });
+
+            if (ret != 0) {
+                goto Exit;
+            }
         }
-        if ((ret = send_certificate_and_certificate_verify(tls, emitter, &ch->signature_algorithms, ptls_iovec_init(NULL, 0),
-                                                           PTLS_SERVER_CERTIFICATE_VERIFY_CONTEXT_STRING, ch->status_request,
-                                                           ch->cert_compression_algos.list, ch->cert_compression_algos.count)) != 0)
+
+        /* send certificate */
+        if ((ret = send_certificate(tls, emitter, &ch->signature_algorithms, ptls_iovec_init(NULL, 0), ch->status_request,
+                                    ch->cert_compression_algos.list, ch->cert_compression_algos.count)) != 0)
             goto Exit;
+        /* send certificateverify, finished, and complete the handshake */
+        if ((ret = server_complete_handshake(tls, emitter, 1, &ch->signature_algorithms)) != 0)
+            goto Exit;
+    } else {
+        /* send finished, and complete the handshake */
+        if ((ret = server_complete_handshake(tls, emitter, 0, NULL)) != 0)
+            goto Exit;
+    }
+
+Exit:
+    free(pubkey.base);
+    if (ecdh_secret.base != NULL) {
+        ptls_clear_memory(ecdh_secret.base, ecdh_secret.len);
+        free(ecdh_secret.base);
+    }
+    free(ch);
+    return ret;
+
+#undef EMIT_SERVER_HELLO
+#undef EMIT_HELLO_RETRY_REQUEST
+}
+
+static int server_complete_handshake(ptls_t *tls, ptls_message_emitter_t *emitter, int send_cert_verify,
+                              struct st_ptls_signature_algorithms_t *signature_algorithms)
+{
+    int ret;
+
+    if (send_cert_verify) {
+        if ((ret = send_certificate_verify(tls, emitter, signature_algorithms, PTLS_SERVER_CERTIFICATE_VERIFY_CONTEXT_STRING)) != 0) {
+            if (ret == PTLS_ERROR_ASYNC_OPERATION) {
+                tls->state = PTLS_STATE_SERVER_GENERATING_CERTIFICATE_VERIFY;
+            }
+            goto Exit;
+        }
     }
 
     if ((ret = send_finished(tls, emitter)) != 0)
@@ -4180,7 +4245,7 @@ static int server_handle_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptl
     }
 
     /* send session ticket if necessary */
-    if (ch->psk.ke_modes != 0 && tls->ctx->ticket_lifetime != 0) {
+    if (tls->server.can_send_session_ticket != 0 && tls->ctx->ticket_lifetime != 0) {
         if ((ret = send_session_ticket(tls, emitter)) != 0)
             goto Exit;
     }
@@ -4192,16 +4257,7 @@ static int server_handle_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptl
     }
 
 Exit:
-    free(pubkey.base);
-    if (ecdh_secret.base != NULL) {
-        ptls_clear_memory(ecdh_secret.base, ecdh_secret.len);
-        free(ecdh_secret.base);
-    }
-    free(ch);
     return ret;
-
-#undef EMIT_SERVER_HELLO
-#undef EMIT_HELLO_RETRY_REQUEST
 }
 
 static int server_handle_end_of_early_data(ptls_t *tls, ptls_iovec_t message)
@@ -4746,6 +4802,7 @@ static int handle_handshake_record(ptls_t *tls,
         ret = cb(tls, emitter, ptls_iovec_init(src, mess_len), src_end - src == mess_len, properties);
         switch (ret) {
         case 0:
+        case PTLS_ERROR_ASYNC_OPERATION:
         case PTLS_ERROR_IN_PROGRESS:
             break;
         default:
@@ -4887,6 +4944,8 @@ int ptls_handshake(ptls_t *tls, ptls_buffer_t *_sendbuf, const void *input, size
         assert(tls->ctx->key_exchanges[0] != NULL);
         return send_client_hello(tls, &emitter.super, properties, NULL);
     }
+    case PTLS_STATE_SERVER_GENERATING_CERTIFICATE_VERIFY:
+        return server_complete_handshake(tls, &emitter.super, 1, NULL);
     default:
         break;
     }
@@ -4911,6 +4970,7 @@ int ptls_handshake(ptls_t *tls, ptls_buffer_t *_sendbuf, const void *input, size
     case 0:
     case PTLS_ERROR_IN_PROGRESS:
     case PTLS_ERROR_STATELESS_RETRY:
+    case PTLS_ERROR_ASYNC_OPERATION:
         break;
     default:
         /* flush partially written response */
@@ -5458,6 +5518,12 @@ int ptls_server_handle_message(ptls_t *tls, ptls_buffer_t *sendbuf, size_t epoch
     struct st_ptls_raw_message_emitter_t emitter = {
         {sendbuf, &tls->traffic_protection.enc, 0, begin_raw_message, commit_raw_message}, SIZE_MAX, epoch_offsets};
     struct st_ptls_record_t rec = {PTLS_CONTENT_TYPE_HANDSHAKE, 0, inlen, input};
+
+    if (tls->state == PTLS_STATE_SERVER_GENERATING_CERTIFICATE_VERIFY) {
+        int ret;
+        if ((ret = server_complete_handshake(tls, &emitter.super, 1, NULL)) != 0)
+            return ret;
+    }
 
     assert(input);
 

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -2758,8 +2758,9 @@ static int send_certificate_verify(ptls_t *tls, ptls_message_emitter_t *emitter,
             uint16_t algo;
             uint8_t data[PTLS_MAX_CERTIFICATE_VERIFY_SIGNDATA_SIZE];
             size_t datalen = build_certificate_verify_signdata(data, tls->key_schedule, context_string);
-            if ((ret = tls->ctx->sign_certificate->cb(tls->ctx->sign_certificate, tls, &tls->server.sign_certificate.cb,
-                                                      &tls->server.sign_certificate.sign_certificate_ctx,
+            if ((ret = tls->ctx->sign_certificate->cb(tls->ctx->sign_certificate, tls,
+                                                      tls->is_server ? &tls->server.sign_certificate.cb : NULL,
+                                                      tls->is_server ? &tls->server.sign_certificate.sign_certificate_ctx : NULL,
                                                       &algo, sendbuf, ptls_iovec_init(data, datalen),
                                                       signature_algorithms != NULL ? signature_algorithms->list : NULL,
                                                       signature_algorithms != NULL ? signature_algorithms->count : 0)) != 0) {

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -4504,7 +4504,7 @@ void ptls_set_context(ptls_t *tls, ptls_context_t *ctx)
     tls->ctx = ctx;
 }
 
-void *ptls_get_sign_ctx(ptls_t *tls)
+void *ptls_get_sign_context(ptls_t *tls)
 {
     assert(tls->is_server);
     return tls->server.sign_certificate_ctx;

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -253,7 +253,7 @@ struct st_ptls_t {
             uint32_t early_data_skipped_bytes; /* if not UINT32_MAX, the server is skipping early data */
             unsigned can_send_session_ticket : 1;
             struct {
-                void (*cb)(void *sign_certificate_ctx);
+                void (*cancel_cb)(void *sign_certificate_ctx);
                 void *sign_certificate_ctx;
             } sign_certificate;
         } server;
@@ -389,7 +389,7 @@ static int hkdf_expand_label(ptls_hash_algorithm_t *algo, void *output, size_t o
                              ptls_iovec_t hash_value, const char *label_prefix);
 static ptls_aead_context_t *new_aead(ptls_aead_algorithm_t *aead, ptls_hash_algorithm_t *hash, int is_enc, const void *secret,
                                      ptls_iovec_t hash_value, const char *label_prefix);
-static int server_complete_handshake(ptls_t *tls, ptls_message_emitter_t *emitter, int send_cert_verify,
+static int server_finish_handshake(ptls_t *tls, ptls_message_emitter_t *emitter, int send_cert_verify,
                                      struct st_ptls_signature_algorithms_t *signature_algorithms);
 
 static int is_supported_version(uint16_t v)
@@ -2759,7 +2759,7 @@ static int send_certificate_verify(ptls_t *tls, ptls_message_emitter_t *emitter,
             uint8_t data[PTLS_MAX_CERTIFICATE_VERIFY_SIGNDATA_SIZE];
             size_t datalen = build_certificate_verify_signdata(data, tls->key_schedule, context_string);
             if ((ret = tls->ctx->sign_certificate->cb(tls->ctx->sign_certificate, tls,
-                                                      tls->is_server ? &tls->server.sign_certificate.cb : NULL,
+                                                      tls->is_server ? &tls->server.sign_certificate.cancel_cb : NULL,
                                                       tls->is_server ? &tls->server.sign_certificate.sign_certificate_ctx : NULL,
                                                       &algo, sendbuf, ptls_iovec_init(data, datalen),
                                                       signature_algorithms != NULL ? signature_algorithms->list : NULL,
@@ -4488,8 +4488,8 @@ void ptls_free(ptls_t *tls)
     if (tls->certificate_verify.cb != NULL) {
         tls->certificate_verify.cb(tls->certificate_verify.verify_ctx, 0, ptls_iovec_init(NULL, 0), ptls_iovec_init(NULL, 0));
     }
-    if (tls->server.sign_certificate.cb != NULL) {
-        tls->server.sign_certificate.cb(tls->server.sign_certificate.sign_certificate_ctx);
+    if (tls->server.sign_certificate.cancel_cb != NULL) {
+        tls->server.sign_certificate.cancel_cb(tls->server.sign_certificate.sign_certificate_ctx);
     }
     if (tls->pending_handshake_secret != NULL) {
         ptls_clear_memory(tls->pending_handshake_secret, PTLS_MAX_DIGEST_SIZE);

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -4187,11 +4187,11 @@ static int server_handle_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptl
                                     ch->cert_compression_algos.list, ch->cert_compression_algos.count)) != 0)
             goto Exit;
         /* send certificateverify, finished, and complete the handshake */
-        if ((ret = server_complete_handshake(tls, emitter, 1, &ch->signature_algorithms)) != 0)
+        if ((ret = server_finish_handshake(tls, emitter, 1, &ch->signature_algorithms)) != 0)
             goto Exit;
     } else {
         /* send finished, and complete the handshake */
-        if ((ret = server_complete_handshake(tls, emitter, 0, NULL)) != 0)
+        if ((ret = server_finish_handshake(tls, emitter, 0, NULL)) != 0)
             goto Exit;
     }
 
@@ -4208,7 +4208,7 @@ Exit:
 #undef EMIT_HELLO_RETRY_REQUEST
 }
 
-static int server_complete_handshake(ptls_t *tls, ptls_message_emitter_t *emitter, int send_cert_verify,
+static int server_finish_handshake(ptls_t *tls, ptls_message_emitter_t *emitter, int send_cert_verify,
                               struct st_ptls_signature_algorithms_t *signature_algorithms)
 {
     int ret;
@@ -4959,7 +4959,7 @@ int ptls_handshake(ptls_t *tls, ptls_buffer_t *_sendbuf, const void *input, size
         return send_client_hello(tls, &emitter.super, properties, NULL);
     }
     case PTLS_STATE_SERVER_GENERATING_CERTIFICATE_VERIFY:
-        return server_complete_handshake(tls, &emitter.super, 1, NULL);
+        return server_finish_handshake(tls, &emitter.super, 1, NULL);
     default:
         break;
     }
@@ -5535,7 +5535,7 @@ int ptls_server_handle_message(ptls_t *tls, ptls_buffer_t *sendbuf, size_t epoch
 
     if (tls->state == PTLS_STATE_SERVER_GENERATING_CERTIFICATE_VERIFY) {
         int ret;
-        if ((ret = server_complete_handshake(tls, &emitter.super, 1, NULL)) != 0)
+        if ((ret = server_finish_handshake(tls, &emitter.super, 1, NULL)) != 0)
             return ret;
     }
 

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -4504,6 +4504,12 @@ void ptls_set_context(ptls_t *tls, ptls_context_t *ctx)
     tls->ctx = ctx;
 }
 
+void *ptls_get_sign_ctx(ptls_t *tls)
+{
+    assert(tls->is_server);
+    return tls->server.sign_certificate_ctx;
+}
+
 ptls_iovec_t ptls_get_client_random(ptls_t *tls)
 {
     return ptls_iovec_init(tls->client_random, PTLS_HELLO_RANDOM_SIZE);

--- a/lib/uecc.c
+++ b/lib/uecc.c
@@ -131,7 +131,7 @@ Exit:
     return ret;
 }
 
-static int secp256r1sha256_sign(ptls_sign_certificate_t *_self, ptls_t *tls, uint16_t *selected_algorithm, ptls_buffer_t *outbuf,
+static int secp256r1sha256_sign(ptls_sign_certificate_t *_self, ptls_t *tls, void **sign_ctx, uint16_t *selected_algorithm, ptls_buffer_t *outbuf,
                                 ptls_iovec_t input, const uint16_t *algorithms, size_t num_algorithms)
 {
     ptls_minicrypto_secp256r1sha256_sign_certificate_t *self = (ptls_minicrypto_secp256r1sha256_sign_certificate_t *)_self;

--- a/t/minicrypto.c
+++ b/t/minicrypto.c
@@ -52,7 +52,7 @@ static void test_secp256r1_sign(void)
     uECC_make_key(pub, signer.key, uECC_secp256r1());
     ptls_buffer_init(&sigbuf, sigbuf_small, sizeof(sigbuf_small));
 
-    ok(secp256r1sha256_sign(&signer.super, NULL, &selected, &sigbuf, ptls_iovec_init(msg, 32),
+    ok(secp256r1sha256_sign(&signer.super, NULL, NULL, &selected, &sigbuf, ptls_iovec_init(msg, 32),
                             (uint16_t[]){PTLS_SIGNATURE_ECDSA_SECP256R1_SHA256}, 1) == 0);
     ok(selected == PTLS_SIGNATURE_ECDSA_SECP256R1_SHA256);
 

--- a/t/openssl.c
+++ b/t/openssl.c
@@ -138,18 +138,21 @@ static void test_key_exchanges(void)
 static void test_sign_verify(EVP_PKEY *key, const struct st_ptls_openssl_signature_scheme_t *schemes)
 {
     for (size_t i = 0; schemes[i].scheme_id != UINT16_MAX; ++i) {
+        struct sign_ctx *args = malloc(sizeof(*args));
+        memset(args, 0, sizeof(*args));
         note("scheme 0x%04x", schemes[i].scheme_id);
         const void *message = "hello world";
         ptls_buffer_t sigbuf;
         uint8_t sigbuf_small[1024];
 
         ptls_buffer_init(&sigbuf, sigbuf_small, sizeof(sigbuf_small));
-        ok(do_sign(key, schemes + i, &sigbuf, ptls_iovec_init(message, strlen(message))) == 0);
+        ok(do_sign(key, schemes + i, &sigbuf, ptls_iovec_init(message, strlen(message)), (void**)&args) == 0);
         EVP_PKEY_up_ref(key);
         ok(verify_sign(key, schemes[i].scheme_id, ptls_iovec_init(message, strlen(message)),
                        ptls_iovec_init(sigbuf.base, sigbuf.off)) == 0);
 
         ptls_buffer_dispose(&sigbuf);
+        free(args);
     }
 }
 

--- a/t/picotls.c
+++ b/t/picotls.c
@@ -906,15 +906,15 @@ static void test_handshake(ptls_iovec_t ticket, int mode, int expect_ticket, int
 
 static ptls_sign_certificate_t *sc_orig;
 
-static int sign_certificate(ptls_sign_certificate_t *self, ptls_t *tls, void (**cb)(void *sign_ctx), void **sign_ctx,
+static int sign_certificate(ptls_sign_certificate_t *self, ptls_t *tls, void (**cancel_cb)(void *sign_ctx), void **sign_ctx,
                             uint16_t *selected_algorithm, ptls_buffer_t *output, ptls_iovec_t input, const uint16_t *algorithms,
                             size_t num_algorithms)
 {
     ++*(ptls_is_server(tls) ? &server_sc_callcnt : &client_sc_callcnt);
-    return sc_orig->cb(sc_orig, tls, cb, sign_ctx, selected_algorithm, output, input, algorithms, num_algorithms);
+    return sc_orig->cb(sc_orig, tls, cancel_cb, sign_ctx, selected_algorithm, output, input, algorithms, num_algorithms);
 }
 
-static int async_sign_certificate(ptls_sign_certificate_t *self, ptls_t *tls, void (**cb)(void *sign_ctx), void **sign_ctx,
+static int async_sign_certificate(ptls_sign_certificate_t *self, ptls_t *tls, void (**cancel_cb)(void *sign_ctx), void **sign_ctx,
                                   uint16_t *selected_algorithm, ptls_buffer_t *output, ptls_iovec_t input, const uint16_t *algorithms,
                                   size_t num_algorithms)
 {
@@ -926,7 +926,7 @@ static int async_sign_certificate(ptls_sign_certificate_t *self, ptls_t *tls, vo
         /* first invocation, make a fake call to the backend and obtain the algorithm, return it, but not the signature */
         ptls_buffer_t fakebuf;
         ptls_buffer_init(&fakebuf, "", 0);
-        int ret = sign_certificate(self, tls, cb, &inner_sign_ctx, selected_algorithm, &fakebuf, input, algorithms,
+        int ret = sign_certificate(self, tls, cancel_cb, &inner_sign_ctx, selected_algorithm, &fakebuf, input, algorithms,
                                    num_algorithms);
         assert(ret == 0);
         ptls_buffer_dispose(&fakebuf);
@@ -943,18 +943,18 @@ static int async_sign_certificate(ptls_sign_certificate_t *self, ptls_t *tls, vo
         num_algorithms = 1;
     }
 
-    return sign_certificate(self, tls, cb, &inner_sign_ctx, selected_algorithm, output, input, algorithms,
+    return sign_certificate(self, tls, cancel_cb, &inner_sign_ctx, selected_algorithm, output, input, algorithms,
                             num_algorithms);
 }
 
 static ptls_sign_certificate_t *second_sc_orig;
 
-static int second_sign_certificate(ptls_sign_certificate_t *self, ptls_t *tls, void (**cb)(void *sign_ctx), void **sign_ctx,
+static int second_sign_certificate(ptls_sign_certificate_t *self, ptls_t *tls, void (**cancel_cb)(void *sign_ctx), void **sign_ctx,
                                    uint16_t *selected_algorithm, ptls_buffer_t *output, ptls_iovec_t input, const uint16_t *algorithms,
                                    size_t num_algorithms)
 {
     ++*(ptls_is_server(tls) ? &server_sc_callcnt : &client_sc_callcnt);
-    return second_sc_orig->cb(second_sc_orig, tls, cb, sign_ctx, selected_algorithm, output, input, algorithms, num_algorithms);
+    return second_sc_orig->cb(second_sc_orig, tls, cancel_cb, sign_ctx, selected_algorithm, output, input, algorithms, num_algorithms);
 }
 
 static void test_full_handshake_impl(int require_client_authentication, int is_async)

--- a/t/picotls.c
+++ b/t/picotls.c
@@ -906,15 +906,17 @@ static void test_handshake(ptls_iovec_t ticket, int mode, int expect_ticket, int
 
 static ptls_sign_certificate_t *sc_orig;
 
-static int sign_certificate(ptls_sign_certificate_t *self, ptls_t *tls, void **sign_ctx, uint16_t *selected_algorithm, ptls_buffer_t *output,
-                            ptls_iovec_t input, const uint16_t *algorithms, size_t num_algorithms)
+static int sign_certificate(ptls_sign_certificate_t *self, ptls_t *tls, void (**cb)(void *sign_ctx), void **sign_ctx,
+                            uint16_t *selected_algorithm, ptls_buffer_t *output, ptls_iovec_t input, const uint16_t *algorithms,
+                            size_t num_algorithms)
 {
     ++*(ptls_is_server(tls) ? &server_sc_callcnt : &client_sc_callcnt);
-    return sc_orig->cb(sc_orig, tls, sign_ctx, selected_algorithm, output, input, algorithms, num_algorithms);
+    return sc_orig->cb(sc_orig, tls, cb, sign_ctx, selected_algorithm, output, input, algorithms, num_algorithms);
 }
 
-static int async_sign_certificate(ptls_sign_certificate_t *self, ptls_t *tls, void **sign_ctx, uint16_t *selected_algorithm,
-                                  ptls_buffer_t *output, ptls_iovec_t input, const uint16_t *algorithms, size_t num_algorithms)
+static int async_sign_certificate(ptls_sign_certificate_t *self, ptls_t *tls, void (**cb)(void *sign_ctx), void **sign_ctx,
+                                  uint16_t *selected_algorithm, ptls_buffer_t *output, ptls_iovec_t input, const uint16_t *algorithms,
+                                  size_t num_algorithms)
 {
     static void *inner_sign_ctx = NULL;
     if (!ptls_is_server(tls)) {
@@ -924,7 +926,7 @@ static int async_sign_certificate(ptls_sign_certificate_t *self, ptls_t *tls, vo
         /* first invocation, make a fake call to the backend and obtain the algorithm, return it, but not the signature */
         ptls_buffer_t fakebuf;
         ptls_buffer_init(&fakebuf, "", 0);
-        int ret = sign_certificate(self, tls, &inner_sign_ctx, selected_algorithm, &fakebuf, input, algorithms,
+        int ret = sign_certificate(self, tls, cb, &inner_sign_ctx, selected_algorithm, &fakebuf, input, algorithms,
                                    num_algorithms);
         assert(ret == 0);
         ptls_buffer_dispose(&fakebuf);
@@ -941,17 +943,18 @@ static int async_sign_certificate(ptls_sign_certificate_t *self, ptls_t *tls, vo
         num_algorithms = 1;
     }
 
-    return sign_certificate(self, tls, &inner_sign_ctx, selected_algorithm, output, input, algorithms,
+    return sign_certificate(self, tls, cb, &inner_sign_ctx, selected_algorithm, output, input, algorithms,
                             num_algorithms);
 }
 
 static ptls_sign_certificate_t *second_sc_orig;
 
-static int second_sign_certificate(ptls_sign_certificate_t *self, ptls_t *tls, void **sign_ctx, uint16_t *selected_algorithm, ptls_buffer_t *output,
-                                   ptls_iovec_t input, const uint16_t *algorithms, size_t num_algorithms)
+static int second_sign_certificate(ptls_sign_certificate_t *self, ptls_t *tls, void (**cb)(void *sign_ctx), void **sign_ctx,
+                                   uint16_t *selected_algorithm, ptls_buffer_t *output, ptls_iovec_t input, const uint16_t *algorithms,
+                                   size_t num_algorithms)
 {
     ++*(ptls_is_server(tls) ? &server_sc_callcnt : &client_sc_callcnt);
-    return second_sc_orig->cb(second_sc_orig, tls, sign_ctx, selected_algorithm, output, input, algorithms, num_algorithms);
+    return second_sc_orig->cb(second_sc_orig, tls, cb, sign_ctx, selected_algorithm, output, input, algorithms, num_algorithms);
 }
 
 static void test_full_handshake_impl(int require_client_authentication, int is_async)


### PR DESCRIPTION
For: https://github.com/h2o/h2o/pull/3064

Splits the certificate and certificate verify function and adds a `PTLS_STATE_SERVER_GENERATING_CERTIFICATE_VERIFY` state and `PTLS_ERROR_ASYNC_OPERATION` return code

References:
https://github.com/h2o/picotls/pull/291