### PR TITLE
go back to the old way hard-coding the HKDF label prefix

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -822,8 +822,7 @@ struct st_ptls_context_t {
      */
     size_t max_buffer_size;
     /**
-     * the field is obsolete; should be set to NULL for QUIC draft-17.  Note also that even though everybody did, it was incorrect
-     * to set the value to "quic " in the earlier versions of the draft.
+     * this field is obsolete and ignored
      */
     const char *hkdf_label_prefix__obsolete;
     /**


### PR DESCRIPTION
At one point during the development of QUIC v1, we thought that separation within the TLS handshake protocol was necessary (#158). But we decided to not do that, and the field was marked obsolete (#192).

Now that QUIC v1 has shipped, let's revert the unnecessary complexity altogether (modulo keeping the field in the context for source compatibility).