### PR TITLE
Add missing log_event when application uses its own record layer

### DIFF
--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -1636,6 +1636,8 @@ static int setup_traffic_protection(ptls_t *tls, int is_enc, const char *secret_
 
     /* special path for applications having their own record layer */
     if (tls->ctx->update_traffic_key != NULL) {
+        log_secret(tls, log_labels[ptls_is_server(tls) == is_enc][epoch],
+                   ptls_iovec_init(ctx->secret, tls->key_schedule->hashes[0].algo->digest_size));
         if (skip_notify)
             return 0;
         return tls->ctx->update_traffic_key->cb(tls->ctx->update_traffic_key, tls, is_enc, epoch, ctx->secret);

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -1634,10 +1634,11 @@ static int setup_traffic_protection(ptls_t *tls, int is_enc, const char *secret_
 
     ctx->epoch = epoch;
 
+    log_secret(tls, log_labels[ptls_is_server(tls) == is_enc][epoch],
+               ptls_iovec_init(ctx->secret, tls->key_schedule->hashes[0].algo->digest_size));
+
     /* special path for applications having their own record layer */
     if (tls->ctx->update_traffic_key != NULL) {
-        log_secret(tls, log_labels[ptls_is_server(tls) == is_enc][epoch],
-                   ptls_iovec_init(ctx->secret, tls->key_schedule->hashes[0].algo->digest_size));
         if (skip_notify)
             return 0;
         return tls->ctx->update_traffic_key->cb(tls->ctx->update_traffic_key, tls, is_enc, epoch, ctx->secret);
@@ -1650,8 +1651,6 @@ static int setup_traffic_protection(ptls_t *tls, int is_enc, const char *secret_
         return PTLS_ERROR_NO_MEMORY; /* TODO obtain error from ptls_aead_new */
     ctx->seq = 0;
 
-    log_secret(tls, log_labels[ptls_is_server(tls) == is_enc][epoch],
-               ptls_iovec_init(ctx->secret, tls->key_schedule->hashes[0].algo->digest_size));
     PTLS_DEBUGF("[%s] %02x%02x,%02x%02x\n", log_labels[ptls_is_server(tls)][epoch], (unsigned)ctx->secret[0],
                 (unsigned)ctx->secret[1], (unsigned)ctx->aead->static_iv[0], (unsigned)ctx->aead->static_iv[1]);
 


### PR DESCRIPTION
This commit adds missing log_event callback invocation when an application uses its own record layer.  While such application may use update_traffic_key callback to log secrets, it still be useful to share log_event callback with a regular TLS application.