### PR TITLE
Ptls mbedtls

### DIFF
--- a/.github/workflows/mbedtls.yml
+++ b/.github/workflows/mbedtls.yml
@@ -19,6 +19,7 @@ jobs:
 
       - name: Installing MbedTLS
         run: |
+             cd ..
              git clone https://github.com/Mbed-TLS/mbedtls
              cd mbedtls
              echo "cloned mbedtls"
@@ -29,7 +30,7 @@ jobs:
              make
              echo "compiled MbedTLS"
              pwd
-             cd ../..
+             cd ../../picotls
 
       - name: Compile picotls
         run: |

--- a/.github/workflows/mbedtls.yml
+++ b/.github/workflows/mbedtls.yml
@@ -22,9 +22,10 @@ jobs:
              git clone https://github.com/Mbed-TLS/mbedtls
              cd mbedtls
              echo "cloned mbedtls"
-             ls
-             cmake --build .
+             mkdir build
              cd build
+             cmake -S .. .
+             echo "cmake done"
              make
              cd ../..
 

--- a/.github/workflows/mbedtls.yml
+++ b/.github/workflows/mbedtls.yml
@@ -21,6 +21,8 @@ jobs:
         run: |
              git clone https://github.com/Mbed-TLS/mbedtls
              cd mbedtls
+             echo "cloned mbedtls"
+             ls
              cmake --build .
              cd build
              make

--- a/.github/workflows/mbedtls.yml
+++ b/.github/workflows/mbedtls.yml
@@ -27,10 +27,14 @@ jobs:
              cmake -S .. .
              echo "cmake done"
              make
+             echo "compiled MbedTLS"
+             pwd
              cd ../..
 
       - name: Compile picotls
         run: |
+             echo "building picotls with MbedTLS"
+             pwd
              cmake "-DWITH_MBEDTLS=ON" .
              make
 

--- a/.github/workflows/mbedtls.yml
+++ b/.github/workflows/mbedtls.yml
@@ -1,0 +1,36 @@
+---
+name: "MbedTLS-test"
+
+on: [push, pull_request]
+
+jobs:
+  mbedtls:
+    name: MbedTLS-test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          # We must fetch at least the immediate parents so that if this is
+          # a pull request then we can checkout the head.
+          fetch-depth: 2
+          submodules: 'recursive'
+
+      - name: Installing MbedTLS
+        run: |
+             git clone https://github.com/Mbed-TLS/mbedtls
+             cd mbedtls
+             cmake --build .
+             cd build
+             make
+             cd ../..
+
+      - name: Compile picotls
+        run: |
+             cmake "-DWITH_MBEDTLS=ON" .
+             make
+
+      - name: Run test
+        run: |
+             ./test-mbedtls.t

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ ENDIF ()
 FIND_PACKAGE(PkgConfig REQUIRED)
 INCLUDE(cmake/dtrace-utils.cmake)
 INCLUDE(cmake/boringssl-adjust.cmake)
-INCLUDE(cmake/FindMbedTLS.cmake)
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 CHECK_DTRACE(${PROJECT_SOURCE_DIR}/picotls-probes.d)
 IF ((CMAKE_SIZEOF_VOID_P EQUAL 8) AND

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ ENDIF ()
 FIND_PACKAGE(PkgConfig REQUIRED)
 INCLUDE(cmake/dtrace-utils.cmake)
 INCLUDE(cmake/boringssl-adjust.cmake)
+INCLUDE(cmake/FindMbedTLS.cmake)
 
 CHECK_DTRACE(${PROJECT_SOURCE_DIR}/picotls-probes.d)
 IF ((CMAKE_SIZEOF_VOID_P EQUAL 8) AND

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,7 +197,8 @@ IF (WITH_FUSION)
         ADD_DEPENDENCIES(test-fusion.t generate-picotls-probes)
     ENDIF ()
     SET(TEST_EXES ${TEST_EXES} test-fusion.t)
-
+    
+    SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DPTLS_HAVE_FUSION=1")
     LIST(APPEND PTLSBENCH_LIBS picotls-fusion)
 ENDIF ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,9 +203,7 @@ ENDIF ()
 
 IF (WITH_MBEDTLS)
     FIND_PACKAGE(MbedTLS)
-    IF (NOT MbedTLS_FOUND)
-        MESSAGE (FATAL_ERROR "MbedTLS not found")
-    ELSE ()
+    IF (MbedTLS_FOUND)
         message(STATUS "mbedtls/include: ${MBEDTLS_INCLUDE_DIRS}")
         message(STATUS "mbedtls libraries: ${MBEDTLS_LIBRARIES}")
         INCLUDE_DIRECTORIES(${MBEDTLS_INCLUDE_DIRS})
@@ -217,6 +215,8 @@ IF (WITH_MBEDTLS)
         TARGET_LINK_LIBRARIES(test-mbedtls.t
             picotls-minicrypto picotls-mbedtls
             ${MBEDTLS_LIBRARIES})
+    ELSE ()
+        MESSAGE (FATAL_ERROR "MbedTLS not found")
     ENDIF()
 ENDIF ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,7 +203,7 @@ ENDIF ()
 
 IF (WITH_MBEDTLS)
     FIND_PACKAGE(MbedTLS)
-    IF (NOT MbedTLS)
+    IF (NOT MbedTLS_FOUND)
         MESSAGE (FATAL_ERROR "MbedTLS not found")
     ELSE ()
         message(STATUS "mbedtls/include: ${MBEDTLS_INCLUDE_DIRS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,7 +203,7 @@ ENDIF ()
 
 IF (WITH_MBEDTLS)
     FIND_PACKAGE(MbedTLS)
-    IF (MbedTLS_FOUND)
+    # IF (MbedTLS_FOUND)
         message(STATUS "mbedtls/include: ${MBEDTLS_INCLUDE_DIRS}")
         message(STATUS "mbedtls libraries: ${MBEDTLS_LIBRARIES}")
         INCLUDE_DIRECTORIES(${MBEDTLS_INCLUDE_DIRS})
@@ -215,9 +215,9 @@ IF (WITH_MBEDTLS)
         TARGET_LINK_LIBRARIES(test-mbedtls.t
             picotls-minicrypto picotls-mbedtls
             ${MBEDTLS_LIBRARIES})
-    ELSE ()
-        MESSAGE (FATAL_ERROR "MbedTLS not found")
-    ENDIF()
+    #ELSE ()
+    #    MESSAGE (FATAL_ERROR "MbedTLS not found")
+    #ENDIF()
 ENDIF ()
 
 ADD_EXECUTABLE(ptlsbench t/ptlsbench.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,6 +215,8 @@ IF (WITH_MBEDTLS)
         TARGET_LINK_LIBRARIES(test-mbedtls.t
             picotls-minicrypto picotls-mbedtls
             ${MBEDTLS_LIBRARIES})
+        SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DPTLS_HAVE_MBEDTLS=1")
+        LIST(APPEND PTLSBENCH_LIBS picotls-mbedtls ${MBEDTLS_LIBRARIES})
     #ELSE ()
     #    MESSAGE (FATAL_ERROR "MbedTLS not found")
     #ENDIF()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ IF (WITH_FUSION)
     MESSAGE(STATUS "Enabling 'fusion' AES-GCM engine")
 ENDIF ()
 OPTION(WITH_AEGIS "enable AEGIS (requires libaegis)" ${WITH_AEGIS})
+OPTION(WITH_MBEDTLS "enable MBEDTLS" ${WITH_MBEDTLS})
 
 SET(CMAKE_C_FLAGS "-std=c99 -Wall -O2 -g ${CC_WARNING_FLAGS} ${CMAKE_C_FLAGS}")
 INCLUDE_DIRECTORIES(
@@ -197,6 +198,25 @@ IF (WITH_FUSION)
     SET(TEST_EXES ${TEST_EXES} test-fusion.t)
 
     LIST(APPEND PTLSBENCH_LIBS picotls-fusion)
+ENDIF ()
+
+IF (WITH_MBEDTLS)
+    FIND_PACKAGE(MbedTLS)
+    IF (NOT MbedTLS)
+        MESSAGE (FATAL_ERROR "MbedTLS not found")
+    ELSE ()
+        message(STATUS "mbedtls/include: ${MBEDTLS_INCLUDE_DIRS}")
+        message(STATUS "mbedtls libraries: ${MBEDTLS_LIBRARIES}")
+        INCLUDE_DIRECTORIES(${MBEDTLS_INCLUDE_DIRS})
+        ADD_LIBRARY(picotls-mbedtls lib/ptls_mbedtls.c)
+        ADD_EXECUTABLE(test-mbedtls.t
+        deps/picotest/picotest.c
+        lib/picotls.c
+        t/ptls_mbedtls.c)
+        TARGET_LINK_LIBRARIES(test-mbedtls.t
+            picotls-minicrypto picotls-mbedtls
+            ${MBEDTLS_LIBRARIES})
+    ENDIF()
 ENDIF ()
 
 ADD_EXECUTABLE(ptlsbench t/ptlsbench.c)

--- a/cmake/FindMbedTLS.cmake
+++ b/cmake/FindMbedTLS.cmake
@@ -1,0 +1,15 @@
+# - Try to find MbedTLS
+# set(MBEDTLS_LIBRARY mbedtls)
+# set(MBEDTLS_INCLUDE_DIRS ${MBEDTLS_SOURCE_DIR}/include)
+find_path(MBEDTLS_INCLUDE_DIRS
+    NAMES mbedtls/build_info.h psa/crypto.h
+    HINTS ${MBEDTLS_PREFIX}/include/
+        ${CMAKE_SOURCE_DIR}/../mbedtls/include/
+        ${CMAKE_BINARY_DIR}/../mbedtls/include/
+        ../mbedtls/include/ )
+
+set(MBEDTLS_HINTS ${MBEDTLS_PREFIX}/build ${CMAKE_BINARY_DIR}/../mbedtls/build ../mbedtls/build)
+
+find_library(MBEDTLS_LIBRARY mbedtls HINTS ${MBEDTLS_HINTS})
+
+mark_as_advanced(MBEDTLS_LIBRARY MBEDTLS_INCLUDE_DIRS)

--- a/cmake/FindMbedTLS.cmake
+++ b/cmake/FindMbedTLS.cmake
@@ -8,14 +8,24 @@ find_path(MBEDTLS_INCLUDE_DIRS
         ${CMAKE_BINARY_DIR}/../mbedtls/include/
         ../mbedtls/include/ )
 
-set(MBEDTLS_HINTS ${MBEDTLS_PREFIX}/build ${CMAKE_BINARY_DIR}/../mbedtls/build ../mbedtls/build)
+
+
+set(MBEDTLS_HINTS ${MBEDTLS_PREFIX}/build/library 
+    ${CMAKE_BINARY_DIR}/../mbedtls/build/library
+    ../mbedtls/build/library ../mbedtls/library)
 
 find_library(MBEDTLS_LIBRARY mbedtls HINTS ${MBEDTLS_HINTS})
+find_library(MBEDTLS_CRYPTO mbedcrypto HINTS ${MBEDTLS_HINTS})
+find_library(MBEDTLS_X509 mbedx509 HINTS ${MBEDTLS_HINTS})
 include(FindPackageHandleStandardArgs)
 # handle the QUIETLY and REQUIRED arguments and set PTLS_FOUND to TRUE
 # if all listed variables are TRUE
 find_package_handle_standard_args(MbedTLS REQUIRED_VARS
     MBEDTLS_LIBRARY
+    MBEDTLS_CRYPTO
+    MBEDTLS_X509
     MBEDTLS_INCLUDE_DIRS)
-
-mark_as_advanced(MBEDTLS_LIBRARY MBEDTLS_INCLUDE_DIRS)
+    
+if(MbedTLS_FOUND)
+    set(MBEDTLS_LIBRARIES ${MBEDTLS_LIBRARY} ${MBEDTLS_CRYPTO} ${MBEDTLS_X509})
+    mark_as_advanced(MBEDTLS_LIBRARIES MBEDTLS_INCLUDE_DIRS)

--- a/cmake/FindMbedTLS.cmake
+++ b/cmake/FindMbedTLS.cmake
@@ -11,5 +11,11 @@ find_path(MBEDTLS_INCLUDE_DIRS
 set(MBEDTLS_HINTS ${MBEDTLS_PREFIX}/build ${CMAKE_BINARY_DIR}/../mbedtls/build ../mbedtls/build)
 
 find_library(MBEDTLS_LIBRARY mbedtls HINTS ${MBEDTLS_HINTS})
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set PTLS_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(MbedTLS REQUIRED_VARS
+    MBEDTLS_LIBRARY
+    MBEDTLS_INCLUDE_DIRS)
 
 mark_as_advanced(MBEDTLS_LIBRARY MBEDTLS_INCLUDE_DIRS)

--- a/cmake/FindMbedTLS.cmake
+++ b/cmake/FindMbedTLS.cmake
@@ -26,6 +26,7 @@ find_package_handle_standard_args(MbedTLS REQUIRED_VARS
     MBEDTLS_X509
     MBEDTLS_INCLUDE_DIRS)
     
-if(MbedTLS_FOUND)
+if (MbedTLS_FOUND)
     set(MBEDTLS_LIBRARIES ${MBEDTLS_LIBRARY} ${MBEDTLS_CRYPTO} ${MBEDTLS_X509})
     mark_as_advanced(MBEDTLS_LIBRARIES MBEDTLS_INCLUDE_DIRS)
+endif ()

--- a/include/picotls/ptls_mbedtls.h
+++ b/include/picotls/ptls_mbedtls.h
@@ -27,30 +27,25 @@ extern "C" {
 #endif
 #include "picotls.h"
 
-extern ptls_hash_algorithm_t ptls_mbedtls_sha256;
-extern ptls_hash_algorithm_t ptls_mbedtls_sha512;
+    extern ptls_hash_algorithm_t ptls_mbedtls_sha256;
+    extern ptls_hash_algorithm_t ptls_mbedtls_sha512;
 #if defined(MBEDTLS_SHA384_C)
-extern ptls_hash_algorithm_t ptls_mbedtls_sha384;
+    extern ptls_hash_algorithm_t ptls_mbedtls_sha384;
 #endif
 
-extern ptls_cipher_algorithm_t ptls_mbedtls_aes128ecb;
-extern ptls_cipher_algorithm_t ptls_mbedtls_aes256ecb;
-extern ptls_cipher_algorithm_t ptls_mbedtls_aes128ctr;
-extern ptls_cipher_algorithm_t ptls_mbedtls_aes256ctr;
-extern ptls_cipher_algorithm_t ptls_mbedtls_chacha20;
+    extern ptls_cipher_algorithm_t ptls_mbedtls_aes128ecb;
+    extern ptls_cipher_algorithm_t ptls_mbedtls_aes256ecb;
+    extern ptls_cipher_algorithm_t ptls_mbedtls_aes128ctr;
+    extern ptls_cipher_algorithm_t ptls_mbedtls_aes256ctr;
+    extern ptls_cipher_algorithm_t ptls_mbedtls_chacha20;
 
-extern ptls_aead_algorithm_t ptls_mbedtls_aes128gcm;
-extern ptls_aead_algorithm_t ptls_mbedtls_aes256gcm;
-extern ptls_aead_algorithm_t ptls_mbedtls_chacha20poly1305;
+    extern ptls_aead_algorithm_t ptls_mbedtls_aes128gcm;
+    extern ptls_aead_algorithm_t ptls_mbedtls_aes256gcm;
+    extern ptls_aead_algorithm_t ptls_mbedtls_chacha20poly1305;
 
-
-extern ptls_cipher_suite_t ptls_mbedtls_aes128gcmsha256;
-#if defined(MBEDTLS_SHA384_C)
-extern ptls_cipher_suite_t ptls_mbedtls_aes256gcmsha384;
-#endif
-extern ptls_cipher_suite_t ptls_mbedtls_chacha20poly1305sha256;
-
-void ptls_mbedtls_random_bytes(void* buf, size_t len);
+    int ptls_mbedtls_init();
+    void ptls_mbedtls_free();
+    void ptls_mbedtls_random_bytes(void* buf, size_t len);
 
 #ifdef __cplusplus
 }

--- a/include/picotls/ptls_mbedtls.h
+++ b/include/picotls/ptls_mbedtls.h
@@ -43,6 +43,13 @@ extern ptls_aead_algorithm_t ptls_mbedtls_aes128gcm;
 extern ptls_aead_algorithm_t ptls_mbedtls_aes256gcm;
 extern ptls_aead_algorithm_t ptls_mbedtls_chacha20poly1305;
 
+
+extern ptls_cipher_suite_t ptls_mbedtls_aes128gcmsha256;
+#if defined(MBEDTLS_SHA384_C)
+extern ptls_cipher_suite_t ptls_mbedtls_aes256gcmsha384;
+#endif
+extern ptls_cipher_suite_t ptls_mbedtls_chacha20poly1305sha256;
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/picotls/ptls_mbedtls.h
+++ b/include/picotls/ptls_mbedtls.h
@@ -43,7 +43,12 @@ extern "C" {
     extern ptls_aead_algorithm_t ptls_mbedtls_aes256gcm;
     extern ptls_aead_algorithm_t ptls_mbedtls_chacha20poly1305;
 
+    extern ptls_cipher_suite_t ptls_mbedtls_aes128gcmsha256;
+    extern ptls_cipher_suite_t ptls_mbedtls_aes256gcmsha384;
+    extern ptls_cipher_suite_t ptls_mbedtls_chacha20poly1305sha256;
+
     extern ptls_key_exchange_algorithm_t ptls_mbedtls_secp256r1;
+    extern ptls_key_exchange_algorithm_t ptls_mbedtls_x25519;
 
     int ptls_mbedtls_init();
     void ptls_mbedtls_free();

--- a/include/picotls/ptls_mbedtls.h
+++ b/include/picotls/ptls_mbedtls.h
@@ -28,6 +28,10 @@ extern "C" {
 #include "picotls.h"
 
 extern ptls_hash_algorithm_t ptls_mbedtls_sha256;
+extern ptls_hash_algorithm_t ptls_mbedtls_sha512;
+#if defined(MBEDTLS_SHA384_C)
+extern ptls_hash_algorithm_t ptls_mbedtls_sha384;
+#endif
 
 extern ptls_cipher_algorithm_t ptls_mbedtls_aes128ecb;
 extern ptls_cipher_algorithm_t ptls_mbedtls_aes256ecb;

--- a/include/picotls/ptls_mbedtls.h
+++ b/include/picotls/ptls_mbedtls.h
@@ -50,6 +50,8 @@ extern ptls_cipher_suite_t ptls_mbedtls_aes256gcmsha384;
 #endif
 extern ptls_cipher_suite_t ptls_mbedtls_chacha20poly1305sha256;
 
+void ptls_mbedtls_random_bytes(void* buf, size_t len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/picotls/ptls_mbedtls.h
+++ b/include/picotls/ptls_mbedtls.h
@@ -1,0 +1,42 @@
+/*
+* Copyright (c) 2023, Christian Huitema
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to
+* deal in the Software without restriction, including without limitation the
+* rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+* sell copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+* IN THE SOFTWARE.
+*/
+#ifndef picotls_mbedtls_h
+#define picotls_mbedtls_h
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "picotls.h"
+
+extern ptls_hash_algorithm_t ptls_mbedtls_sha256;
+
+extern ptls_cipher_algorithm_t ptls_mbedtls_aes128ecb;
+extern ptls_cipher_algorithm_t ptls_mbedtls_aes256ecb;
+extern ptls_cipher_algorithm_t ptls_mbedtls_aes128ctr;
+extern ptls_cipher_algorithm_t ptls_mbedtls_aes256ctr;
+
+extern ptls_aead_algorithm_t ptls_mbedtls_aes128gcm;
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* picotls_mbedtls_h */

--- a/include/picotls/ptls_mbedtls.h
+++ b/include/picotls/ptls_mbedtls.h
@@ -39,6 +39,7 @@ extern ptls_cipher_algorithm_t ptls_mbedtls_aes128ctr;
 extern ptls_cipher_algorithm_t ptls_mbedtls_aes256ctr;
 
 extern ptls_aead_algorithm_t ptls_mbedtls_aes128gcm;
+extern ptls_aead_algorithm_t ptls_mbedtls_aes256gcm;
 
 #ifdef __cplusplus
 }

--- a/include/picotls/ptls_mbedtls.h
+++ b/include/picotls/ptls_mbedtls.h
@@ -37,7 +37,7 @@ extern ptls_cipher_algorithm_t ptls_mbedtls_aes128ecb;
 extern ptls_cipher_algorithm_t ptls_mbedtls_aes256ecb;
 extern ptls_cipher_algorithm_t ptls_mbedtls_aes128ctr;
 extern ptls_cipher_algorithm_t ptls_mbedtls_aes256ctr;
-extern ptls_cipher_algorithm_t ptls_minicrypto_chacha20;
+extern ptls_cipher_algorithm_t ptls_mbedtls_chacha20;
 
 extern ptls_aead_algorithm_t ptls_mbedtls_aes128gcm;
 extern ptls_aead_algorithm_t ptls_mbedtls_aes256gcm;

--- a/include/picotls/ptls_mbedtls.h
+++ b/include/picotls/ptls_mbedtls.h
@@ -37,9 +37,11 @@ extern ptls_cipher_algorithm_t ptls_mbedtls_aes128ecb;
 extern ptls_cipher_algorithm_t ptls_mbedtls_aes256ecb;
 extern ptls_cipher_algorithm_t ptls_mbedtls_aes128ctr;
 extern ptls_cipher_algorithm_t ptls_mbedtls_aes256ctr;
+extern ptls_cipher_algorithm_t ptls_minicrypto_chacha20;
 
 extern ptls_aead_algorithm_t ptls_mbedtls_aes128gcm;
 extern ptls_aead_algorithm_t ptls_mbedtls_aes256gcm;
+extern ptls_aead_algorithm_t ptls_mbedtls_chacha20poly1305;
 
 #ifdef __cplusplus
 }

--- a/include/picotls/ptls_mbedtls.h
+++ b/include/picotls/ptls_mbedtls.h
@@ -43,6 +43,8 @@ extern "C" {
     extern ptls_aead_algorithm_t ptls_mbedtls_aes256gcm;
     extern ptls_aead_algorithm_t ptls_mbedtls_chacha20poly1305;
 
+    extern ptls_key_exchange_algorithm_t ptls_mbedtls_secp256r1;
+
     int ptls_mbedtls_init();
     void ptls_mbedtls_free();
     void ptls_mbedtls_random_bytes(void* buf, size_t len);

--- a/lib/ptls_mbedtls.c
+++ b/lib/ptls_mbedtls.c
@@ -1,0 +1,586 @@
+#ifdef _WINDOWS
+#include "wincompat.h"
+#endif
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <picotls.h>
+#include "mbedtls/build_info.h"
+#include "psa/crypto.h"
+#include "psa/crypto_struct.h"
+#include "mbedtls/sha256.h"
+#include "mbedtls/aes.h"
+
+/* Definitions for hash algorithms.
+* In Picotls, these are described by the stucture
+* ptls_hash_algorithm_t, which include the function
+* pointer for creation of the hash context.
+* 
+* The structure contains a function pointer to the
+* "create" function that creates a hash operation,
+* which itself contains three function pointers:
+* 
+* void (*update)(struct st_ptls_hash_context_t *ctx, const void *src, size_t len);
+* void (*final)(struct st_ptls_hash_context_t *ctx, void *md, ptls_hash_final_mode_t mode);
+* struct st_ptls_hash_context_t *(*clone_)(struct st_ptls_hash_context_t *src);
+* 
+* TODO: develop shim for other hash methods besides SHA256
+*/
+
+typedef struct st_ptls_mbedtls_sha256_ctx_t {
+    ptls_hash_context_t super;
+    mbedtls_sha256_context mctx;
+} ptls_mbedtls_sha256_ctx_t;
+
+static void ptls_mbedtls_sha256_update(struct st_ptls_hash_context_t* _ctx, const void* src, size_t len)
+{
+    ptls_mbedtls_sha256_ctx_t* ctx = (ptls_mbedtls_sha256_ctx_t*)_ctx;
+
+    (void)mbedtls_sha256_update(&ctx->mctx, (const uint8_t*)src, len);
+}
+
+static void ptls_mbedtls_sha256_final(struct st_ptls_hash_context_t* _ctx, void* md, ptls_hash_final_mode_t mode);
+
+static struct st_ptls_hash_context_t* ptls_mbedtls_sha256_clone(struct st_ptls_hash_context_t* _src)
+{
+    ptls_mbedtls_sha256_ctx_t* ctx = (ptls_mbedtls_sha256_ctx_t*)malloc(sizeof(ptls_mbedtls_sha256_ctx_t));
+
+    if (ctx != NULL) {
+        ptls_mbedtls_sha256_ctx_t* src = (ptls_mbedtls_sha256_ctx_t*)_src;
+        memset(&ctx->mctx, 0, sizeof(mbedtls_sha256_context));
+        ctx->super.clone_ = ptls_mbedtls_sha256_clone;
+        ctx->super.update = ptls_mbedtls_sha256_update;
+        ctx->super.final = ptls_mbedtls_sha256_final;
+        mbedtls_sha256_clone(&ctx->mctx, &src->mctx);
+    }
+    return (ptls_hash_context_t*)ctx;
+}
+
+static void ptls_mbedtls_sha256_final(struct st_ptls_hash_context_t* _ctx, void* md, ptls_hash_final_mode_t mode)
+{
+    ptls_mbedtls_sha256_ctx_t* ctx = (ptls_mbedtls_sha256_ctx_t*)_ctx;
+
+    if (mode == PTLS_HASH_FINAL_MODE_SNAPSHOT) {
+        struct st_ptls_hash_context_t* cloned = ptls_mbedtls_sha256_clone(_ctx);
+
+        if (cloned != NULL) {
+            ptls_mbedtls_sha256_final(cloned, md, PTLS_HASH_FINAL_MODE_FREE);
+        }
+    } else {
+        if (md != NULL) {
+            (void)mbedtls_sha256_finish(&ctx->mctx, (uint8_t*)md);
+        }
+
+        if (mode == PTLS_HASH_FINAL_MODE_FREE) {
+            mbedtls_sha256_free(&ctx->mctx);
+            free(ctx);
+        }
+        else {
+            /* if mode = reset, reset the context */
+            mbedtls_sha256_init(&ctx->mctx);
+            mbedtls_sha256_starts(&ctx->mctx, 0 /* is224 = 0 */);
+        }
+    }
+}
+
+ptls_hash_context_t* ptls_mbedtls_sha256_create(void)
+{
+    ptls_mbedtls_sha256_ctx_t* ctx = (ptls_mbedtls_sha256_ctx_t*)malloc(sizeof(ptls_mbedtls_sha256_ctx_t));
+
+    if (ctx != NULL) {
+        memset(&ctx->mctx, 0, sizeof(mbedtls_sha256_context));
+        ctx->super.clone_ = ptls_mbedtls_sha256_clone;
+        ctx->super.update = ptls_mbedtls_sha256_update;
+        ctx->super.final = ptls_mbedtls_sha256_final;
+        if (mbedtls_sha256_starts(&ctx->mctx, 0 /* is224 = 0 */) != 0) {
+            free(ctx);
+            ctx = NULL;
+        }
+    }
+    return (ptls_hash_context_t*)ctx;
+}
+
+ptls_hash_algorithm_t ptls_mbedtls_sha256 = {"sha256", PTLS_SHA256_BLOCK_SIZE, PTLS_SHA256_DIGEST_SIZE, ptls_mbedtls_sha256_create,
+PTLS_ZERO_DIGEST_SHA256};
+
+
+/* definitions for symmetric crypto algorithms. 
+* Each algorithm (ECB or CTR) is represented by an "algorithm"
+* entry in which the 'setup" function is used to initialize
+* The "setup" function creates an object of type
+* ptls_cipher_context_t, with three function pointers:
+* 
+*   void (*do_dispose)(struct st_ptls_cipher_context_t *ctx);
+*   void (*do_init)(struct st_ptls_cipher_context_t *ctx, const void *iv);
+*   void (*do_transform)(struct st_ptls_cipher_context_t *ctx, void *output, const void *input, size_t len);
+* 
+* "do_init" sets the IV value. In CTR mode, this is the nonce value, which
+* will be incremented after each block. In CTR mode, this also sets the 
+* "stream block".
+* 
+ */
+struct ptls_mbedtls_symmetric_param_t {
+    uint8_t iv[PTLS_MAX_IV_SIZE];
+    uint8_t *key_object;
+    int is_enc;
+};
+
+struct st_ptls_mbedtls_aes_context_t {
+    ptls_cipher_context_t super;
+    mbedtls_aes_context aes_ctx;
+    uint8_t nonce_counter[16];
+    uint8_t stream_block[16];
+    int is_enc; /* MBEDTLS_AES_ENCRYPT or MBEDTLS_AES_DECRYPT */
+};
+
+static void ptls_mbedtls_aes_ctr_init(ptls_cipher_context_t *_ctx, const void *iv)
+{
+    struct st_ptls_mbedtls_aes_context_t *ctx = (struct st_ptls_mbedtls_aes_context_t *)_ctx;
+
+    if (iv == NULL) {
+        memset(ctx->nonce_counter, 0, 16);
+    }
+    else {
+        memcpy(ctx->nonce_counter, iv, 16);
+    }
+    memset(ctx->stream_block, 0, 16);
+}
+
+static void ptls_mbedtls_aes_ecb_transform(ptls_cipher_context_t *_ctx, void *output, const void *input, size_t len)
+{
+    struct st_ptls_mbedtls_aes_context_t *ctx = (struct st_ptls_mbedtls_aes_context_t *)_ctx;
+
+    /* Call the encryption */
+    if (mbedtls_aes_crypt_ecb(&ctx->aes_ctx, ctx->is_enc, (const uint8_t*)input, (uint8_t*)output) != 0) {
+        memset(output, 0, len);
+    }
+}
+
+static void ptls_mbedtls_aes_ctr_transform(ptls_cipher_context_t *_ctx, void *output, const void *input, size_t len)
+{
+    struct st_ptls_mbedtls_aes_context_t *ctx = (struct st_ptls_mbedtls_aes_context_t *)_ctx;
+    size_t nc_off = 0;
+
+    if (mbedtls_aes_crypt_ctr(&ctx->aes_ctx, len, &nc_off, ctx->nonce_counter, ctx->stream_block,
+        (const uint8_t*)input, (uint8_t*)output) != 0) {
+        memset(output, 0, len);
+    }
+}
+
+static void ptls_mbedtls_aes_ctr_dispose(ptls_cipher_context_t *_ctx)
+{
+    struct st_ptls_mbedtls_aes_context_t *ctx = (struct st_ptls_mbedtls_aes_context_t *)_ctx;
+    mbedtls_aes_free(&ctx->aes_ctx);
+}
+
+static int ptls_mbedtls_cipher_setup_crypto_aes(ptls_cipher_context_t* _ctx, int is_enc, const void* key, unsigned int keybits)
+{
+    struct st_ptls_mbedtls_aes_context_t *ctx = (struct st_ptls_mbedtls_aes_context_t *)_ctx;
+    int ret = 0;
+
+    memset(ctx->nonce_counter, 0, 16);
+    memset(ctx->stream_block, 0, 16);
+
+    ctx->super.do_dispose = ptls_mbedtls_aes_ctr_dispose;
+    ctx->super.do_init = ptls_mbedtls_aes_ctr_init;
+    ctx->super.do_transform = NULL;
+
+    mbedtls_aes_init(&ctx->aes_ctx);
+    if (is_enc) {
+        ret = mbedtls_aes_setkey_enc(&ctx->aes_ctx, key, keybits);
+        ctx->is_enc = MBEDTLS_AES_ENCRYPT;
+    }
+    else {
+        ret = mbedtls_aes_setkey_dec(&ctx->aes_ctx, key, keybits);
+        ctx->is_enc = MBEDTLS_AES_DECRYPT;
+    }
+
+    return ret;
+
+}
+
+static int ptls_mbedtls_cipher_setup_crypto_aes128_ecb(ptls_cipher_context_t *_ctx, int is_enc, const void *key)
+{
+    struct st_ptls_mbedtls_aes_context_t *ctx = (struct st_ptls_mbedtls_aes_context_t *)_ctx;
+    int ret = ptls_mbedtls_cipher_setup_crypto_aes(_ctx, is_enc, key, 128);
+
+    if (ret == 0) {
+        ctx->super.do_transform = ptls_mbedtls_aes_ecb_transform;
+    }
+
+    return ret;
+}
+
+static int ptls_mbedtls_cipher_setup_crypto_aes128_ctr(ptls_cipher_context_t *_ctx, int is_enc, const void *key)
+{
+#ifdef _WINDOWS
+    UNREFERENCED_PARAMETER(is_enc);
+#endif
+    struct st_ptls_mbedtls_aes_context_t *ctx = (struct st_ptls_mbedtls_aes_context_t *)_ctx;
+    int ret = ptls_mbedtls_cipher_setup_crypto_aes(_ctx, 1, key, 128); /* No difference between CTR encrypt and decrypt */
+
+    if (ret == 0) {
+        ctx->super.do_transform = ptls_mbedtls_aes_ctr_transform;
+    }
+
+    return ret;
+}
+
+
+static int ptls_mbedtls_cipher_setup_crypto_aes256_ecb(ptls_cipher_context_t *_ctx, int is_enc, const void *key)
+{
+    struct st_ptls_mbedtls_aes_context_t *ctx = (struct st_ptls_mbedtls_aes_context_t *)_ctx;
+    int ret = ptls_mbedtls_cipher_setup_crypto_aes(_ctx, is_enc, key, 256);
+
+    if (ret == 0) {
+        ctx->super.do_transform = ptls_mbedtls_aes_ecb_transform;
+    }
+
+    return ret;
+}
+
+static int ptls_mbedtls_cipher_setup_crypto_aes256_ctr(ptls_cipher_context_t *_ctx, int is_enc, const void *key)
+{
+#ifdef _WINDOWS
+    UNREFERENCED_PARAMETER(is_enc);
+#endif
+    struct st_ptls_mbedtls_aes_context_t *ctx = (struct st_ptls_mbedtls_aes_context_t *)_ctx;
+    int ret = ptls_mbedtls_cipher_setup_crypto_aes(_ctx, 1, key, 256); /* No difference between CTR encrypt and decrypt */
+
+    if (ret == 0) {
+        ctx->super.do_transform = ptls_mbedtls_aes_ctr_transform;
+    }
+
+    return ret;
+}
+
+ptls_cipher_algorithm_t ptls_mbedtls_aes128ecb = {
+    "AES128-ECB",
+    PTLS_AES128_KEY_SIZE,
+    PTLS_AES_BLOCK_SIZE,
+    0 /* iv size */,
+    sizeof(struct st_ptls_mbedtls_aes_context_t),
+    ptls_mbedtls_cipher_setup_crypto_aes128_ecb};
+
+ptls_cipher_algorithm_t ptls_mbedtls_aes256ecb = {"AES256-ECB",
+PTLS_AES256_KEY_SIZE,
+PTLS_AES_BLOCK_SIZE,
+0 /* iv size */,
+sizeof(struct st_ptls_mbedtls_aes_context_t),
+ptls_mbedtls_cipher_setup_crypto_aes256_ecb};
+
+ptls_cipher_algorithm_t ptls_mbedtls_aes128ctr = {"AES128-CTR",
+PTLS_AES128_KEY_SIZE,
+PTLS_AES_BLOCK_SIZE,
+0 /* iv size */,
+sizeof(struct st_ptls_mbedtls_aes_context_t),
+ptls_mbedtls_cipher_setup_crypto_aes128_ctr};
+
+ptls_cipher_algorithm_t ptls_mbedtls_aes256ctr = {"AES256-CTR",
+PTLS_AES256_KEY_SIZE,
+PTLS_AES_BLOCK_SIZE,
+0 /* iv size */,
+sizeof(struct st_ptls_mbedtls_aes_context_t),
+ptls_mbedtls_cipher_setup_crypto_aes256_ctr};
+
+/* Definitions of AEAD algorithms.
+* 
+* For the picotls API, AEAD algorithms are created by calling:
+* 
+* ptls_aead_context_t *ptls_aead_new(ptls_aead_algorithm_t *aead,
+*       ptls_hash_algorithm_t *hash, int is_enc, const void *secret,
+*                                   const char *label_prefix)
+* That procedure will allocate memory and create keys, and then call
+* a provider specific function:
+* 
+*   if (aead->setup_crypto(ctx, is_enc, key, iv) != 0) {
+*       free(ctx);
+*       return NULL;
+*   }
+* 
+* The function will finish completing the aead structure, perform
+* initialization, and then document the function pointers:
+* 
+* ctx->super.dispose_crypto: release all resourc
+* ctx->super.do_get_iv: return IV
+* ctx->super.do_set_iv: set IV value
+* ctx->super.do_decrypt: decrypt function
+* ctx->super.do_encrypt_init: start encrypting one message
+* ctx->super.do_encrypt_update: feed more ciphertext to descriptor
+* ctx->super.do_encrypt_final: finalize encryption, including AEAD checksum
+* ctx->super.do_encrypt: single shot variant of init/update/final
+* ctx->super.do_encrypt_v: scatter gather version of do encrypt
+* 
+* The aead context also documents the underlying "ECB" and "CTR" modes.
+* In QUIC, these are used for PN encryption.
+* 
+* TODO: declare other lagorithms besides AES128_GCM
+*/
+
+struct ptls_mbedtls_aead_param_t {
+    uint8_t static_iv[PTLS_MAX_IV_SIZE];
+    psa_algorithm_t alg;
+    psa_key_id_t key;
+    psa_aead_operation_t op;
+    size_t extra_bytes;
+    int is_op_in_progress;
+};
+
+struct ptls_mbedtls_aead_context_t {
+    struct st_ptls_aead_context_t super;
+    struct ptls_mbedtls_aead_param_t mctx;
+};
+
+void ptls_mbedtls_aead_dispose_crypto(struct st_ptls_aead_context_t* _ctx)
+{
+    struct ptls_mbedtls_aead_context_t* ctx =
+        (struct ptls_mbedtls_aead_context_t*)_ctx;
+    if (ctx->mctx.is_op_in_progress) {
+        psa_aead_abort(&ctx->mctx.op);
+        ctx->mctx.is_op_in_progress = 0;
+    }
+    psa_destroy_key(ctx->mctx.key);
+}
+
+
+static void ptls_mbedtls_aead_get_iv(ptls_aead_context_t *_ctx, void *iv)
+{
+    struct ptls_mbedtls_aead_context_t* ctx =
+        (struct ptls_mbedtls_aead_context_t*)_ctx;
+
+    memcpy(iv, ctx->mctx.static_iv, ctx->super.algo->iv_size);
+}
+
+static void ptls_mbedtls_aead_set_iv(ptls_aead_context_t *_ctx, const void *iv)
+{
+    struct ptls_mbedtls_aead_context_t* ctx =
+        (struct ptls_mbedtls_aead_context_t*)_ctx;
+
+    memcpy(ctx->mctx.static_iv, iv, ctx->super.algo->iv_size);
+}
+
+void ptls_mbedtls_aead_do_encrypt_init(struct st_ptls_aead_context_t* _ctx, uint64_t seq, const void* aad, size_t aadlen)
+{
+    struct ptls_mbedtls_aead_context_t* ctx =
+        (struct ptls_mbedtls_aead_context_t*)_ctx;
+    psa_status_t status;
+
+    if (ctx->mctx.is_op_in_progress) {
+        psa_aead_abort(&ctx->mctx.op);   /* required on errors, harmless on success */
+        ctx->mctx.is_op_in_progress = 0;
+    }
+
+    ctx->mctx.is_op_in_progress = 1;
+    memset(&ctx->mctx.op, 0, sizeof(ctx->mctx.op));
+
+    status = psa_aead_encrypt_setup(&ctx->mctx.op, ctx->mctx.key, ctx->mctx.alg);
+
+    if (status == PSA_SUCCESS) {
+        /* set the nonce. */
+        uint8_t iv[PTLS_MAX_IV_SIZE];
+        ptls_aead__build_iv(ctx->super.algo, iv, ctx->mctx.static_iv, seq);
+        status = psa_aead_set_nonce(&ctx->mctx.op, iv, ctx->super.algo->iv_size);
+    }
+
+    if (status == PSA_SUCCESS) {
+        status = psa_aead_update_ad(&ctx->mctx.op, aad, aadlen);
+    }
+
+    if (status != PSA_SUCCESS) {
+        psa_aead_abort(&ctx->mctx.op);   /* required on errors, harmless on success */
+        ctx->mctx.is_op_in_progress = 0;
+    }
+}
+
+size_t ptls_mbedtls_aead_do_encrypt_update(struct st_ptls_aead_context_t* _ctx, void* output, const void* input, size_t inlen)
+{
+    size_t olen = 0;
+    struct ptls_mbedtls_aead_context_t* ctx =
+        (struct ptls_mbedtls_aead_context_t*)_ctx;
+
+    if (ctx->mctx.is_op_in_progress) {
+        size_t available = inlen + ctx->mctx.extra_bytes;
+        psa_status_t status = psa_aead_update(&ctx->mctx.op, input, inlen, (uint8_t *)output, available + ctx->super.algo->tag_size, &olen);
+
+        if (status == PSA_SUCCESS) {
+            if (olen < available) {
+                ctx->mctx.extra_bytes = available - olen;
+            }
+            else {
+                ctx->mctx.extra_bytes = 0;
+            }
+        }
+        else {
+            psa_aead_abort(&ctx->mctx.op);   /* required on errors */
+            ctx->mctx.is_op_in_progress = 0;
+        }
+    }
+
+    return olen;
+}
+
+size_t ptls_mbedtls_aead_do_encrypt_final(struct st_ptls_aead_context_t* _ctx, void* output)
+{
+    size_t olen = 0;
+    struct ptls_mbedtls_aead_context_t* ctx =
+        (struct ptls_mbedtls_aead_context_t*)_ctx;
+
+    if (ctx->mctx.is_op_in_progress) {
+        unsigned char tag[PSA_AEAD_TAG_MAX_SIZE];
+        size_t olen_tag = 0;
+        size_t available = ctx->mctx.extra_bytes;
+        uint8_t* p = (uint8_t*)output;
+        psa_status_t status = psa_aead_finish(&ctx->mctx.op, p, available + ctx->super.algo->tag_size, &olen,
+            tag, sizeof(tag), &olen_tag);
+
+        if (status == PSA_SUCCESS) {
+            p += olen;
+            memcpy(p, tag, ctx->super.algo->tag_size);
+            olen += ctx->super.algo->tag_size;
+        }
+        else {
+            psa_aead_abort(&ctx->mctx.op);   /* required on errors */
+        }
+        ctx->mctx.is_op_in_progress = 0;
+    }
+
+    return(olen);
+}
+
+void ptls_mbedtls_aead_do_encrypt_v(struct st_ptls_aead_context_t* _ctx, void* output, ptls_iovec_t* input, size_t incnt, uint64_t seq,
+    const void* aad, size_t aadlen)
+{
+    unsigned char* p = (uint8_t*)output;
+
+    ptls_mbedtls_aead_do_encrypt_init(_ctx, seq, aad, aadlen);
+
+    for (size_t i = 0; i < incnt; i++) {
+        p += ptls_mbedtls_aead_do_encrypt_update(_ctx, p, input[i].base, input[i].len);
+    }
+
+    (void)ptls_mbedtls_aead_do_encrypt_final(_ctx, p);
+}
+
+void ptls_mbedtls_aead_do_encrypt(struct st_ptls_aead_context_t* _ctx, void* output, const void* input, size_t inlen, uint64_t seq,
+    const void* aad, size_t aadlen, ptls_aead_supplementary_encryption_t* supp)
+{
+    ptls_iovec_t in_v;
+    in_v.base = (uint8_t*)input;
+    in_v.len = inlen;
+
+    ptls_mbedtls_aead_do_encrypt_v(_ctx, output, &in_v, 1, seq, aad, aadlen);
+}
+
+size_t ptls_mbedtls_aead_do_decrypt(struct st_ptls_aead_context_t* _ctx, void* output, const void* input, size_t inlen, uint64_t seq,
+    const void* aad, size_t aadlen)
+{
+    size_t o_len = 0;
+    uint8_t iv[PTLS_MAX_IV_SIZE];
+    struct ptls_mbedtls_aead_context_t* ctx =
+        (struct ptls_mbedtls_aead_context_t*)_ctx;
+    psa_status_t status;
+    /* set the nonce. */
+    ptls_aead__build_iv(ctx->super.algo, iv, ctx->mctx.static_iv, seq);
+
+    status = psa_aead_decrypt(ctx->mctx.key, ctx->mctx.alg, iv, ctx->super.algo->iv_size, (uint8_t*)aad, aadlen,
+        (uint8_t*)input, inlen, (uint8_t*)output, inlen, &o_len);
+    if (status != PSA_SUCCESS) {
+        o_len = inlen + 1;
+    }
+    return o_len;
+}
+
+static int ptls_mbedtls_aead_setup_crypto(ptls_aead_context_t *_ctx, int is_enc, const void *key_bytes, const void *iv)
+{
+    int ret = 0;
+    struct ptls_mbedtls_aead_context_t* ctx =
+        (struct ptls_mbedtls_aead_context_t*)_ctx;
+    size_t key_bits;
+    psa_key_type_t key_type;
+
+    /* set mbed specific context to NULL, just to be sure */
+    memset(&ctx->mctx, 0, sizeof(struct ptls_mbedtls_aead_param_t));
+
+    /* deduce the PSA algorithm from the name */
+    if (strcmp(ctx->super.algo->name, "AES128-GCM") == 0) {
+        ctx->mctx.alg = PSA_ALG_GCM;
+        key_bits = 128;
+        key_type = PSA_KEY_TYPE_AES;
+    } else if (strcmp(ctx->super.algo->name, "AES256-GCM") == 0) {
+        ctx->mctx.alg = PSA_ALG_GCM;
+        key_bits = 256;
+        key_type = PSA_KEY_TYPE_AES;
+    } else if (strcmp(ctx->super.algo->name, "AES128-GCM_8") == 0) {
+        ctx->mctx.alg = PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_GCM, 8);
+        key_bits = 128;
+        key_type = PSA_KEY_TYPE_AES;
+    } else if (strcmp(ctx->super.algo->name, "CHACHA20-POLY1305") == 0) {
+        ctx->mctx.alg = PSA_ALG_CHACHA20_POLY1305;
+        key_bits = 256;
+        key_type = PSA_KEY_TYPE_CHACHA20;
+    } else {
+        ret = PTLS_ERROR_LIBRARY;
+    }
+
+    /* Initialize the key attributes */
+    if (ret == 0) {
+        psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+        psa_set_key_usage_flags(&attributes, 
+            (is_enc)?PSA_KEY_USAGE_ENCRYPT:PSA_KEY_USAGE_DECRYPT);
+        psa_set_key_algorithm(&attributes, ctx->mctx.alg);
+        psa_set_key_type(&attributes, key_type);
+        psa_set_key_bits(&attributes, key_bits);
+        /* Import key */
+        if (psa_import_key(&attributes, key_bytes, key_bits / 8,
+            &ctx->mctx.key) != PSA_SUCCESS) {
+            ret = PTLS_ERROR_LIBRARY;
+        }
+    }
+
+    if (ret == 0) {
+        /* Store the static IV */
+        if (ctx->super.algo->iv_size > PTLS_MAX_IV_SIZE) {
+            ret = PTLS_ERROR_LIBRARY;
+        }
+        else {
+            memcpy(ctx->mctx.static_iv, iv, ctx->super.algo->iv_size);
+            ctx->mctx.is_op_in_progress = 0;
+        }
+    }
+
+    /* set the pointers to the individual functions */
+    if (ret == 0) {
+        if (is_enc) {
+            ctx->super.do_encrypt_init = ptls_mbedtls_aead_do_encrypt_init;
+            ctx->super.do_encrypt_update = ptls_mbedtls_aead_do_encrypt_update;
+            ctx->super.do_encrypt_final = ptls_mbedtls_aead_do_encrypt_final;
+            ctx->super.do_encrypt = ptls_mbedtls_aead_do_encrypt;
+            ctx->super.do_encrypt_v = ptls_mbedtls_aead_do_encrypt_v;
+        }
+        else {
+            ctx->super.do_decrypt = ptls_mbedtls_aead_do_decrypt;
+        }
+        ctx->super.dispose_crypto = ptls_mbedtls_aead_dispose_crypto;
+        ctx->super.do_get_iv = ptls_mbedtls_aead_get_iv;
+        ctx->super.do_set_iv = ptls_mbedtls_aead_set_iv;
+    }
+
+    return ret;
+}
+
+ptls_aead_algorithm_t ptls_mbedtls_aes128gcm = {
+    "AES128-GCM",
+    PTLS_AESGCM_CONFIDENTIALITY_LIMIT,
+    PTLS_AESGCM_INTEGRITY_LIMIT,
+    &ptls_mbedtls_aes128ecb,
+    &ptls_mbedtls_aes128ctr,
+    PTLS_AES128_KEY_SIZE,
+    PTLS_AESGCM_IV_SIZE,
+    PTLS_AESGCM_TAG_SIZE,
+    {PTLS_TLS12_AESGCM_FIXED_IV_SIZE, PTLS_TLS12_AESGCM_RECORD_IV_SIZE},
+    0,
+    0,
+    sizeof(struct ptls_mbedtls_aead_context_t),
+    ptls_mbedtls_aead_setup_crypto
+};

--- a/lib/ptls_mbedtls.c
+++ b/lib/ptls_mbedtls.c
@@ -754,7 +754,7 @@ ptls_aead_algorithm_t ptls_mbedtls_chacha20poly1305 = {
     "CHACHA20-POLY1305",
     PTLS_CHACHA20POLY1305_CONFIDENTIALITY_LIMIT,
     PTLS_CHACHA20POLY1305_INTEGRITY_LIMIT,
-    &ptls_minicrypto_chacha20,
+    &ptls_mbedptls_chacha20,
     NULL,
     PTLS_CHACHA20_KEY_SIZE,
     PTLS_CHACHA20POLY1305_IV_SIZE,

--- a/lib/ptls_mbedtls.c
+++ b/lib/ptls_mbedtls.c
@@ -685,3 +685,19 @@ ptls_aead_algorithm_t ptls_mbedtls_aes128gcm = {
     sizeof(struct ptls_mbedtls_aead_context_t),
     ptls_mbedtls_aead_setup_crypto
 };
+
+ptls_aead_algorithm_t ptls_mbedtls_aes256gcm = {
+    "AES256-GCM",
+    PTLS_AESGCM_CONFIDENTIALITY_LIMIT,
+    PTLS_AESGCM_INTEGRITY_LIMIT,
+    &ptls_mbedtls_aes256ecb,
+    &ptls_mbedtls_aes256ctr,
+    PTLS_AES256_KEY_SIZE,
+    PTLS_AESGCM_IV_SIZE,
+    PTLS_AESGCM_TAG_SIZE,
+    {PTLS_TLS12_AESGCM_FIXED_IV_SIZE, PTLS_TLS12_AESGCM_RECORD_IV_SIZE},
+    0,
+    0,
+    sizeof(struct ptls_mbedtls_aead_context_t),
+    ptls_mbedtls_aead_setup_crypto
+};

--- a/lib/ptls_mbedtls.c
+++ b/lib/ptls_mbedtls.c
@@ -386,11 +386,13 @@ struct st_ptls_mbedtls_chacha20_context_t {
     mbedtls_chacha20_context mctx;
 };
 
-static void ptls_mbedtls_chacha20_init(ptls_cipher_context_t *_ctx, const void *iv)
+static void ptls_mbedtls_chacha20_init(ptls_cipher_context_t *_ctx, const void *v_iv)
 {
     struct st_ptls_mbedtls_chacha20_context_t *ctx = (struct st_ptls_mbedtls_chacha20_context_t *)_ctx;
+    const uint8_t* iv = (const uint8_t*)v_iv;
+    uint32_t ctr = iv[0] | ((uint32_t)iv[1] << 8) | ((uint32_t)iv[2] << 16) | ((uint32_t)iv[3] << 24);
 
-    (void)mbedtls_chacha20_starts(&ctx->mctx, (const uint8_t*)iv, 0);
+    (void)mbedtls_chacha20_starts(&ctx->mctx, (const uint8_t*)(iv+4), ctr);
 }
 
 static void ptls_mbedtls_chacha20_transform(ptls_cipher_context_t *_ctx, void *output, const void *input, size_t len)

--- a/lib/ptls_mbedtls.c
+++ b/lib/ptls_mbedtls.c
@@ -428,7 +428,7 @@ static int ptls_mbedtls_cipher_setup_crypto_chacha20(ptls_cipher_context_t *_ctx
     return ret;
 }
 
-ptls_cipher_algorithm_t ptls_minicrypto_chacha20 = {
+ptls_cipher_algorithm_t ptls_mbedtls_chacha20 = {
     "CHACHA20", PTLS_CHACHA20_KEY_SIZE, 1 /* block size */, PTLS_CHACHA20_IV_SIZE, sizeof(struct st_ptls_mbedtls_chacha20_context_t),
     ptls_mbedtls_cipher_setup_crypto_chacha20};
 

--- a/lib/ptls_mbedtls.c
+++ b/lib/ptls_mbedtls.c
@@ -1,3 +1,25 @@
+/*
+* Copyright (c) 2023, Christian Huitema
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to
+* deal in the Software without restriction, including without limitation the
+* rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+* sell copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+* IN THE SOFTWARE.
+*/
+
 #ifdef _WINDOWS
 #include "wincompat.h"
 #endif
@@ -704,6 +726,11 @@ ptls_aead_algorithm_t ptls_mbedtls_aes128gcm = {
     ptls_mbedtls_aead_setup_aes128gcm
 };
 
+ptls_cipher_suite_t ptls_mbedtls_aes128gcmsha256 = {.id = PTLS_CIPHER_SUITE_AES_128_GCM_SHA256,
+.name = PTLS_CIPHER_SUITE_NAME_AES_128_GCM_SHA256,
+.aead = &ptls_mbedtls_aes128gcm,
+.hash = &ptls_mbedtls_sha256};
+
 static int ptls_mbedtls_aead_setup_aes256gcm(ptls_aead_context_t* _ctx, int is_enc, const void* key_bytes, const void* iv)
 {
     return ptls_mbedtls_aead_setup_crypto(_ctx, is_enc, key_bytes, iv, PSA_ALG_GCM, 256, PSA_KEY_TYPE_AES);
@@ -725,6 +752,12 @@ ptls_aead_algorithm_t ptls_mbedtls_aes256gcm = {
     ptls_mbedtls_aead_setup_aes256gcm
 };
 
+ptls_cipher_suite_t ptls_mbedtls_aes256gcmsha384 = {
+    .id = PTLS_CIPHER_SUITE_AES_256_GCM_SHA384,
+    .name = PTLS_CIPHER_SUITE_NAME_AES_256_GCM_SHA384,
+    .aead = &ptls_mbedtls_aes256gcm,
+    .hash = &ptls_mbedtls_sha384};
+
 static int ptls_mbedtls_aead_setup_chacha20poly1305(ptls_aead_context_t* _ctx, int is_enc, const void* key_bytes, const void* iv)
 {
     return ptls_mbedtls_aead_setup_crypto(_ctx, is_enc, key_bytes, iv, PSA_ALG_CHACHA20_POLY1305, 256, PSA_KEY_TYPE_CHACHA20);
@@ -745,6 +778,11 @@ ptls_aead_algorithm_t ptls_mbedtls_chacha20poly1305 = {
     sizeof(struct ptls_mbedtls_aead_context_t),
     ptls_mbedtls_aead_setup_chacha20poly1305
 };
+
+ptls_cipher_suite_t ptls_mbedtls_chacha20poly1305sha256 = {.id = PTLS_CIPHER_SUITE_CHACHA20_POLY1305_SHA256,
+.name = PTLS_CIPHER_SUITE_NAME_CHACHA20_POLY1305_SHA256,
+.aead = &ptls_mbedtls_chacha20poly1305,
+.hash = &ptls_mbedtls_sha256};
 
 /* Key exchange algorithms.
 * The Picotls framework defines these algorithms as ptls_key_exchange_algorithm_t,
@@ -922,7 +960,7 @@ static int ptls_mbedtls_key_exchange_exchange(const struct st_ptls_key_exchange_
     return ret;
 }
 
-/* Instantiation of the generic API with secp256r1
+/* Instantiation of the generic key exchange API with secp256r1
 */
 static int ptls_mbedtls_secp256r1_create(const struct st_ptls_key_exchange_algorithm_t* algo, ptls_key_exchange_context_t** ctx)
 {
@@ -941,3 +979,23 @@ ptls_key_exchange_algorithm_t ptls_mbedtls_secp256r1 = {.id = PTLS_GROUP_SECP256
 .name = PTLS_GROUP_NAME_SECP256R1,
 .create = ptls_mbedtls_secp256r1_create,
 .exchange = ptls_mbedtls_secp256r1_exchange};
+
+/* Instantiation of the generic key exchange API with x25519
+*/
+static int ptls_mbedtls_x25519_create(const struct st_ptls_key_exchange_algorithm_t* algo, ptls_key_exchange_context_t** ctx)
+{
+    return ptls_mbedtls_key_exchange_create(algo, ctx,
+        PSA_ALG_ECDH, PSA_ECC_FAMILY_MONTGOMERY, 255, 32);
+}
+
+static int ptls_mbedtls_x25519_exchange(const struct st_ptls_key_exchange_algorithm_t* algo, ptls_iovec_t* pubkey, ptls_iovec_t* secret,
+    ptls_iovec_t peerkey)
+{
+    return ptls_mbedtls_key_exchange_exchange(algo, pubkey, secret, peerkey,
+        PSA_ALG_ECDH, PSA_ECC_FAMILY_MONTGOMERY, 255, 32);
+}
+
+ptls_key_exchange_algorithm_t ptls_mbedtls_x25519 = {.id = PTLS_GROUP_X25519,
+.name = PTLS_GROUP_NAME_X25519,
+.create = ptls_mbedtls_x25519_create,
+.exchange = ptls_mbedtls_x25519_exchange};

--- a/lib/ptls_mbedtls.c
+++ b/lib/ptls_mbedtls.c
@@ -754,7 +754,7 @@ ptls_aead_algorithm_t ptls_mbedtls_chacha20poly1305 = {
     "CHACHA20-POLY1305",
     PTLS_CHACHA20POLY1305_CONFIDENTIALITY_LIMIT,
     PTLS_CHACHA20POLY1305_INTEGRITY_LIMIT,
-    &ptls_mbedptls_chacha20,
+    &ptls_mbedtls_chacha20,
     NULL,
     PTLS_CHACHA20_KEY_SIZE,
     PTLS_CHACHA20POLY1305_IV_SIZE,

--- a/lib/ptls_mbedtls.c
+++ b/lib/ptls_mbedtls.c
@@ -388,15 +388,14 @@ struct st_ptls_mbedtls_chacha20_context_t {
 
 static void ptls_mbedtls_chacha20_init(ptls_cipher_context_t *_ctx, const void *iv)
 {
-    struct st_ptls_mbedtls_chacha20_context_t *ctx = (struct st_ptls_mbedtls_aes_context_t *)_ctx;
+    struct st_ptls_mbedtls_chacha20_context_t *ctx = (struct st_ptls_mbedtls_chacha20_context_t *)_ctx;
 
-    (void)mbedtls_chacha20_starts(mbedtls_chacha20_context * ctx, (const uint8_t*)iv, 0);
+    (void)mbedtls_chacha20_starts(&ctx->mctx, (const uint8_t*)iv, 0);
 }
 
 static void ptls_mbedtls_chacha20_transform(ptls_cipher_context_t *_ctx, void *output, const void *input, size_t len)
 {
-    struct st_ptls_mbedtls_chacha20_context_t *ctx = (struct st_ptls_mbedtls_aes_context_t *)_ctx;
-    size_t nc_off = 0;
+    struct st_ptls_mbedtls_chacha20_context_t *ctx = (struct st_ptls_mbedtls_chacha20_context_t *)_ctx;
 
     if (mbedtls_chacha20_update(&ctx->mctx, len, 
         (const uint8_t*)input, (uint8_t*)output) != 0) {
@@ -406,13 +405,13 @@ static void ptls_mbedtls_chacha20_transform(ptls_cipher_context_t *_ctx, void *o
 
 static void ptls_mbedtls_chacha20_dispose(ptls_cipher_context_t *_ctx)
 {
-    struct st_ptls_mbedtls_chacha20_context_t *ctx = (struct st_ptls_mbedtls_aes_context_t *)_ctx;
+    struct st_ptls_mbedtls_chacha20_context_t *ctx = (struct st_ptls_mbedtls_chacha20_context_t *)_ctx;
     mbedtls_chacha20_free(&ctx->mctx);
 }
 
 static int ptls_mbedtls_cipher_setup_crypto_chacha20(ptls_cipher_context_t *_ctx, int is_enc, const void *key)
 {
-    struct st_ptls_mbedtls_chacha20_context_t *ctx = (struct st_ptls_mbedtls_aes_context_t *)_ctx;
+    struct st_ptls_mbedtls_chacha20_context_t *ctx = (struct st_ptls_mbedtls_chacha20_context_t *)_ctx;
     int ret = 0;
 
     mbedtls_chacha20_init(&ctx->mctx);

--- a/lib/ptls_mbedtls.c
+++ b/lib/ptls_mbedtls.c
@@ -750,7 +750,7 @@ ptls_aead_algorithm_t ptls_mbedtls_aes256gcm = {
     ptls_mbedtls_aead_setup_crypto
 };
 
-ptls_aead_algorithm_t ptls_minicrypto_chacha20poly1305 = {
+ptls_aead_algorithm_t ptls_mbedtls_chacha20poly1305 = {
     "CHACHA20-POLY1305",
     PTLS_CHACHA20POLY1305_CONFIDENTIALITY_LIMIT,
     PTLS_CHACHA20POLY1305_INTEGRITY_LIMIT,

--- a/lib/ptls_mbedtls.c
+++ b/lib/ptls_mbedtls.c
@@ -767,3 +767,20 @@ ptls_aead_algorithm_t ptls_mbedtls_chacha20poly1305 = {
     sizeof(struct ptls_mbedtls_aead_context_t),
     ptls_mbedtls_aead_setup_crypto
 };
+
+ptls_cipher_suite_t ptls_mbedtls_aes128gcmsha256 = {.id = PTLS_CIPHER_SUITE_AES_128_GCM_SHA256,
+.name = PTLS_CIPHER_SUITE_NAME_AES_128_GCM_SHA256,
+.aead = &ptls_mbedtls_aes128gcm,
+.hash = &ptls_mbedtls_sha256};
+
+#if defined(MBEDTLS_SHA384_C)
+ptls_cipher_suite_t ptls_mbedtls_aes256gcmsha384 = {.id = PTLS_CIPHER_SUITE_AES_256_GCM_SHA384,
+.name = PTLS_CIPHER_SUITE_NAME_AES_256_GCM_SHA384,
+.aead = &ptls_mbedtls_aes256gcm,
+.hash = &ptls_mbedtls_sha384};
+#endif
+
+ptls_cipher_suite_t ptls_mbedtls_chacha20poly1305sha256 = {.id = PTLS_CIPHER_SUITE_CHACHA20_POLY1305_SHA256,
+.name = PTLS_CIPHER_SUITE_NAME_CHACHA20_POLY1305_SHA256,
+.aead = &ptls_mbedtls_chacha20poly1305,
+.hash = &ptls_mbedtls_sha256};

--- a/lib/ptls_mbedtls.c
+++ b/lib/ptls_mbedtls.c
@@ -15,6 +15,18 @@
 #include "mbedtls/aes.h"
 #include "mbedtls/chacha20.h"
 
+/* Random number generator.
+* This is a call to the PSA random number generator, which according
+* to the documentation meets cryptographic requirements.
+*/
+
+void ptls_mbedtls_random_bytes(void* buf, size_t len)
+{
+    if (psa_generate_random((uint8_t*)buf, len) != 0) {
+        memset(buf, 0, len);
+    }
+}
+
 /* Definitions for hash algorithms.
 * In Picotls, these are described by the stucture
 * ptls_hash_algorithm_t, which include the function

--- a/t/ptls_mbedtls.c
+++ b/t/ptls_mbedtls.c
@@ -36,6 +36,7 @@
 #include "picotls/ptls_mbedtls.h"
 #include "picotls/minicrypto.h"
 #include "../deps/picotest/picotest.h"
+#include "test.h"
 
 static int random_trial()
 {
@@ -401,6 +402,24 @@ static void test_chacha20poly1305_sha256(void)
     ok(!!"success");
 }
 
+static void test_secp256r1(void)
+{
+    test_key_exchange(&ptls_mbedtls_secp256r1, &ptls_minicrypto_secp256r1);
+    test_key_exchange(&ptls_minicrypto_secp256r1, &ptls_mbedtls_secp256r1);
+}
+
+static void test_x25519(void)
+{
+    test_key_exchange(&ptls_mbedtls_x25519, &ptls_minicrypto_x25519);
+    test_key_exchange(&ptls_minicrypto_x25519, &ptls_mbedtls_x25519);
+}
+
+static void test_key_exchanges(void)
+{
+    subtest("secp256r1", test_secp256r1);
+    subtest("x25519", test_x25519);
+}
+
 int main(int argc, char **argv)
 {
     /* Initialize the PSA crypto library. */
@@ -426,6 +445,7 @@ int main(int argc, char **argv)
     subtest("aes256gcm_sha384", test_aes256gcm_sha384);
 #endif
     subtest("chacha20poly1305_sha256", test_chacha20poly1305_sha256);
+    subtest("key_exchanges", test_key_exchanges);
     /* Deinitialize the PSA crypto library. */
     mbedtls_psa_crypto_free();
 

--- a/t/ptls_mbedtls.c
+++ b/t/ptls_mbedtls.c
@@ -330,6 +330,14 @@ static void test_aes256ctr(void)
     ok(!!"success");
 }
 
+static void test_chacha20(void)
+{
+    if (test_cipher(&ptls_mbedtls_chacha20, &ptls_minicrypto_chacha20) != 0) {
+        ok(!"fail");
+    }
+    ok(!!"success");
+}
+
 static void test_aes128gcm_sha256(void)
 {
     if (test_aead(&ptls_mbedtls_aes128gcm, &ptls_mbedtls_sha256, &ptls_minicrypto_aes128gcm, &ptls_minicrypto_sha256) != 0) {
@@ -350,7 +358,7 @@ static void test_aes256gcm_sha384(void)
 
 static void test_chacha20poly1305_sha256(void)
 {
-    if (test_aead(&ptls_minicrypto_chacha20poly1305, &ptls_mbedtls_sha256, &ptls_minicrypto_chacha20poly1305, &ptls_minicrypto_sha256) != 0) {
+    if (test_aead(&ptls_mbedtls_chacha20poly1305, &ptls_mbedtls_sha256, &ptls_minicrypto_chacha20poly1305, &ptls_minicrypto_sha256) != 0) {
         ok(!"fail");
     }
     ok(!!"success");

--- a/t/ptls_mbedtls.c
+++ b/t/ptls_mbedtls.c
@@ -29,7 +29,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <picotls.h>
-#include "mbedtls/config.h"
+#include "mbedtls/mbedtls_config.h"
 #include "mbedtls/build_info.h"
 #include "psa/crypto.h"
 #include "psa/crypto_struct.h"
@@ -278,16 +278,6 @@ static void test_sha256(void)
     ok(!!"success");
 }
 
-static void test_sha512(void)
-{
-    if (test_hash(&ptls_mbedtls_sha512, &ptls_minicrypto_sha512) != 0) {
-        ok(!"fail");
-        return;
-    }
-    ok(!!"success");
-}
-
-
 #if defined(MBEDTLS_SHA384_C)
 static void test_sha384(void)
 {
@@ -357,9 +347,8 @@ int main(int argc, char **argv)
     }
     /* Series of test to check consistency between wrapped mbedtls and minicrypto */
     subtest("sha256", test_sha256);
-    subtest("sha512", test_sha256);
 #if defined(MBEDTLS_SHA384_C)
-    subtest("sha384", test_sha256);
+    subtest("sha384", test_sha384);
 #endif
     subtest("label_sha256", test_label_sha256);
     subtest("aes128ecb", test_aes128ecb);

--- a/t/ptls_mbedtls.c
+++ b/t/ptls_mbedtls.c
@@ -348,6 +348,14 @@ static void test_aes256gcm_sha384(void)
 }
 #endif
 
+static void test_chacha20poly1305_sha256(void)
+{
+    if (test_aead(&ptls_minicrypto_chacha20poly1305, &ptls_mbedtls_sha256, &ptls_minicrypto_chacha20poly1305, &ptls_minicrypto_sha256) != 0) {
+        ok(!"fail");
+    }
+    ok(!!"success");
+}
+
 int main(int argc, char **argv)
 {
     /* Initialize the PSA crypto library. */

--- a/t/ptls_mbedtls.c
+++ b/t/ptls_mbedtls.c
@@ -29,6 +29,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <picotls.h>
+#include "mbedtls/config.h"
 #include "mbedtls/build_info.h"
 #include "psa/crypto.h"
 #include "psa/crypto_struct.h"
@@ -68,9 +69,9 @@ static int test_hash(ptls_hash_algorithm_t* algo, ptls_hash_algorithm_t* ref)
 {
     int ret = 0;
     uint8_t input[1234];
-    uint8_t final_hash[32];
-    uint8_t final_ref[32];
-    uint8_t hash1[32], hash2[32], href1[32], href2[32];
+    uint8_t final_hash[64];
+    uint8_t final_ref[64];
+    uint8_t hash1[64], hash2[64], href1[64], href2[64];
 
     memset(input, 0xba, sizeof(input));
 
@@ -277,6 +278,27 @@ static void test_sha256(void)
     ok(!!"success");
 }
 
+static void test_sha512(void)
+{
+    if (test_hash(&ptls_mbedtls_sha512, &ptls_minicrypto_sha512) != 0) {
+        ok(!"fail");
+        return;
+    }
+    ok(!!"success");
+}
+
+
+#if defined(MBEDTLS_SHA384_C)
+static void test_sha384(void)
+{
+    if (test_hash(&ptls_mbedtls_sha384, &ptls_minicrypto_sha384) != 0) {
+        ok(!"fail");
+        return;
+    }
+    ok(!!"success");
+}
+#endif
+
 static void test_label_sha256(void)
 {
     if (test_label(&ptls_mbedtls_sha256, &ptls_minicrypto_sha256) != 0) {
@@ -335,6 +357,10 @@ int main(int argc, char **argv)
     }
     /* Series of test to check consistency between wrapped mbedtls and minicrypto */
     subtest("sha256", test_sha256);
+    subtest("sha512", test_sha256);
+#if defined(MBEDTLS_SHA384_C)
+    subtest("sha384", test_sha256);
+#endif
     subtest("label_sha256", test_label_sha256);
     subtest("aes128ecb", test_aes128ecb);
     subtest("aes128ctr", test_aes128ctr);

--- a/t/ptls_mbedtls.c
+++ b/t/ptls_mbedtls.c
@@ -37,7 +37,9 @@
 #include "picotls/minicrypto.h"
 #include "../deps/picotest/picotest.h"
 
-static int test_random()
+#define PTLS_MBEDTLS_RANDOM_TEST_LENGTH 1021;
+
+static int random_trial()
 {
     /* The random test is just trying to check that we call the API properly. 
     * This is done by getting a vector of 1021 bytes, computing the sum of
@@ -63,6 +65,15 @@ static int test_random()
     }
 
     return ret;
+}
+
+static void test_random(void)
+{
+    if (random_trial() != 0) {
+        ok(!"fail");
+        return;
+    }
+    ok(!!"success");
 }
 
 static int hash_trial(ptls_hash_algorithm_t* algo, const uint8_t* input, size_t len1, size_t len2, uint8_t* final_hash)

--- a/t/ptls_mbedtls.c
+++ b/t/ptls_mbedtls.c
@@ -37,8 +37,6 @@
 #include "picotls/minicrypto.h"
 #include "../deps/picotest/picotest.h"
 
-#define PTLS_MBEDTLS_RANDOM_TEST_LENGTH 1021;
-
 static int random_trial()
 {
     /* The random test is just trying to check that we call the API properly. 
@@ -50,14 +48,14 @@ static int random_trial()
     * Note that this does not actually test the random generator.
     */
 
-    uint8_t buf[PTLS_MBEDTLS_RANDOM_TEST_LENGTH];
+    uint8_t buf[1021];
     uint64_t sum = 0;
     const uint64_t max_sum_1021 = 149505;
     const uint64_t min_sum_1021 = 110849;
     int ret = 0;
 
-    ptls_mbedtls_random_bytes(buf, PTLS_MBEDTLS_RANDOM_TEST_LENGTH);
-    for (size_t i = 0; i < PTLS_MBEDTLS_RANDOM_TEST_LENGTH; i++) {
+    ptls_mbedtls_random_bytes(buf, sizeof(buf));
+    for (size_t i = 0; i < sizeof(buf); i++) {
         sum += buf[i];
     }
     if (sum > max_sum_1021 || sum < min_sum_1021) {

--- a/t/ptls_mbedtls.c
+++ b/t/ptls_mbedtls.c
@@ -1,0 +1,349 @@
+/*
+* Copyright (c) 2023, Christian Huitema
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to
+* deal in the Software without restriction, including without limitation the
+* rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+* sell copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+* IN THE SOFTWARE.
+*/
+
+#ifdef _WINDOWS
+#include "wincompat.h"
+#endif
+
+#include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <picotls.h>
+#include "mbedtls/build_info.h"
+#include "psa/crypto.h"
+#include "psa/crypto_struct.h"
+#include "picotls/ptls_mbedtls.h"
+#include "picotls/minicrypto.h"
+#include "../deps/picotest/picotest.h"
+
+static int hash_trial(ptls_hash_algorithm_t* algo, const uint8_t* input, size_t len1, size_t len2, uint8_t* final_hash)
+{
+    int ret = 0;
+    ptls_hash_context_t* hash_ctx = algo->create();
+
+    hash_ctx->update(hash_ctx, input, len1);
+    if (len2 > 0) {
+        hash_ctx->update(hash_ctx, input + len1, len2);
+    }
+    hash_ctx->final(hash_ctx, final_hash, PTLS_HASH_FINAL_MODE_FREE);
+
+    return ret;
+}
+
+static int hash_reset_trial(ptls_hash_algorithm_t* algo, const uint8_t* input, size_t len1, size_t len2, 
+    uint8_t* hash1, uint8_t* hash2)
+{
+    int ret = 0;
+    ptls_hash_context_t* hash_ctx = algo->create();
+
+    hash_ctx->update(hash_ctx, input, len1);
+    hash_ctx->final(hash_ctx, hash1, PTLS_HASH_FINAL_MODE_RESET);
+    hash_ctx->update(hash_ctx, input + len1, len2);
+    hash_ctx->final(hash_ctx, hash2, PTLS_HASH_FINAL_MODE_FREE);
+
+    return ret;
+}
+
+static int test_hash(ptls_hash_algorithm_t* algo, ptls_hash_algorithm_t* ref)
+{
+    int ret = 0;
+    uint8_t input[1234];
+    uint8_t final_hash[32];
+    uint8_t final_ref[32];
+    uint8_t hash1[32], hash2[32], href1[32], href2[32];
+
+    memset(input, 0xba, sizeof(input));
+
+    ret = hash_trial(algo, input, sizeof(input), 0, final_hash);
+    if (ret == 0) {
+        ret = hash_trial(ref, input, sizeof(input), 0, final_ref);
+    }
+    if (ret == 0) {
+        if (memcmp(final_hash, final_ref, ref->digest_size) != 0) {
+            ret = -1;
+        }
+    }
+    if (ret == 0) {
+        ret = hash_trial(algo, input, sizeof(input) - 17, 17, final_hash);
+    }
+    if (ret == 0) {
+        if (memcmp(final_hash, final_ref, ref->digest_size) != 0) {
+            ret = -1;
+        }
+    }
+
+    if (ret == 0) {
+        ret = hash_reset_trial(algo, input, sizeof(input) - 126, 126, hash1, hash2);
+    }
+    if (ret == 0) {
+        ret = hash_reset_trial(ref, input, sizeof(input) - 126, 126, href1, href2);
+    }
+    if (ret == 0) {
+        if (memcmp(hash1, href1, ref->digest_size) != 0) {
+            ret = -1;
+        }
+        else if (memcmp(hash2, href2, ref->digest_size) != 0) {
+            ret = -1;
+        }
+    }
+
+    return ret;
+}
+
+static int cipher_trial(ptls_cipher_algorithm_t * cipher, const uint8_t * key, const uint8_t * iv, int is_enc, const uint8_t * v_in, uint8_t * v_out1, uint8_t * v_out2, size_t len)
+{
+    int ret = 0;
+    ptls_cipher_context_t* test_cipher = ptls_cipher_new(cipher, is_enc, key);
+    if (test_cipher == NULL) {
+        ret = -1;
+    } else {
+        if (test_cipher->do_init != NULL) {
+            ptls_cipher_init(test_cipher, iv);
+        }
+        ptls_cipher_encrypt(test_cipher, v_out1, v_in, len);
+        if (test_cipher->do_init != NULL) {
+            ptls_cipher_init(test_cipher, iv);
+        }
+        ptls_cipher_encrypt(test_cipher, v_out2, v_out1, len);
+        ptls_cipher_free(test_cipher);
+    }
+
+    return ret;
+}
+
+static int test_cipher(ptls_cipher_algorithm_t * cipher, ptls_cipher_algorithm_t * cipher_ref)
+{
+    uint8_t key[32];
+    uint8_t iv[16];
+    uint8_t v_in[16];
+    uint8_t v_out_1a[16], v_out_2a[16], v_out_1b[16], v_out_2b[16], v_out_1d[16], v_out_2d[16];
+    int ret = 0;
+
+    /* Set initial values */
+    memset(key, 0x55, sizeof(key));
+    memset(iv, 0x33, sizeof(iv));
+    memset(v_in, 0xaa, sizeof(v_in));
+
+    /* Encryption test */
+    ret = cipher_trial(cipher, key, iv, 1, v_in, v_out_1a, v_out_2a, 16);
+    if (ret == 0) {
+        ret = cipher_trial(cipher_ref, key, iv, 1, v_in, v_out_1b, v_out_2b, 16);
+    }
+    if (ret == 0) {
+        if (memcmp(v_out_1a, v_out_1b, 16) != 0) {
+            ret = -1;
+        }
+        else if (memcmp(v_out_2a, v_out_2b, 16) != 0) {
+            ret = -1;
+        }
+    }
+    /* decryption test */
+    if (ret == 0) {
+        ret = cipher_trial(cipher, key, iv, 0, v_out_2a, v_out_1d, v_out_2d, 16);
+    }
+    if (ret == 0) {
+        if (memcmp(v_out_1a, v_out_1d, 16) != 0) {
+            ret = -1;
+        }
+        else if (memcmp(v_out_2d, v_in, 16) != 0) {
+            ret = -1;
+        }
+    }
+
+    return ret;
+}
+
+static int label_test(ptls_hash_algorithm_t * hash, uint8_t * v_out, size_t o_len, const uint8_t * secret,
+    char const * label, char const * label_prefix)
+{
+    uint8_t h_val_v[32];
+    ptls_iovec_t h_val = { 0 };
+    ptls_iovec_t s_vec = { 0 };
+    s_vec.base = (uint8_t *)secret;
+    s_vec.len = 32;
+    h_val.base = h_val_v;
+    h_val.len = 32;
+    memset(h_val_v, 0, sizeof(h_val_v));
+
+    ptls_hkdf_expand_label(hash, v_out, o_len, s_vec, label, h_val, label_prefix);
+    return 0;
+}
+
+static int test_label(ptls_hash_algorithm_t* hash, ptls_hash_algorithm_t* ref)
+{
+    int ret = 0;
+    uint8_t v_out[16], v_ref[16];
+    uint8_t secret[32];
+    char const* label = "label";
+    char const* label_prefix = "label_prefix";
+    memset(secret, 0x5e, sizeof(secret));
+
+    ret = label_test(hash, v_out, 16, secret, label, label_prefix);
+
+    if (ret == 0) {
+        ret = label_test(ref, v_ref, 16, secret, label, label_prefix);
+    }
+
+    if (ret == 0 && memcmp(v_out, v_ref, 16) != 0) {
+        ret = -1;
+    }
+
+    return ret;
+}
+
+static int aead_trial(ptls_aead_algorithm_t * algo, ptls_hash_algorithm_t * hash, const uint8_t * secret, int is_enc, 
+    const uint8_t * v_in, size_t len, uint8_t * aad, size_t aad_len, uint64_t seq, uint8_t * v_out, size_t * o_len)
+{
+    int ret = 0;
+    ptls_aead_context_t* aead = ptls_aead_new(algo, hash, is_enc, secret, "test_aead");
+
+    if (aead == NULL) {
+        ret = -1;
+    }
+    else{
+        if (is_enc) {
+            *o_len = ptls_aead_encrypt(aead, v_out, v_in, len, seq, aad, aad_len);
+            if (*o_len != len + algo->tag_size) {
+                ret = -1;
+            }
+        }
+        else {
+            *o_len = ptls_aead_decrypt(aead, v_out, v_in, len, seq, aad, aad_len);
+            if (*o_len != len - algo->tag_size) {
+                ret = -1;
+            }
+        }
+        ptls_aead_free(aead);
+    }
+    return ret;
+}
+
+static int test_aead(ptls_aead_algorithm_t* algo, ptls_hash_algorithm_t* hash, ptls_aead_algorithm_t* ref, ptls_hash_algorithm_t* hash_ref)
+{
+    uint8_t secret[32];
+    uint8_t v_in[1234];
+    uint8_t aad[17];
+    uint8_t v_out_a[1250], v_out_b[1250], v_out_r[1250];
+    size_t olen_a, olen_b, olen_r;
+    uint64_t seq = 12345;
+    int ret = 0;
+
+    memset(secret, 0x58, sizeof(secret));
+    memset(v_in, 0x12, sizeof(v_in));
+    memset(aad, 0xaa, sizeof(aad));
+
+    ret = aead_trial(algo, hash, secret, 1, v_in, sizeof(v_in), aad, sizeof(aad), seq, v_out_a, &olen_a);
+    if (ret == 0) {
+        ret = aead_trial(ref, hash_ref, secret, 1, v_in, sizeof(v_in), aad, sizeof(aad), seq, v_out_b, &olen_b);
+    }
+    if (ret == 0 && (olen_a != olen_b || memcmp(v_out_a, v_out_b, olen_a) != 0)) {
+        ret = -1;
+    }
+    if (ret == 0) {
+        ret = aead_trial(ref, hash_ref, secret, 0, v_out_a, olen_a, aad, sizeof(aad), seq, v_out_r, &olen_r);
+    }
+    if (ret == 0 && (olen_r != sizeof(v_in) || memcmp(v_in, v_out_r, sizeof(v_in)) != 0)) {
+        ret = -1;
+    }
+    return ret;
+}
+
+static void test_sha256(void)
+{
+    if (test_hash(&ptls_mbedtls_sha256, &ptls_minicrypto_sha256) != 0) {
+        ok(!"fail");
+        return;
+    }
+    ok(!!"success");
+}
+
+static void test_label_sha256(void)
+{
+    if (test_label(&ptls_mbedtls_sha256, &ptls_minicrypto_sha256) != 0) {
+        ok(!"fail");
+        return;
+    }
+    ok(!!"success");
+}
+
+static void test_aes128ecb(void)
+{
+    if (test_cipher(ptls_mbedtls_aes128ecb, ptls_minicrypto_aes128ecb) != 0) {
+        ok(!"fail");
+    }
+    ok(!!"success");
+}
+
+static void test_aes128ctr(void)
+{
+    if (test_cipher(ptls_mbedtls_aes128ctr, ptls_minicrypto_aes128ctr) != 0) {
+        ok(!"fail");
+    }
+    ok(!!"success");
+}
+
+static void test_aes256ecb(void)
+{
+    if (test_cipher(ptls_mbedtls_aes256ecb, ptls_minicrypto_aes256ecb) != 0) {
+        ok(!"fail");
+    }
+    ok(!!"success");
+}
+
+static void test_aes256ctr(void)
+{
+    if (test_cipher(ptls_mbedtls_aes256ctr, ptls_minicrypto_aes2568ctr) != 0) {
+        ok(!"fail");
+    }
+    ok(!!"success");
+}
+
+static void test_aes128gcm_sha256(void)
+{
+    if (test_aead(&ptls_mbedtls_aes128gcm, &ptls_mbedtls_sha256, &ptls_minicrypto_aes128gcm, &ptls_minicrypto_sha256) != 0) {
+        ok(!"fail");
+    }
+    ok(!!"success");
+}
+
+int main(int argc, char **argv)
+{
+    /* Initialize the PSA crypto library. */
+    if ((status = psa_crypto_init()) != PSA_SUCCESS) {
+        note("psa_crypto_init fails.");
+        return done_testing();
+    }
+    /* Series of test to check consistency between wrapped mbedtls and minicrypto */
+    subtest("sha256", test_sha256);
+    subtest("label_sha256", test_label_sha256);
+    subtest("aes128ecb", test_aes128ecb);
+    subtest("aes128ctr", test_aes128ctr);
+    subtest("aes256ecb", test_aes256ecb);
+    subtest("aes256ctr", test_aes256ctr);
+    subtest("aes128gcm_sha256", test_aes128gcm_sha256);
+
+    /* Deinitialize the PSA crypto library. */
+    mbedtls_psa_crypto_free();
+
+    return done_testing();
+}

--- a/t/ptls_mbedtls.c
+++ b/t/ptls_mbedtls.c
@@ -312,7 +312,7 @@ static void test_aes256ecb(void)
 
 static void test_aes256ctr(void)
 {
-    if (test_cipher(&ptls_mbedtls_aes256ctr, &ptls_minicrypto_aes2568ctr) != 0) {
+    if (test_cipher(&ptls_mbedtls_aes256ctr, &ptls_minicrypto_aes256ctr) != 0) {
         ok(!"fail");
     }
     ok(!!"success");

--- a/t/ptls_mbedtls.c
+++ b/t/ptls_mbedtls.c
@@ -288,7 +288,7 @@ static void test_label_sha256(void)
 
 static void test_aes128ecb(void)
 {
-    if (test_cipher(ptls_mbedtls_aes128ecb, ptls_minicrypto_aes128ecb) != 0) {
+    if (test_cipher(&ptls_mbedtls_aes128ecb, &ptls_minicrypto_aes128ecb) != 0) {
         ok(!"fail");
     }
     ok(!!"success");
@@ -296,7 +296,7 @@ static void test_aes128ecb(void)
 
 static void test_aes128ctr(void)
 {
-    if (test_cipher(ptls_mbedtls_aes128ctr, ptls_minicrypto_aes128ctr) != 0) {
+    if (test_cipher(&ptls_mbedtls_aes128ctr, &ptls_minicrypto_aes128ctr) != 0) {
         ok(!"fail");
     }
     ok(!!"success");
@@ -304,7 +304,7 @@ static void test_aes128ctr(void)
 
 static void test_aes256ecb(void)
 {
-    if (test_cipher(ptls_mbedtls_aes256ecb, ptls_minicrypto_aes256ecb) != 0) {
+    if (test_cipher(&ptls_mbedtls_aes256ecb, &ptls_minicrypto_aes256ecb) != 0) {
         ok(!"fail");
     }
     ok(!!"success");
@@ -312,7 +312,7 @@ static void test_aes256ecb(void)
 
 static void test_aes256ctr(void)
 {
-    if (test_cipher(ptls_mbedtls_aes256ctr, ptls_minicrypto_aes2568ctr) != 0) {
+    if (test_cipher(&ptls_mbedtls_aes256ctr, &ptls_minicrypto_aes2568ctr) != 0) {
         ok(!"fail");
     }
     ok(!!"success");
@@ -329,7 +329,7 @@ static void test_aes128gcm_sha256(void)
 int main(int argc, char **argv)
 {
     /* Initialize the PSA crypto library. */
-    if ((status = psa_crypto_init()) != PSA_SUCCESS) {
+    if (psa_crypto_init() != PSA_SUCCESS) {
         note("psa_crypto_init fails.");
         return done_testing();
     }

--- a/t/ptls_mbedtls.c
+++ b/t/ptls_mbedtls.c
@@ -241,7 +241,7 @@ static int aead_trial(ptls_aead_algorithm_t * algo, ptls_hash_algorithm_t * hash
 
 static int test_aead(ptls_aead_algorithm_t* algo, ptls_hash_algorithm_t* hash, ptls_aead_algorithm_t* ref, ptls_hash_algorithm_t* hash_ref)
 {
-    uint8_t secret[32];
+    uint8_t secret[64];
     uint8_t v_in[1234];
     uint8_t aad[17];
     uint8_t v_out_a[1250], v_out_b[1250], v_out_r[1250];
@@ -338,6 +338,16 @@ static void test_aes128gcm_sha256(void)
     ok(!!"success");
 }
 
+#if defined(MBEDTLS_SHA384_C)
+static void test_aes256gcm_sha384(void)
+{
+    if (test_aead(&ptls_mbedtls_aes256gcm, &ptls_mbedtls_sha384, &ptls_minicrypto_aes256gcm, &ptls_minicrypto_sha384) != 0) {
+        ok(!"fail");
+    }
+    ok(!!"success");
+}
+#endif
+
 int main(int argc, char **argv)
 {
     /* Initialize the PSA crypto library. */
@@ -356,7 +366,9 @@ int main(int argc, char **argv)
     subtest("aes256ecb", test_aes256ecb);
     subtest("aes256ctr", test_aes256ctr);
     subtest("aes128gcm_sha256", test_aes128gcm_sha256);
-
+#if defined(MBEDTLS_SHA384_C)
+    subtest("aes256gcm_sha384", test_aes256gcm_sha384);
+#endif
     /* Deinitialize the PSA crypto library. */
     mbedtls_psa_crypto_free();
 

--- a/t/ptls_mbedtls.c
+++ b/t/ptls_mbedtls.c
@@ -377,6 +377,7 @@ int main(int argc, char **argv)
 #if defined(MBEDTLS_SHA384_C)
     subtest("aes256gcm_sha384", test_aes256gcm_sha384);
 #endif
+    subtest("chacha20poly1305_sha256", test_chacha20poly1305_sha256);
     /* Deinitialize the PSA crypto library. */
     mbedtls_psa_crypto_free();
 

--- a/t/ptls_mbedtls.c
+++ b/t/ptls_mbedtls.c
@@ -381,6 +381,7 @@ int main(int argc, char **argv)
     subtest("aes128ctr", test_aes128ctr);
     subtest("aes256ecb", test_aes256ecb);
     subtest("aes256ctr", test_aes256ctr);
+    subtest("chacha20", test_chacha20);
     subtest("aes128gcm_sha256", test_aes128gcm_sha256);
 #if defined(MBEDTLS_SHA384_C)
     subtest("aes256gcm_sha384", test_aes256gcm_sha384);

--- a/t/ptlsbench.c
+++ b/t/ptlsbench.c
@@ -36,7 +36,9 @@
 #include "picotls/minicrypto.h"
 #include "picotls/openssl.h"
 #ifndef _WINDOWS
+#ifdef PTLS_HAVE_FUSION
 #include "picotls/fusion.h"
+#endif
 #endif
 #include <openssl/opensslv.h>
 
@@ -268,8 +270,10 @@ static ptls_bench_entry_t aead_list[] = {
     {"ptlsbcrypt", "aes256gcm", &ptls_bcrypt_aes256gcm, &ptls_bcrypt_sha384, 1},
 #endif
 #if !defined(_WINDOWS)
+#ifdef PTLS_HAVE_FUSION
     {"fusion", "aes128gcm", &ptls_fusion_aes128gcm, &ptls_minicrypto_sha256, 1},
     {"fusion", "aes256gcm", &ptls_fusion_aes256gcm, &ptls_minicrypto_sha384, 1},
+#endif
 #endif
 #if PTLS_OPENSSL_HAVE_CHACHA20_POLY1305
     {"openssl", "chacha20poly1305", &ptls_openssl_chacha20poly1305, &ptls_minicrypto_sha256, 1},

--- a/t/ptlsbench.c
+++ b/t/ptlsbench.c
@@ -57,6 +57,12 @@
 #endif
 #endif
 
+#ifdef PTLS_HAVE_MBEDTLS
+#include "mbedtls/build_info.h"
+#include "psa/crypto.h"
+#include "picotls/ptls_mbedtls.h"
+#endif
+
 /* Time in microseconds */
 static uint64_t bench_time()
 {
@@ -269,7 +275,15 @@ static ptls_bench_entry_t aead_list[] = {
     {"openssl", "chacha20poly1305", &ptls_openssl_chacha20poly1305, &ptls_minicrypto_sha256, 1},
 #endif
     {"openssl", "aes128gcm", &ptls_openssl_aes128gcm, &ptls_minicrypto_sha256, 1},
-    {"openssl", "aes256gcm", &ptls_openssl_aes256gcm, &ptls_minicrypto_sha384, 1}};
+    {"openssl", "aes256gcm", &ptls_openssl_aes256gcm, &ptls_minicrypto_sha384, 1},
+#ifdef PTLS_HAVE_MBEDTLS
+    {"mbedtls", "aes128gcm",& ptls_mbedtls_aes128gcm,& ptls_mbedtls_sha256, 1},
+#if defined(MBEDTLS_SHA384_C)
+    { "mbedtls", "aes256gcm", &ptls_mbedtls_aes256gcm, &ptls_mbedtls_sha384, 1 },
+#endif
+    { "mbedtls", "chacha20poly1305", &ptls_mbedtls_chacha20poly1305, &ptls_mbedtls_sha256, 1 },
+#endif
+};
 
 static size_t nb_aead_list = sizeof(aead_list) / sizeof(ptls_bench_entry_t);
 
@@ -323,6 +337,13 @@ int main(int argc, char **argv)
     }
 #endif
 
+#ifdef PTLS_HAVE_MBEDTLS
+    if (psa_crypto_init() != PSA_SUCCESS) {
+        note("psa_crypto_init fails.");
+        exit(-1);
+    }
+#endif
+
     if (argc == 2 && strcmp(argv[1], "-f") == 0) {
         force_all_tests = 1;
     } else if (argc > 1) {
@@ -345,6 +366,11 @@ int main(int argc, char **argv)
     if (s == 0) {
         printf("Unexpected value of test sum s = %llx\n", (unsigned long long)s);
     }
+
+#ifdef PTLS_HAVE_MBEDTLS
+    /* Deinitialize the PSA crypto library. */
+    mbedtls_psa_crypto_free();
+#endif
 
     return ret;
 }

--- a/t/ptlsbench.c
+++ b/t/ptlsbench.c
@@ -339,7 +339,7 @@ int main(int argc, char **argv)
 
 #ifdef PTLS_HAVE_MBEDTLS
     if (psa_crypto_init() != PSA_SUCCESS) {
-        note("psa_crypto_init fails.");
+        fprintf(stderr, "psa_crypto_init fails.\n");
         exit(-1);
     }
 #endif


### PR DESCRIPTION
The goal of this PR is to support MbedTLS as an alternative to OpenSSL, especially on "embedded" platforms.

The first milestone is to verify that CMake and Make work properly and produce a library `picotls-mbedtls` and a test program `t.mbedtls` when using the option "WITH_MBEDTLS=ON". The current set of supported algorithms is minimal -- mainly, aes128_gcm with sha256. MbedTLS supports a much larger range of algorithm, which will be added later.