### PR TITLE
[evp_keyex_init] keep refcount unchanged when the function fails

### DIFF
--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -608,6 +608,9 @@ Exit:
     return ret;
 }
 
+/**
+ * Upon success, ownership of `pkey` is transferred to the object being created. Otherwise, the refcount remains unchanged.
+ */
 static int evp_keyex_init(ptls_key_exchange_algorithm_t *algo, ptls_key_exchange_context_t **_ctx, EVP_PKEY *pkey)
 {
     struct st_evp_keyex_context_t *ctx = NULL;
@@ -630,8 +633,10 @@ static int evp_keyex_init(ptls_key_exchange_algorithm_t *algo, ptls_key_exchange
     *_ctx = &ctx->super;
     ret = 0;
 Exit:
-    if (ret != 0 && ctx != NULL)
+    if (ret != 0 && ctx != NULL) {
+        ctx->privkey = NULL; /* do not decrement refcount of pkey in case of error */
         evp_keyex_free(ctx);
+    }
     return ret;
 }
 


### PR DESCRIPTION
`evp_keyex_init` is called from two locations. Both of them assume that if the functions returns zero (success) the ownership of `pkey` is transferred to `evp_pkey_init`, or if the function returns non-zero (failure) the reference count of `pkey` remains as-is.

However, `evp_keyex_init` has been inconsistent in what to do upon failure; it has been retaining reference count as-is if `malloc` failed, but has been decrementing the reference count if `EVP_PKEY_get1_tls_encodedpoint` failed.

This PR address the latter, making sure that if an error is returned the reference count remains as-is.