### PR TITLE
[async signing] no cancellation

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -608,7 +608,7 @@ PTLS_CALLBACK_TYPE(int, emit_certificate, ptls_t *tls, ptls_message_emitter_t *e
  * Context object used for generating public key signature in an asynchronous manner.
  */
 typedef struct st_ptls_async_sign_certificate_t {
-    void (*cancel_)(struct st_ptls_async_sign_certificate_t *self);
+    void (*destroy_)(struct st_ptls_async_sign_certificate_t *self);
 } ptls_async_sign_certificate_t;
 /**
  * When gerenating CertificateVerify, the core calls the callback to sign the handshake context using the certificate. This callback

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -612,13 +612,7 @@ typedef struct st_ptls_async_job_t {
 } ptls_async_job_t;
 /**
  * When gerenating CertificateVerify, the core calls the callback to sign the handshake context using the certificate. This callback
- * may return PTLS_ERROR_ASYNC_OPERATION, and signal the application outside of picotls when the signature has been generated. At
- * that point, the application should call `ptls_handshake`, which in turn would invoke this callback once again. The callback then
- * fills `*selected_algorithm` and `output` with the signature being generated. Note that `algorithms` and `num_algorithms` are
- * provided only when the callback is called for the first time. The callback can store an object specific to each signature
- * generation in `*async_ctx`.
- * When `ptls_t` is disposed of while the async operation is in flight, `(*async_ctx)->cancel_` is invoked. The backend should abort
- * the calculation and free any temporary data allocated for that calculation.
+ * supports asynchronous mode; see `ptls_openssl_sign_certificate_t` for more information.
  */
 PTLS_CALLBACK_TYPE(int, sign_certificate, ptls_t *tls, ptls_async_job_t **async, uint16_t *selected_algorithm,
                    ptls_buffer_t *output, ptls_iovec_t input, const uint16_t *algorithms, size_t num_algorithms);

--- a/include/picotls/openssl.h
+++ b/include/picotls/openssl.h
@@ -119,7 +119,8 @@ typedef struct st_ptls_openssl_sign_certificate_t {
      * When set to true, indicates to the backend that the signature can be generated asynchronously. When the backend decides to
      * generate the signature asynchronously, `ptls_handshake` will return PTLS_ERROR_ASYNC_OPERATION. When receiving that error
      * code, the user should call `ptls_openssl_get_async_fd` to obtain the file descriptor that represents the asynchronous
-     * operation and poll it for read. Once the file descriptor becomes readable, the user calls `ptls_handshake` once again.
+     * operation and poll it for read. Once the file descriptor becomes readable, the user calls `ptls_handshake` once again to
+     * obtain the handshake messages being generated, or call `ptls_free` to discard TLS state.
      */
     unsigned async : 1;
 } ptls_openssl_sign_certificate_t;

--- a/include/picotls/openssl.h
+++ b/include/picotls/openssl.h
@@ -98,7 +98,11 @@ void ptls_openssl_random_bytes(void *buf, size_t len);
  * constructs a key exchange context. pkey's reference count is incremented.
  */
 int ptls_openssl_create_key_exchange(ptls_key_exchange_context_t **ctx, EVP_PKEY *pkey);
+
 #if PTLS_OPENSSL_HAVE_ASYNC
+/**
+ * Returns the file descriptor of the asynchronous operation in flight.
+ */
 OSSL_ASYNC_FD ptls_openssl_get_async_fd(ptls_t *ptls);
 #endif
 
@@ -112,7 +116,10 @@ typedef struct st_ptls_openssl_sign_certificate_t {
     EVP_PKEY *key;
     const struct st_ptls_openssl_signature_scheme_t *schemes; /* terminated by .scheme_id == UINT16_MAX */
     /**
-     * boolean indicating if signing should be asynchronous
+     * When set to true, indicates to the backend that the signature can be generated asynchronously. When the backend decides to
+     * generate the signature asynchronously, `ptls_handshake` will return PTLS_ERROR_ASYNC_OPERATION. When receiving that error
+     * code, the user should call `ptls_openssl_get_async_fd` to obtain the file descriptor that represents the asynchronous
+     * operation and poll it for read. Once the file descriptor becomes readable, the user calls `ptls_handshake` once again.
      */
     unsigned async : 1;
 } ptls_openssl_sign_certificate_t;

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -715,7 +715,7 @@ static void async_sign_ctx_free(ptls_async_job_t *_self)
      * it is the responsibility of the user to refrain from calling `ptls_free` until the asynchronous operation is complete. */
     if (self->job != NULL) {
         int ret;
-        while (ASYNC_start_job(&async->job, async->waitctx, &ret, NULL, NULL, 0) == ASYNC_PAUSE)
+        while (ASYNC_start_job(&self->job, self->waitctx, &ret, NULL, NULL, 0) == ASYNC_PAUSE)
             ;
     }
 

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -710,13 +710,10 @@ static void async_sign_ctx_free(ptls_async_sign_certificate_t *_self)
 {
     struct async_sign_ctx *self = (void *)_self;
 
+    assert(self->job == NULL);
+
     if (self->ctx != NULL)
         EVP_MD_CTX_destroy(self->ctx);
-    if (self->job != NULL) {
-        int _ret;
-        // resume the job to free resources
-        ASYNC_start_job(&self->job, self->waitctx, &_ret, NULL, NULL, 0);
-    }
     if (self->waitctx != NULL)
         ASYNC_WAIT_CTX_free(self->waitctx);
     free(self);

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -4472,7 +4472,7 @@ void ptls_free(ptls_t *tls)
     free(tls->negotiated_protocol);
     if (tls->is_server) {
         if (tls->server.async_sign_certificate != NULL)
-            tls->server.async_sign_certificate->cancel_(tls->server.async_sign_certificate);
+            tls->server.async_sign_certificate->destroy_(tls->server.async_sign_certificate);
     } else {
         if (tls->client.key_share_ctx != NULL)
             tls->client.key_share_ctx->on_exchange(&tls->client.key_share_ctx, 1, NULL, ptls_iovec_init(NULL, 0));

--- a/t/picotls.c
+++ b/t/picotls.c
@@ -931,7 +931,7 @@ static int async_sign_certificate(ptls_sign_certificate_t *self, ptls_t *tls, pt
             int ret = sign_certificate(self, tls, NULL, selected_algorithm, &fakebuf, input, algorithms, num_algorithms);
             assert(ret == 0);
             ptls_buffer_dispose(&fakebuf);
-            async_ctx.super.cancel_ = (void (*)(ptls_async_sign_certificate_t *))0xdeadbeef;
+            async_ctx.super.destroy_ = (void (*)(ptls_async_sign_certificate_t *))0xdeadbeef;
             async_ctx.selected_algorithm = *selected_algorithm;
             *async = &async_ctx.super;
             --server_sc_callcnt;


### PR DESCRIPTION
One way of fixing the cancellation bug is to remove support for cancellation.

When using asynchronous signing, users are "required" to retain `ptls_t` until the async operation is complete.

Alternative to #423.