### PR TITLE
move `tls12_cipher_suites` to the end to improve source compatibility

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -719,10 +719,6 @@ struct st_ptls_context_t {
      */
     ptls_cipher_suite_t **cipher_suites;
     /**
-     * list of supported tls12 cipher-suites terminated by NULL
-     */
-    ptls_cipher_suite_t **tls12_cipher_suites;
-    /**
      * list of certificates
      */
     struct {
@@ -837,6 +833,10 @@ struct st_ptls_context_t {
      *
      */
     ptls_on_extension_t *on_extension;
+    /**
+     * (optional) list of supported tls12 cipher-suites terminated by NULL
+     */
+    ptls_cipher_suite_t **tls12_cipher_suites;
 };
 
 typedef struct st_ptls_raw_extension_t {

--- a/t/cli.c
+++ b/t/cli.c
@@ -425,7 +425,7 @@ int main(int argc, char **argv)
 
     ptls_key_exchange_algorithm_t *key_exchanges[128] = {NULL};
     ptls_cipher_suite_t *cipher_suites[128] = {NULL};
-    ptls_context_t ctx = {ptls_openssl_random_bytes, &ptls_get_time, key_exchanges, cipher_suites, NULL};
+    ptls_context_t ctx = {ptls_openssl_random_bytes, &ptls_get_time, key_exchanges, cipher_suites};
     ptls_handshake_properties_t hsprop = {{{{NULL}}}};
     const char *host, *port, *input_file = NULL, *esni_file = NULL;
     struct {

--- a/t/minicrypto.c
+++ b/t/minicrypto.c
@@ -64,7 +64,7 @@ static void test_secp256r1_sign(void)
 static void test_hrr(void)
 {
     ptls_key_exchange_algorithm_t *client_keyex[] = {&ptls_minicrypto_x25519, &ptls_minicrypto_secp256r1, NULL};
-    ptls_context_t client_ctx = {ptls_minicrypto_random_bytes, &ptls_get_time, client_keyex, ptls_minicrypto_cipher_suites, NULL};
+    ptls_context_t client_ctx = {ptls_minicrypto_random_bytes, &ptls_get_time, client_keyex, ptls_minicrypto_cipher_suites};
     ptls_t *client, *server;
     ptls_buffer_t cbuf, sbuf, decbuf;
     uint8_t cbuf_small[16384], sbuf_small[16384], decbuf_small[16384];
@@ -154,7 +154,6 @@ int main(int argc, char **argv)
                              &ptls_get_time,
                              ptls_minicrypto_key_exchanges,
                              ptls_minicrypto_cipher_suites,
-                             NULL,
                              {&cert, 1},
                              NULL,
                              NULL,

--- a/t/openssl.c
+++ b/t/openssl.c
@@ -311,7 +311,6 @@ int main(int argc, char **argv)
     ENGINE_register_all_digests();
 #endif
 
-
     subtest("bf", test_bf);
 
     subtest("key-exchange", test_key_exchanges);
@@ -323,16 +322,13 @@ int main(int argc, char **argv)
     X509_STORE_set_verify_cb(cert_store, verify_cert_cb);
     ptls_openssl_init_verify_certificate(&openssl_verify_certificate, cert_store);
     /* we should call X509_STORE_free on OpenSSL 1.1 or in prior versions decrement refount then call _free */
-    ptls_context_t openssl_ctx = {ptls_openssl_random_bytes,
-                                  &ptls_get_time,
-                                  ptls_openssl_key_exchanges,
-                                  ptls_openssl_cipher_suites,
-                                  ptls_openssl_tls12_cipher_suites,
-                                  {&cert, 1},
-                                  NULL,
-                                  NULL,
-                                  NULL,
-                                  &openssl_sign_certificate.super};
+    ptls_context_t openssl_ctx = {.random_bytes = ptls_openssl_random_bytes,
+                                  .get_time = &ptls_get_time,
+                                  .key_exchanges = ptls_openssl_key_exchanges,
+                                  .cipher_suites = ptls_openssl_cipher_suites,
+                                  .tls12_cipher_suites = ptls_openssl_tls12_cipher_suites,
+                                  .certificates = {&cert, 1},
+                                  .sign_certificate = &openssl_sign_certificate.super};
     assert(openssl_ctx.cipher_suites[0]->hash->digest_size == 48); /* sha384 */
     ptls_context_t openssl_ctx_sha256only = openssl_ctx;
     ++openssl_ctx_sha256only.cipher_suites;
@@ -373,7 +369,6 @@ int main(int argc, char **argv)
                                      &ptls_get_time,
                                      ptls_minicrypto_key_exchanges,
                                      ptls_minicrypto_cipher_suites,
-                                     NULL,
                                      {&minicrypto_certificate, 1},
                                      NULL,
                                      NULL,


### PR DESCRIPTION
… with existing code that uses positional initialization of a struct.

Amends #426.