### PR TITLE
[openssl backend] remove unnecessary check

### DIFF
--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -1095,10 +1095,6 @@ static int aead_setup_crypto(ptls_aead_context_t *_ctx, int is_enc, const void *
     struct aead_crypto_context_t *ctx = (struct aead_crypto_context_t *)_ctx;
     int ret;
 
-    memcpy(ctx->static_iv, iv, ctx->super.algo->iv_size);
-    if (key == NULL)
-        return 0;
-
     ctx->super.dispose_crypto = aead_dispose_crypto;
     ctx->super.do_xor_iv = aead_xor_iv;
     if (is_enc) {
@@ -1137,6 +1133,8 @@ static int aead_setup_crypto(ptls_aead_context_t *_ctx, int is_enc, const void *
         ret = PTLS_ERROR_LIBRARY;
         goto Error;
     }
+
+    memcpy(ctx->static_iv, iv, ctx->super.algo->iv_size);
 
     return 0;
 


### PR DESCRIPTION
It seems that since #310, openssl AEAD backend have been testing if supplied `key` is NULL and returning success if that is the case, while other backends have continued to assume `key` is non-NULL and crash if a NULL keys is supplied.

I believe this was an unintentional change is #310 and nobody is passing a NULL key (this call path can executed only once per object and passing a NULL key makes AEAD unusable), and therefore this PR removes that `if`.