### PR TITLE
Fix compile warnings about unchecked returns in t/cli

### DIFF
--- a/t/cli.c
+++ b/t/cli.c
@@ -158,7 +158,7 @@ static int handle_connection(int sockfd, ptls_context_t *ctx, const char *server
                         /* ok */
                     } else {
                         if (encbuf.off != 0)
-                            (void)write(sockfd, encbuf.base, encbuf.off);
+                            ptls_repeat_while_eintr(write(sockfd, encbuf.base, encbuf.off), { break; });
                         fprintf(stderr, "ptls_handshake:%d\n", ret);
                         goto Exit;
                     }
@@ -167,7 +167,7 @@ static int handle_connection(int sockfd, ptls_context_t *ctx, const char *server
                         if (rbuf.off != 0) {
                             data_received += rbuf.off;
                             if (input_file != input_file_is_benchmark)
-                                write(1, rbuf.base, rbuf.off);
+                                ptls_repeat_while_eintr(write(1, rbuf.base, rbuf.off), { goto Exit; });
                             rbuf.off = 0;
                         }
                     } else if (ret == PTLS_ERROR_IN_PROGRESS) {
@@ -254,7 +254,7 @@ static int handle_connection(int sockfd, ptls_context_t *ctx, const char *server
                     fprintf(stderr, "ptls_send_alert:%d\n", ret);
                 }
                 if (wbuf.off != 0)
-                    (void)write(sockfd, wbuf.base, wbuf.off);
+                    ptls_repeat_while_eintr(write(sockfd, wbuf.base, wbuf.off), { ptls_buffer_dispose(&wbuf); goto Exit; });
                 ptls_buffer_dispose(&wbuf);
                 shutdown(sockfd, SHUT_WR);
             }

--- a/t/util.h
+++ b/t/util.h
@@ -365,4 +365,24 @@ Error:
     return ptls_iovec_init(NULL, 0);
 }
 
+/* The ptls_repeat_while_eintr macro will repeat a function call (block) if
+* it is interrupted (EINTR) before completion. If failing for other reason,
+* the macro executes the exit block, such as either { break; } or
+* { goto Fail; }
+*/
+
+#ifdef _WINDOWS
+#define ptls_repeat_while_eintr(block, exit_block)                                                                                 \
+    while (block < 0) {                                                                                                            \
+        exit_block;                                                                                                                \
+    }
+#else
+#define ptls_repeat_while_eintr(block, exit_block)                                                                                 \
+    while (block < 0) {                                                                                                            \
+        if (errno == EINTR)                                                                                                        \
+            continue;                                                                                                              \
+        exit_block;                                                                                                                \
+    }
+#endif
+
 #endif


### PR DESCRIPTION
This cleaner PR replaces PR #411 which was mixed up with too many old commits.

The warning happens when compiling `t/cli.c` because the return arguments of calls to `write` are not checked. In theory, casting the calls as `(void)` should suffice, but that does not work with `gcc` . Further analysis showed that return code should in fact be checked, because the calls can be interrupted, and in that case it would be better to repeat them.

In order to keep the code simple and readable, the PR proposes adding a macro in `t/util.h`, then use that macro to protect the `write` calls.