### PR TITLE
maybe `_mm_insert_epi64` is unavailable on i386?

### DIFF
--- a/cmake/fusion.cmake
+++ b/cmake/fusion.cmake
@@ -14,6 +14,7 @@ FUNCTION (CHECK_FUSION_PREREQUISITES)
         ord0 = _mm256_aesenc_epi128(ord1, ord2);
         ord3 = _mm256_aesenclast_epi128(ord0, ord1);
         ord1 = _mm256_clmulepi64_epi128(ord3, ord2, 0x00);
+        _mm_insert_epi64(_mm_setr_epi32(0, 1, 2, 3), 0, 0);
         return 0;
     }
     " CC_HAS_AESNI256)


### PR DESCRIPTION
Error message of https://github.com/h2o/h2o/issues/3289 indicates that some i386 environments might have access to AVX2 but not to `_mm_insert_epi64` because the latter takes a 64-bit int as an argument.

This PR adds the invocation of `_mm_insert_epi64` to the test code used for checking if fusion can be used, so that fusion would be disabled on environments that lack support for the intrinsic.