### PR TITLE
detect and report TLS buffer overflows

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -248,6 +248,7 @@ extern "C" {
 #define PTLS_ERROR_REJECT_EARLY_DATA (PTLS_ERROR_CLASS_INTERNAL + 9)
 #define PTLS_ERROR_DELEGATE (PTLS_ERROR_CLASS_INTERNAL + 10)
 #define PTLS_ERROR_ASYNC_OPERATION (PTLS_ERROR_CLASS_INTERNAL + 11)
+#define PTLS_ERROR_BLOCK_OVERFLOW (PTLS_ERROR_CLASS_INTERNAL + 12)
 
 #define PTLS_ERROR_INCORRECT_BASE64 (PTLS_ERROR_CLASS_INTERNAL + 50)
 #define PTLS_ERROR_PEM_LABEL_NOT_FOUND (PTLS_ERROR_CLASS_INTERNAL + 51)
@@ -1203,6 +1204,10 @@ static uint8_t *ptls_encode_quicint(uint8_t *p, uint64_t v);
         } while (0);                                                                                                               \
         size_t body_size = (buf)->off - body_start;                                                                                \
         if (capacity != -1) {                                                                                                      \
+            if (body_size >= (size_t)1 << (capacity * 8)) {                                                                        \
+                ret = PTLS_ERROR_BLOCK_OVERFLOW;                                                                                   \
+                goto Exit;                                                                                                         \
+            }                                                                                                                      \
             for (; capacity != 0; --capacity)                                                                                      \
                 (buf)->base[body_start - capacity] = (uint8_t)(body_size >> (8 * (capacity - 1)));                                 \
         } else {                                                                                                                   \

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -1204,7 +1204,7 @@ static uint8_t *ptls_encode_quicint(uint8_t *p, uint64_t v);
         } while (0);                                                                                                               \
         size_t body_size = (buf)->off - body_start;                                                                                \
         if (capacity != -1) {                                                                                                      \
-            if (body_size >= (size_t)1 << (capacity * 8)) {                                                                        \
+            if (capacity < sizeof(size_t) && body_size >= (size_t)1 << (capacity * 8)) {                                           \
                 ret = PTLS_ERROR_BLOCK_OVERFLOW;                                                                                   \
                 goto Exit;                                                                                                         \
             }                                                                                                                      \

--- a/t/picotls.c
+++ b/t/picotls.c
@@ -1901,6 +1901,56 @@ static void test_all_handshakes(void)
         ctx->sign_certificate = second_sc_orig;
 }
 
+static void do_test_tlsblock(size_t len_encoded, size_t max_bytes)
+{
+    ptls_buffer_t buf;
+    const uint8_t *src, *end;
+    int expect_overflow = 0, ret;
+
+    /* block that fits in */
+    ptls_buffer_init(&buf, "", 0);
+    ptls_buffer_push_block(&buf, len_encoded, {
+        for (size_t i = 0; i < max_bytes; ++i)
+            ptls_buffer_push(&buf, (uint8_t)i);
+    });
+    src = buf.base;
+    end = buf.base + buf.off;
+    ptls_decode_block(src, end, len_encoded, {
+        ok(end - src == 255);
+        for (size_t i = 0; i < max_bytes; ++i)
+            ok(*src == i);
+        src = end;
+    });
+
+    /* block that does not fit in */
+    ptls_buffer_push_block(&buf, len_encoded, {
+        for (size_t i = 0; i < max_bytes + 1; i++)
+            ptls_buffer_push(&buf, 1);
+        expect_overflow = 1;
+    });
+    ok(!"fail");
+
+Exit:
+    if (ret != 0) {
+        if (expect_overflow) {
+            ok(ret == PTLS_ERROR_BLOCK_OVERFLOW);
+        } else {
+            ok(!"fail");
+        }
+    }
+    ptls_buffer_dispose(&buf);
+}
+
+static void test_tlsblock8(void)
+{
+    do_test_tlsblock(1, 255);
+}
+
+static void test_tlsblock16(void)
+{
+    do_test_tlsblock(2, 65535);
+}
+
 static void test_quicint(void)
 {
 #define CHECK_PATTERN(output, ...)                                                                                                 \
@@ -2161,6 +2211,8 @@ void test_picotls(void)
     subtest("chacha20", test_chacha20);
     subtest("ffx", test_ffx);
     subtest("base64-decode", test_base64_decode);
+    subtest("tls-block8", test_tlsblock8);
+    subtest("tls-block16", test_tlsblock16);
     subtest("ech", test_ech);
     subtest("fragmented-message", test_fragmented_message);
     subtest("handshake", test_all_handshakes);

--- a/t/picotls.c
+++ b/t/picotls.c
@@ -1916,9 +1916,13 @@ static void do_test_tlsblock(size_t len_encoded, size_t max_bytes)
     src = buf.base;
     end = buf.base + buf.off;
     ptls_decode_block(src, end, len_encoded, {
-        ok(end - src == 255);
-        for (size_t i = 0; i < max_bytes; ++i)
-            ok(*src == i);
+        ok(end - src == max_bytes);
+        int bytes_eq = 1;
+        for (size_t i = 0; i < max_bytes; ++i) {
+            if (src[i] != (uint8_t)i)
+                bytes_eq = 0;
+        }
+        ok(bytes_eq);
         src = end;
     });
 


### PR DESCRIPTION
Up until now, when generating TLS messages, we have ignored the overflow of length fields. When they overflow, we have been sending length fields that contains the modulo of the actual length.

This does not happen in practice (as the endpoints control what they send in the handshake messages, which tend to be much smaller than the limits), and even if they fail the behavior is not harmful in sense that they end up in TLS handshake failures, but it is better to report them as errors.

Therefore, this PR adds such logic. A new error code is defined that would be reported to the application. The error code sent on wire will be Internal Error, which is the same error code that we send when running out of memory.