### PR TITLE
provide API to obtain ECH config_id being used

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -1472,7 +1472,7 @@ int ptls_is_psk_handshake(ptls_t *tls);
 /**
  * return if a ECH handshake was performed, as well as optionally the kem and cipher-suite being used
  */
-int ptls_is_ech_handshake(ptls_t *tls, ptls_hpke_kem_t **kem, ptls_hpke_cipher_suite_t **cipher);
+int ptls_is_ech_handshake(ptls_t *tls, uint8_t *config_id, ptls_hpke_kem_t **kem, ptls_hpke_cipher_suite_t **cipher);
 /**
  * returns a pointer to user data pointer (client is reponsible for freeing the associated data prior to calling ptls_free)
  */

--- a/t/picotls.c
+++ b/t/picotls.c
@@ -1002,11 +1002,11 @@ static void test_handshake(ptls_iovec_t ticket, int mode, int expect_ticket, int
     }
 
     if (can_ech(ctx_peer, 1) && can_ech(ctx, 0)) {
-        ok(ptls_is_ech_handshake(client, NULL, NULL));
-        ok(ptls_is_ech_handshake(server, NULL, NULL));
+        ok(ptls_is_ech_handshake(client, NULL, NULL, NULL));
+        ok(ptls_is_ech_handshake(server, NULL, NULL, NULL));
     } else {
-        ok(!ptls_is_ech_handshake(client, NULL, NULL));
-        ok(!ptls_is_ech_handshake(server, NULL, NULL));
+        ok(!ptls_is_ech_handshake(client, NULL, NULL, NULL));
+        ok(!ptls_is_ech_handshake(server, NULL, NULL, NULL));
     }
 
     ptls_buffer_dispose(&cbuf);


### PR DESCRIPTION
Would be useful for observing expiry of HTTPS / SVC RRs.