### PR TITLE
[fusion] fix heap read overrun when handling AEAD of > 1500 bytes

### DIFF
--- a/lib/fusion.c
+++ b/lib/fusion.c
@@ -1013,21 +1013,21 @@ ptls_fusion_aesgcm_context_t *ptls_fusion_aesgcm_new(const void *key, size_t key
 
 ptls_fusion_aesgcm_context_t *ptls_fusion_aesgcm_set_capacity(ptls_fusion_aesgcm_context_t *ctx, size_t capacity)
 {
-    size_t ghash_cnt = aesgcm_calc_ghash_cnt(capacity);
+    size_t new_ghash_cnt = aesgcm_calc_ghash_cnt(capacity);
 
-    if (ghash_cnt <= ctx->ghash_cnt)
+    if (new_ghash_cnt <= ctx->ghash_cnt)
         return ctx;
 
-    size_t ctx_size = calc_aesgcm_context_size(&ghash_cnt, ctx->ecb.aesni256);
+    size_t new_ctx_size = calc_aesgcm_context_size(&new_ghash_cnt, ctx->ecb.aesni256);
     ptls_fusion_aesgcm_context_t *newp;
-    if ((newp = aligned_alloc(32, ctx_size)) == NULL)
+    if ((newp = aligned_alloc(32, new_ctx_size)) == NULL)
         return NULL;
-    memcpy(newp, ctx, ctx_size);
+    memcpy(newp, ctx, calc_aesgcm_context_size(&ctx->ghash_cnt, ctx->ecb.aesni256));
     free(ctx);
     ctx = newp;
 
     ctx->capacity = capacity;
-    while (ghash_cnt < ctx->ghash_cnt)
+    while (ctx->ghash_cnt < new_ghash_cnt)
         setup_one_ghash_entry(ctx);
 
     return ctx;

--- a/lib/fusion.c
+++ b/lib/fusion.c
@@ -1018,11 +1018,14 @@ ptls_fusion_aesgcm_context_t *ptls_fusion_aesgcm_set_capacity(ptls_fusion_aesgcm
     if (new_ghash_cnt <= ctx->ghash_cnt)
         return ctx;
 
-    size_t new_ctx_size = calc_aesgcm_context_size(&new_ghash_cnt, ctx->ecb.aesni256);
+    size_t new_ctx_size = calc_aesgcm_context_size(&new_ghash_cnt, ctx->ecb.aesni256),
+           old_ctx_size = calc_aesgcm_context_size(&ctx->ghash_cnt, ctx->ecb.aesni256);
+
     ptls_fusion_aesgcm_context_t *newp;
     if ((newp = aligned_alloc(32, new_ctx_size)) == NULL)
         return NULL;
-    memcpy(newp, ctx, calc_aesgcm_context_size(&ctx->ghash_cnt, ctx->ecb.aesni256));
+    memcpy(newp, ctx, old_ctx_size);
+    ptls_clear_memory(ctx, old_ctx_size);
     free(ctx);
     ctx = newp;
 

--- a/t/fusion.c
+++ b/t/fusion.c
@@ -470,7 +470,7 @@ Fail:
  */
 static void test_generated_set_capacity(void)
 {
-    static const uint8_t secret[PTLS_MAX_DIGEST_SIZE] = "deadbeef", input[3000] = {};
+    static const uint8_t secret[PTLS_MAX_DIGEST_SIZE] = "deadbeef", input[3000] = {0};
     uint8_t encrypted[4000], decrypted[4000];
 
     ptls_aead_context_t *enc = ptls_aead_new(test_generated_encryptor, &ptls_minicrypto_sha256, 1, secret, ""),

--- a/t/fusion.c
+++ b/t/fusion.c
@@ -464,6 +464,28 @@ Fail:
     ok(0);
 }
 
+/**
+ * Default capacity of fusion is 1500 bytes (see `aesgcm_setup`), input of 3000 bytes triggers the invocation of
+ * `ptls_fusion_aesgcm_set_capacity`.
+ */
+static void test_generated_set_capacity(void)
+{
+    static const uint8_t secret[PTLS_MAX_DIGEST_SIZE] = "deadbeef", input[3000] = {};
+    uint8_t encrypted[4000], decrypted[4000];
+
+    ptls_aead_context_t *enc = ptls_aead_new(test_generated_encryptor, &ptls_minicrypto_sha256, 1, secret, ""),
+        *dec = ptls_aead_new(test_generated_encryptor, &ptls_minicrypto_sha256, 0, secret, "");
+
+    size_t enclen = ptls_aead_encrypt(enc, encrypted, input, sizeof(input), 123, "", 0);
+    size_t declen = ptls_aead_decrypt(dec, decrypted, encrypted, enclen, 123, "", 0);
+
+    ok(declen == sizeof(input));
+    ok(memcmp(input, decrypted, sizeof(input)) == 0);
+
+    ptls_aead_free(enc);
+    ptls_aead_free(dec);
+}
+
 static void test_generated_all(ptls_aead_algorithm_t *e1, ptls_aead_algorithm_t *e2, int can_multivec)
 {
     test_generated_encryptor = e1;
@@ -483,6 +505,8 @@ static void test_generated_all(ptls_aead_algorithm_t *e1, ptls_aead_algorithm_t 
         test_generated_multivec = 0;
     }
 
+    subtest("set-capacity", test_generated_set_capacity);
+
     test_generated_encryptor = e2;
     test_generated_decryptor = e1;
 
@@ -490,6 +514,8 @@ static void test_generated_all(ptls_aead_algorithm_t *e1, ptls_aead_algorithm_t 
     subtest("decrypt", test_generated);
     test_generated_iv96 = 1;
     subtest("decrypt-iv96", test_generated);
+
+    subtest("set-capacity", test_generated_set_capacity);
 }
 
 static void test_fusion_aes128gcm(void)

--- a/t/fusion.c
+++ b/t/fusion.c
@@ -474,7 +474,7 @@ static void test_generated_set_capacity(void)
     uint8_t encrypted[4000], decrypted[4000];
 
     ptls_aead_context_t *enc = ptls_aead_new(test_generated_encryptor, &ptls_minicrypto_sha256, 1, secret, ""),
-        *dec = ptls_aead_new(test_generated_encryptor, &ptls_minicrypto_sha256, 0, secret, "");
+                        *dec = ptls_aead_new(test_generated_encryptor, &ptls_minicrypto_sha256, 0, secret, "");
 
     size_t enclen = ptls_aead_encrypt(enc, encrypted, input, sizeof(input), 123, "", 0);
     size_t declen = ptls_aead_decrypt(dec, decrypted, encrypted, enclen, 123, "", 0);


### PR DESCRIPTION
Fixes three issues in `ptls_fusion_aesgcm_set_capacity` which is called when the AEAD input supplied to the fusion engine is longer than 1500 bytes:
* fix read overrun
* correctly initialize the additional ghash precalculated vectors
* clear the precalculated ghash vectors of the old context before calling `free`

Tests are added to cover the use of the function.

Closes #418, subsumes #419.