### PR TITLE
expose raw cipher-suite list from on_client_hello callback

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -626,6 +626,10 @@ typedef struct st_ptls_on_client_hello_parameters_t {
         size_t count;
     } server_certificate_types;
     /**
+     * points to the cipher-suites section of the raw_message (see above)
+     */
+    ptls_iovec_t raw_client_ciphers;
+    /**
      * set to 1 if ClientHello is too old (or too new) to be handled by picotls
      */
     unsigned incompatible_version : 1;

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -622,10 +622,6 @@ typedef struct st_ptls_on_client_hello_parameters_t {
         size_t count;
     } certificate_compression_algorithms;
     struct {
-        const uint16_t *list;
-        size_t count;
-    } cipher_suites;
-    struct {
         const uint8_t *list;
         size_t count;
     } server_certificate_types;

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -607,6 +607,10 @@ typedef struct st_ptls_on_client_hello_parameters_t {
      */
     ptls_iovec_t raw_message;
     /**
+     * points to the cipher-suites section of the raw_message (see above)
+     */
+    ptls_iovec_t cipher_suites;
+    /**
      *
      */
     struct {
@@ -625,10 +629,6 @@ typedef struct st_ptls_on_client_hello_parameters_t {
         const uint8_t *list;
         size_t count;
     } server_certificate_types;
-    /**
-     * points to the cipher-suites section of the raw_message (see above)
-     */
-    ptls_iovec_t raw_client_ciphers;
     /**
      * set to 1 if ClientHello is too old (or too new) to be handled by picotls
      */

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -3541,6 +3541,10 @@ static int decode_client_hello(ptls_context_t *ctx, struct st_ptls_client_hello_
 
     /* decode and select from ciphersuites */
     ptls_decode_open_block(src, end, 2, {
+        if ((end - src) % 2 != 0) {
+            ret = PTLS_ALERT_DECODE_ERROR;
+            goto Exit;
+        }
         ch->cipher_suites = ptls_iovec_init(src, end - src);
         src = end;
     });


### PR DESCRIPTION
Instead of exposing a parsed list of cipher-suites (that might have been cut down at the end), expose the raw vector.

Reverts #227, closes #462.

If necessary, we can do the same for other properties (e.g., `server_certificate_types`), or if we want to go to the extreme, for all types include those that have complicated structures (e.g., `alpn`, `signature_algorithms`).