### PR TITLE
Fix Visual Studio warnings when using OpenSSL 3.0

### DIFF
--- a/src/esni.c
+++ b/src/esni.c
@@ -36,6 +36,9 @@
 #include <time.h>
 #define OPENSSL_API_COMPAT 0x00908000L
 #include <openssl/err.h>
+#if !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x30000000L
+#include <openssl/provider.h>
+#endif
 #include <openssl/engine.h>
 #include <openssl/pem.h>
 #include "picotls.h"
@@ -134,7 +137,9 @@ int main(int argc, char **argv)
     char const *file_output = NULL;
     ERR_load_crypto_strings();
     OpenSSL_add_all_algorithms();
-#if !defined(OPENSSL_NO_ENGINE)
+#if !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x30000000L
+    (void) OSSL_PROVIDER_load(NULL, "default");
+#elif !defined(OPENSSL_NO_ENGINE)
     /* Load all compiled-in ENGINEs */
     ENGINE_load_builtin_engines();
     ENGINE_register_all_ciphers();

--- a/t/openssl.c
+++ b/t/openssl.c
@@ -36,6 +36,7 @@
 #include "picotls.h"
 #include "picotls/minicrypto.h"
 #include "../deps/picotest/picotest.h"
+#undef OPENSSL_API_COMPAT
 #include "../lib/openssl.c"
 #include "test.h"
 
@@ -298,18 +299,18 @@ int main(int argc, char **argv)
 
     ERR_load_crypto_strings();
     OpenSSL_add_all_algorithms();
-#if !defined(OPENSSL_NO_ENGINE)
+
+#if !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x30000000L
+    /* Explicitly load the legacy provider in addition to default, as we test Blowfish in one of the tests. */
+    OSSL_PROVIDER *legacy = OSSL_PROVIDER_load(NULL, "legacy");
+    OSSL_PROVIDER *dflt = OSSL_PROVIDER_load(NULL, "default");
+#elif !defined(OPENSSL_NO_ENGINE)
     /* Load all compiled-in ENGINEs */
     ENGINE_load_builtin_engines();
     ENGINE_register_all_ciphers();
     ENGINE_register_all_digests();
 #endif
 
-#if !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x30000000L
-    /* Explicitly load the legacy provider in addition to default, as we test Blowfish in one of the tests. */
-    OSSL_PROVIDER *legacy = OSSL_PROVIDER_load(NULL, "legacy");
-    OSSL_PROVIDER *dflt = OSSL_PROVIDER_load(NULL, "default");
-#endif
 
     subtest("bf", test_bf);
 


### PR DESCRIPTION
This PR replaces Pr #413, which included too many unrelated commits. The changes affect `src\esni.c` and `t\openssl.c`. The file `esni.c` is only used in tests of ESNI with Visual Studio; the changes there handle the use of providers instead of engines when using OpenSSL 3.0. There are two minor change in `t/openssl.c`. First, not try using the `engine` APIs and load the default module instead when using OpenSSLv3 -- as written, the code relied only on a `OPENSSL_NO_ENGINE` variable, which was not automatically set when using OpenSSL 3.0. Second, undefining the variable `OPENSSL_API_COMPAT` before including `lib/openssl.c`, because that variable is defined again inside `lib/openssl.c`, and Visual Studio protests against redefinition.

The changes resolve issue #412.