### PR TITLE
alternative signers: support callback-based method, add utility functions

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -658,6 +658,10 @@ typedef struct st_ptls_async_job_t {
      * optional callback returning a file descriptor that becomes readable when the job is complete
      */
     int (*get_fd)(struct st_ptls_async_job_t *self);
+    /**
+     * optional callback for setting a completion callback
+     */
+    void (*set_completion_callback)(struct st_ptls_async_job_t *self, void (*cb)(void *), void *cbdata);
 } ptls_async_job_t;
 /**
  * When gerenating CertificateVerify, the core calls the callback to sign the handshake context using the certificate. This callback

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -654,6 +654,10 @@ PTLS_CALLBACK_TYPE(int, emit_certificate, ptls_t *tls, ptls_message_emitter_t *e
  */
 typedef struct st_ptls_async_job_t {
     void (*destroy_)(struct st_ptls_async_job_t *self);
+    /**
+     * optional callback returning a file descriptor that becomes readable when the job is complete
+     */
+    int (*get_fd)(struct st_ptls_async_job_t *self);
 } ptls_async_job_t;
 /**
  * When gerenating CertificateVerify, the core calls the callback to sign the handshake context using the certificate. This callback

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -650,7 +650,12 @@ PTLS_CALLBACK_TYPE(int, on_client_hello, ptls_t *tls, ptls_on_client_hello_param
 PTLS_CALLBACK_TYPE(int, emit_certificate, ptls_t *tls, ptls_message_emitter_t *emitter, ptls_key_schedule_t *key_sched,
                    ptls_iovec_t context, int push_status_request, const uint16_t *compress_algos, size_t num_compress_algos);
 /**
- * context object of an async operation (e.g., RSA signature generation)
+ * Context object of an async operation (e.g., RSA signature generation).
+ * When `ptls_handshake` returns `PTLS_ERROR_ASYNC_OPERATION`, it has an associated asynchronous task in flight which is
+ * represented by ``ptls_async_job_t`. The user should obtain the reference to the associated task by calling `ptls_get_async_job`,
+ * then either wait for the file descriptor obtained from `get_fd` to become readable, or set a completion callback and wait for its
+ * invocation. Once notified, the user should invoke `ptls_handshake` again.
+ * Async jobs typically provide support for only one of the two methods.
  */
 typedef struct st_ptls_async_job_t {
     void (*destroy_)(struct st_ptls_async_job_t *self);

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -650,10 +650,10 @@ PTLS_CALLBACK_TYPE(int, on_client_hello, ptls_t *tls, ptls_on_client_hello_param
 PTLS_CALLBACK_TYPE(int, emit_certificate, ptls_t *tls, ptls_message_emitter_t *emitter, ptls_key_schedule_t *key_sched,
                    ptls_iovec_t context, int push_status_request, const uint16_t *compress_algos, size_t num_compress_algos);
 /**
- * Context object of an async operation (e.g., RSA signature generation).
- * When `ptls_handshake` returns `PTLS_ERROR_ASYNC_OPERATION`, it has an associated asynchronous task in flight which is
- * represented by ``ptls_async_job_t`. The user should obtain the reference to the associated task by calling `ptls_get_async_job`,
- * then either wait for the file descriptor obtained from `get_fd` to become readable, or set a completion callback and wait for its
+ * An object that represents an asynchronous task (e.g., RSA signature generation).
+ * When `ptls_handshake` returns `PTLS_ERROR_ASYNC_OPERATION`, it has an associated task in flight. The user should obtain the
+ * reference to the associated task by calling `ptls_get_async_job`, then either wait for the file descriptor obtained from
+ * the `get_fd` callback to become readable, or set a completion callback via `set_completion_callback` and wait for its
  * invocation. Once notified, the user should invoke `ptls_handshake` again.
  * Async jobs typically provide support for only one of the two methods.
  */

--- a/include/picotls/openssl.h
+++ b/include/picotls/openssl.h
@@ -132,15 +132,20 @@ int ptls_openssl_create_key_exchange(ptls_key_exchange_context_t **ctx, EVP_PKEY
 OSSL_ASYNC_FD ptls_openssl_get_async_fd(ptls_t *ptls);
 #endif
 
-struct st_ptls_openssl_signature_scheme_t {
+typedef struct st_ptls_openssl_signature_scheme_t {
     uint16_t scheme_id;
     const EVP_MD *(*scheme_md)(void);
-};
+} ptls_openssl_signature_scheme_t;
+
+/**
+ * Given a private key, returns a list of compatible signature schemes. This list is terminated by scheme_id of UINT16_MAX.
+ */
+const ptls_openssl_signature_scheme_t *ptls_openssl_lookup_signature_schemes(EVP_PKEY *key);
 
 typedef struct st_ptls_openssl_sign_certificate_t {
     ptls_sign_certificate_t super;
     EVP_PKEY *key;
-    const struct st_ptls_openssl_signature_scheme_t *schemes; /* terminated by .scheme_id == UINT16_MAX */
+    const ptls_openssl_signature_scheme_t *schemes; /* terminated by .scheme_id == UINT16_MAX */
     /**
      * When set to true, indicates to the backend that the signature can be generated asynchronously. When the backend decides to
      * generate the signature asynchronously, `ptls_handshake` will return PTLS_ERROR_ASYNC_OPERATION. When receiving that error

--- a/include/picotls/openssl.h
+++ b/include/picotls/openssl.h
@@ -125,13 +125,6 @@ void ptls_openssl_random_bytes(void *buf, size_t len);
  */
 int ptls_openssl_create_key_exchange(ptls_key_exchange_context_t **ctx, EVP_PKEY *pkey);
 
-#if PTLS_OPENSSL_HAVE_ASYNC
-/**
- * Returns the file descriptor of the asynchronous operation in flight.
- */
-OSSL_ASYNC_FD ptls_openssl_get_async_fd(ptls_t *ptls);
-#endif
-
 typedef struct st_ptls_openssl_signature_scheme_t {
     uint16_t scheme_id;
     const EVP_MD *(*scheme_md)(void);

--- a/include/picotls/openssl.h
+++ b/include/picotls/openssl.h
@@ -141,6 +141,11 @@ typedef struct st_ptls_openssl_signature_scheme_t {
  * Given a private key, returns a list of compatible signature schemes. This list is terminated by scheme_id of UINT16_MAX.
  */
 const ptls_openssl_signature_scheme_t *ptls_openssl_lookup_signature_schemes(EVP_PKEY *key);
+/**
+ * Given available schemes and input, choses one, or returns NULL if none is available.
+ */
+const ptls_openssl_signature_scheme_t *ptls_openssl_select_signature_scheme(const ptls_openssl_signature_scheme_t *available,
+                                                                            const uint16_t *algorithms, size_t num_algorithms);
 
 typedef struct st_ptls_openssl_sign_certificate_t {
     ptls_sign_certificate_t super;

--- a/t/openssl.c
+++ b/t/openssl.c
@@ -143,7 +143,7 @@ static void test_key_exchanges(void)
 #endif
 }
 
-static void test_sign_verify(EVP_PKEY *key, const struct st_ptls_openssl_signature_scheme_t *schemes)
+static void test_sign_verify(EVP_PKEY *key, const ptls_openssl_signature_scheme_t *schemes)
 {
     for (size_t i = 0; schemes[i].scheme_id != UINT16_MAX; ++i) {
         note("scheme 0x%04x", schemes[i].scheme_id);
@@ -198,7 +198,7 @@ static void test_rsa_sign(void)
     test_sign_verify(sc->key, sc->schemes);
 }
 
-static void do_test_ecdsa_sign(int nid, const struct st_ptls_openssl_signature_scheme_t *schemes)
+static void do_test_ecdsa_sign(int nid, const ptls_openssl_signature_scheme_t *schemes)
 {
     EVP_PKEY *pkey;
 

--- a/t/openssl.c
+++ b/t/openssl.c
@@ -464,10 +464,12 @@ static void many_handshakes(void)
                 if (num_issued < num_total)
                     qat_set_pending(offending);
                 break;
-            case PTLS_ERROR_ASYNC_OPERATION:
-                qat.conns[offending].wait_fd = ptls_openssl_get_async_fd(qat.conns[offending].tls);
+            case PTLS_ERROR_ASYNC_OPERATION: {
+                ptls_async_job_t *job = ptls_get_async_job(qat.conns[offending].tls);
+                assert(job->get_fd != NULL);
+                qat.conns[offending].wait_fd = job->get_fd(job);
                 assert(qat.conns[offending].wait_fd != -1);
-                break;
+            } break;
             default:
                 fprintf(stderr, "ptls_handshake returned %d\n", hsret);
                 abort();


### PR DESCRIPTION
Exposes utility functions, generalizes the concept of fd-based notification, adds callback-based notification.