### PR TITLE
`ptls_decode8` for consistency

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -1163,6 +1163,7 @@ static uint8_t *ptls_encode_quicint(uint8_t *p, uint64_t v);
             goto Exit;                                                                                                             \
     } while (0)
 
+int ptls_decode8(uint8_t *value, const uint8_t **src, const uint8_t *end);
 int ptls_decode16(uint16_t *value, const uint8_t **src, const uint8_t *end);
 int ptls_decode24(uint32_t *value, const uint8_t **src, const uint8_t *end);
 int ptls_decode32(uint32_t *value, const uint8_t **src, const uint8_t *end);

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -3124,12 +3124,10 @@ static int client_hello_decode_server_name(ptls_iovec_t *name, const uint8_t **s
     int ret = 0;
 
     ptls_decode_open_block(*src, end, 2, {
-        if (*src == end) {
-            ret = PTLS_ALERT_DECODE_ERROR;
-            goto Exit;
-        }
         do {
-            uint8_t type = *(*src)++;
+            uint8_t type;
+            if ((ret = ptls_decode8(&type, src, end)) != 0)
+                goto Exit;
             ptls_decode_open_block(*src, end, 2, {
                 switch (type) {
                 case PTLS_SERVER_NAME_TYPE_HOSTNAME:


### PR DESCRIPTION
When attempting to read one byte, there are cases where we have to raise either DECODE_ERROR (indicating a syntax error) or another error (e.g., ILLEGAL_PARAMETER indicating logical error).

It is better to have a wrapper function like `ptls_decode16`.