### PR TITLE
[minicrypto][boringssl] x25519 key derivation must fail when output is all-zero

### DIFF
--- a/lib/cifra/x25519.c
+++ b/lib/cifra/x25519.c
@@ -46,7 +46,7 @@ static int x25519_derive_secret(ptls_iovec_t *secret, const uint8_t *clientpriv,
 
     cf_curve25519_mul(secret->base, clientpriv != NULL ? clientpriv : serverpriv, clientpriv != NULL ? serverpub : clientpub);
 
-    static const uint8_t zeros[X25519_KEY_SIZE] = {};
+    static const uint8_t zeros[X25519_KEY_SIZE] = {0};
     if (ptls_mem_equal(secret->base, zeros, sizeof(zeros))) {
         free(secret->base);
         return PTLS_ERROR_INCOMPATIBLE_KEY;

--- a/lib/cifra/x25519.c
+++ b/lib/cifra/x25519.c
@@ -45,6 +45,13 @@ static int x25519_derive_secret(ptls_iovec_t *secret, const uint8_t *clientpriv,
         return PTLS_ERROR_NO_MEMORY;
 
     cf_curve25519_mul(secret->base, clientpriv != NULL ? clientpriv : serverpriv, clientpriv != NULL ? serverpub : clientpub);
+
+    static const uint8_t zeros[X25519_KEY_SIZE] = {};
+    if (ptls_mem_equal(secret->base, zeros, sizeof(zeros))) {
+        free(secret->base);
+        return PTLS_ERROR_INCOMPATIBLE_KEY;
+    }
+
     secret->len = X25519_KEY_SIZE;
     return 0;
 }
@@ -111,8 +118,10 @@ static int x25519_key_exchange(ptls_key_exchange_algorithm_t *algo, ptls_iovec_t
 
 Exit:
     ptls_clear_memory(priv, sizeof(priv));
-    if (pub != NULL && ret != 0)
+    if (pub != NULL && ret != 0) {
         ptls_clear_memory(pub, X25519_KEY_SIZE);
+        free(pub);
+    }
     return ret;
 }
 

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -542,6 +542,7 @@ static int evp_keyex_on_exchange(ptls_key_exchange_context_t **_ctx, int release
         }
         assert(sk_raw_len == sizeof(sk_raw));
         X25519(secret->base, sk_raw, peerkey.base);
+        ptls_clear_memory(sk_raw, sizeof(sk_raw));
         /* check bad key */
         static const uint8_t zeros[SECRET_SIZE] = {0};
         if (ptls_mem_equal(secret->base, zeros, SECRET_SIZE)) {

--- a/t/picotls.c
+++ b/t/picotls.c
@@ -2188,4 +2188,10 @@ void test_key_exchange(ptls_key_exchange_algorithm_t *client, ptls_key_exchange_
     ret = ctx->on_exchange(&ctx, 1, NULL, ptls_iovec_init(NULL, 0));
     ok(ret == 0);
     ok(ctx == NULL);
+
+    /* test derivation failure. In case of X25519, the outcome is derived key becoming all-zero and rejected. In case of others, it
+     * is most likely that the provided key would be rejected. */
+    static uint8_t zeros[32] = {};
+    ret = server->exchange(server, &server_pubkey, &server_secret, ptls_iovec_init(zeros, sizeof(zeros)));
+    ok(ret != 0);
 }

--- a/t/picotls.c
+++ b/t/picotls.c
@@ -2191,7 +2191,7 @@ void test_key_exchange(ptls_key_exchange_algorithm_t *client, ptls_key_exchange_
 
     /* test derivation failure. In case of X25519, the outcome is derived key becoming all-zero and rejected. In case of others, it
      * is most likely that the provided key would be rejected. */
-    static uint8_t zeros[32] = {};
+    static uint8_t zeros[32] = {0};
     ret = server->exchange(server, &server_pubkey, &server_secret, ptls_iovec_init(zeros, sizeof(zeros)));
     ok(ret != 0);
 }


### PR DESCRIPTION
RFC 7748 states we may fail if the derived key is all-zero, RFC 8446 states we MUST.

In the OpenSSL backend we do the check (to be accurate OpenSSL does), but we have not been doing anything on the side of minicrypto and boringssl.

This implements the checks, as well as fixing memory leaks that happen when an error is returned from the derivation function (minicrypto), clearing secrets used (boringssl).