### PR TITLE
[async signing] support cancellation

### DIFF
--- a/t/openssl.c
+++ b/t/openssl.c
@@ -25,7 +25,6 @@
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
-#include <sys/select.h>
 #include <sys/time.h>
 #define OPENSSL_API_COMPAT 0x00908000L
 #include <openssl/opensslv.h>

--- a/t/openssl.c
+++ b/t/openssl.c
@@ -298,6 +298,8 @@ DEFINE_FFX_AES128_ALGORITHMS(openssl);
 DEFINE_FFX_CHACHA20_ALGORITHMS(openssl);
 #endif
 
+#if HAVE_ASYNC
+
 static ENGINE *load_engine(const char *name)
 {
     ENGINE *e;
@@ -458,6 +460,8 @@ static void many_handshakes(void)
     ptls_buffer_dispose(&hellobuf);
 }
 
+#endif
+
 int main(int argc, char **argv)
 {
     ptls_openssl_sign_certificate_t openssl_sign_certificate;
@@ -550,14 +554,13 @@ int main(int argc, char **argv)
     ctx_peer = &openssl_ctx;
     subtest("minicrypto vs.", test_picotls);
 
-#if PTLS_OPENSSL_HAVE_X25519
+#if HAVE_ASYNC
     // switch to x25519 as we run benchmarks
     static ptls_key_exchange_algorithm_t *x25519_keyex[] = {&ptls_openssl_x25519, NULL}; // use x25519 for speed
     openssl_ctx.key_exchanges = x25519_keyex;
     ctx = &openssl_ctx;
     ctx_peer = &openssl_ctx;
     subtest("many-handshakes-non-async", many_handshakes);
-#if HAVE_ASYNC
     ptls_openssl_async_runner_t async_runner = {async_submit};
     openssl_sign_certificate.async_runner = &async_runner;
     subtest("many-handshakes-async", many_handshakes);
@@ -574,7 +577,6 @@ int main(int argc, char **argv)
             note("%s not found", engine_name);
         }
     }
-#endif
 #endif
 
     esni_private_keys[0]->on_exchange(esni_private_keys, 1, NULL, ptls_iovec_init(NULL, 0));

--- a/t/openssl.c
+++ b/t/openssl.c
@@ -33,7 +33,7 @@
 #if !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x30000000L
 #include <openssl/provider.h>
 #endif
-#if !defined(WINDOWS) && OPENSSL_VERSION_NUMBER >= 0x10100010L && !defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_NO_ASYNC)
+#if !defined(_WINDOWS) && OPENSSL_VERSION_NUMBER >= 0x10100010L && !defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_NO_ASYNC)
 #include <sys/select.h>
 #include <sys/time.h>
 #include <openssl/async.h>

--- a/t/openssl.c
+++ b/t/openssl.c
@@ -35,9 +35,10 @@
 #if !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x30000000L
 #include <openssl/provider.h>
 #endif
-#if OPENSSL_VERSION_NUMBER >= 0x10100010L && !defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_NO_ASYNC)
+#if !defined(WINDOWS) && OPENSSL_VERSION_NUMBER >= 0x10100010L && !defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_NO_ASYNC)
+#include <sys/select.h>
 #include <openssl/async.h>
-#define HAVE_ASYNC 1
+#define TEST_ASYNC 1
 #endif
 #include "picotls.h"
 #include "picotls/minicrypto.h"
@@ -298,7 +299,7 @@ DEFINE_FFX_AES128_ALGORITHMS(openssl);
 DEFINE_FFX_CHACHA20_ALGORITHMS(openssl);
 #endif
 
-#if HAVE_ASYNC
+#if TEST_ASYNC
 
 static ENGINE *load_engine(const char *name)
 {
@@ -554,7 +555,7 @@ int main(int argc, char **argv)
     ctx_peer = &openssl_ctx;
     subtest("minicrypto vs.", test_picotls);
 
-#if HAVE_ASYNC
+#if TEST_ASYNC
     // switch to x25519 as we run benchmarks
     static ptls_key_exchange_algorithm_t *x25519_keyex[] = {&ptls_openssl_x25519, NULL}; // use x25519 for speed
     openssl_ctx.key_exchanges = x25519_keyex;

--- a/t/openssl.c
+++ b/t/openssl.c
@@ -25,7 +25,6 @@
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
-#include <sys/time.h>
 #define OPENSSL_API_COMPAT 0x00908000L
 #include <openssl/opensslv.h>
 #include <openssl/bio.h>
@@ -36,6 +35,7 @@
 #endif
 #if !defined(WINDOWS) && OPENSSL_VERSION_NUMBER >= 0x10100010L && !defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_NO_ASYNC)
 #include <sys/select.h>
+#include <sys/time.h>
 #include <openssl/async.h>
 #define TEST_ASYNC 1
 #endif


### PR DESCRIPTION
Under the new design, picotls supplies jobs and weak references to `ptls_t` associated to each job. It is up to the user to run those jobs. Once the job is complete, the user calls `ptls_handshake` if the weak reference is still valid. Otherwise, resources are reclaimed automatically.

The upside of the design is that the API (`ptls_openssl_async_runner_t`) is agnostic of the type of the job. At the moment only RSA signature generation is offloaded, but we have the opportunity to offload other stuff without changing the API.

The downside is that each user has to implement their own job handling code (e.g., call `ASYNC_start_job`). Though, it might be possible to argue that the design is simpler and easier to understand because picotls does not abstract how OpenSSL runs async jobs.

For more information, please refer to the definition of `ptls_openssl_async_runner_t` (found [here](https://github.com/h2o/picotls/pull/423/files#diff-059e83c74deb9bddb508ce889295f7607b6680902cb931b30015425bda34ae63R101)) as well the async code is t/openssl.c.