### PR TITLE
adds TLS13 support for ptls_import() and ptls_export()

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -1588,6 +1588,7 @@ int ptls_handshake_is_complete(ptls_t *tls);
 int ptls_is_psk_handshake(ptls_t *tls);
 /**
  * return if a ECH handshake was performed, as well as optionally the kem and cipher-suite being used
+ * FIXME: this function always return false when the TLS session is exported and imported
  */
 int ptls_is_ech_handshake(ptls_t *tls, uint8_t *config_id, ptls_hpke_kem_t **kem, ptls_hpke_cipher_suite_t **cipher);
 /**

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -5142,7 +5142,7 @@ int ptls_export(ptls_t *tls, ptls_buffer_t *output)
     }
 }
 
-static int build_tls12_traffic_protection(ptls_t *tls, int is_enc, const uint8_t **src, const uint8_t *const end)
+static int import_tls12_traffic_protection(ptls_t *tls, int is_enc, const uint8_t **src, const uint8_t *const end)
 {
     struct st_ptls_traffic_protection_t *tp = is_enc ? &tls->traffic_protection.enc : &tls->traffic_protection.dec;
 
@@ -5169,7 +5169,7 @@ static int build_tls12_traffic_protection(ptls_t *tls, int is_enc, const uint8_t
     return 0;
 }
 
-static int build_tls13_traffic_protection(ptls_t *tls, int is_enc, const uint8_t **src, const uint8_t *const end)
+static int import_tls13_traffic_protection(ptls_t *tls, int is_enc, const uint8_t **src, const uint8_t *const end)
 {
     struct st_ptls_traffic_protection_t *tp = is_enc ? &tls->traffic_protection.enc : &tls->traffic_protection.dec;
 
@@ -5242,9 +5242,9 @@ int ptls_import(ptls_context_t *ctx, ptls_t **tls, ptls_iovec_t params)
                     goto Exit;
                 }
                 /* setup AEAD keys */
-                if ((ret = build_tls12_traffic_protection(*tls, 1, &src, end)) != 0)
+                if ((ret = import_tls12_traffic_protection(*tls, 1, &src, end)) != 0)
                     goto Exit;
-                if ((ret = build_tls12_traffic_protection(*tls, 0, &src, end)) != 0)
+                if ((ret = import_tls12_traffic_protection(*tls, 0, &src, end)) != 0)
                     goto Exit;
                 break;
             case PTLS_PROTOCOL_VERSION_TLS13:
@@ -5259,9 +5259,9 @@ int ptls_import(ptls_context_t *ctx, ptls_t **tls, ptls_iovec_t params)
                     ret = PTLS_ERROR_NO_MEMORY;
                     goto Exit;
                 }
-                if ((ret = build_tls13_traffic_protection(*tls, 1, &src, end)) != 0)
+                if ((ret = import_tls13_traffic_protection(*tls, 1, &src, end)) != 0)
                     goto Exit;
-                if ((ret = build_tls13_traffic_protection(*tls, 0, &src, end)) != 0)
+                if ((ret = import_tls13_traffic_protection(*tls, 0, &src, end)) != 0)
                     goto Exit;
                 (*tls)->state = PTLS_STATE_SERVER_POST_HANDSHAKE;
                 goto Exit;

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -5260,7 +5260,10 @@ int ptls_import(ptls_context_t *ctx, ptls_t **tls, ptls_iovec_t params)
                     goto Exit;
                 if ((ret = build_tls13_traffic_protection(*tls, 0, &src, end)) != 0)
                     goto Exit;
-                (*tls)->key_schedule = key_schedule_new((*tls)->cipher_suite, NULL, (*tls)->ech.aead != NULL);
+                if (((*tls)->key_schedule = key_schedule_new((*tls)->cipher_suite, NULL, (*tls)->ech.aead != NULL)) == NULL) {
+                    ret = PTLS_ERROR_NO_MEMORY;
+                    goto Exit;
+                }
                 (*tls)->state = PTLS_STATE_SERVER_POST_HANDSHAKE;
                 goto Exit;
             default:

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -5260,7 +5260,7 @@ int ptls_import(ptls_context_t *ctx, ptls_t **tls, ptls_iovec_t params)
                     goto Exit;
                 if ((ret = build_tls13_traffic_protection(*tls, 0, &src, end)) != 0)
                     goto Exit;
-                (*tls)->key_schedule = key_schedule_new((*tls)->cipher_suite, (*tls)->ctx->cipher_suites, (*tls)->ech.aead != NULL);
+                (*tls)->key_schedule = key_schedule_new((*tls)->cipher_suite, NULL, (*tls)->ech.aead != NULL);
                 (*tls)->state = PTLS_STATE_SERVER_POST_HANDSHAKE;
                 goto Exit;
             default:

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -5262,11 +5262,10 @@ int ptls_import(ptls_context_t *ctx, ptls_t **tls, ptls_iovec_t params)
                     goto Exit;
                 if ((ret = import_tls13_traffic_protection(*tls, 0, &src, end)) != 0)
                     goto Exit;
-                (*tls)->state = PTLS_STATE_SERVER_POST_HANDSHAKE;
-                goto Exit;
+                break;
             default:
                 ret = PTLS_ALERT_ILLEGAL_PARAMETER;
-                break;
+                goto Exit;
             }
         });
         /* extensions */

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -1630,7 +1630,7 @@ static int setup_traffic_protection(ptls_t *tls, int is_enc, const char *secret_
 
     ctx->epoch = epoch;
 
-    if (tls->key_schedule)
+    if (tls->key_schedule != NULL)
         log_secret(tls, log_labels[ptls_is_server(tls) == is_enc][epoch],
                    ptls_iovec_init(ctx->secret, tls->key_schedule->hashes[0].algo->digest_size));
 

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -5248,7 +5248,6 @@ int ptls_import(ptls_context_t *ctx, ptls_t **tls, ptls_iovec_t params)
                     goto Exit;
                 break;
             case PTLS_PROTOCOL_VERSION_TLS13:
-                assert((*tls)->key_schedule == NULL);
                 (*tls)->cipher_suite = ptls_find_cipher_suite(ctx->cipher_suites, csid);
                 if ((*tls)->cipher_suite == NULL) {
                     ret = PTLS_ALERT_HANDSHAKE_FAILURE;

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -1615,7 +1615,7 @@ static int get_traffic_keys(ptls_aead_algorithm_t *aead, ptls_hash_algorithm_t *
     return ret;
 }
 
-static int setup_traffic_protection(ptls_t *tls, int is_enc, const char *secret_label, size_t epoch, int skip_notify)
+static int setup_traffic_protection(ptls_t *tls, int is_enc, const char *secret_label, size_t epoch, int skip_notify, int seq)
 {
     static const char *log_labels[2][4] = {
         {NULL, "CLIENT_EARLY_TRAFFIC_SECRET", "CLIENT_HANDSHAKE_TRAFFIC_SECRET", "CLIENT_TRAFFIC_SECRET_0"},
@@ -1630,8 +1630,9 @@ static int setup_traffic_protection(ptls_t *tls, int is_enc, const char *secret_
 
     ctx->epoch = epoch;
 
-    log_secret(tls, log_labels[ptls_is_server(tls) == is_enc][epoch],
-               ptls_iovec_init(ctx->secret, tls->key_schedule->hashes[0].algo->digest_size));
+    if (tls->key_schedule)
+        log_secret(tls, log_labels[ptls_is_server(tls) == is_enc][epoch],
+                   ptls_iovec_init(ctx->secret, tls->key_schedule->hashes[0].algo->digest_size));
 
     /* special path for applications having their own record layer */
     if (tls->ctx->update_traffic_key != NULL) {
@@ -1645,7 +1646,7 @@ static int setup_traffic_protection(ptls_t *tls, int is_enc, const char *secret_
     if ((ctx->aead = ptls_aead_new(tls->cipher_suite->aead, tls->cipher_suite->hash, is_enc, ctx->secret,
                                    tls->ctx->hkdf_label_prefix__obsolete)) == NULL)
         return PTLS_ERROR_NO_MEMORY; /* TODO obtain error from ptls_aead_new */
-    ctx->seq = 0;
+    ctx->seq = seq;
 
     PTLS_DEBUGF("[%s] %02x%02x,%02x%02x\n", log_labels[ptls_is_server(tls)][epoch], (unsigned)ctx->secret[0],
                 (unsigned)ctx->secret[1], (unsigned)ctx->aead->static_iv[0], (unsigned)ctx->aead->static_iv[1]);
@@ -1664,7 +1665,7 @@ static int commission_handshake_secret(ptls_t *tls)
     free(tls->pending_handshake_secret);
     tls->pending_handshake_secret = NULL;
 
-    return setup_traffic_protection(tls, is_enc, NULL, 2, 1);
+    return setup_traffic_protection(tls, is_enc, NULL, 2, 1, 0);
 }
 
 static void log_client_random(ptls_t *tls)
@@ -2479,7 +2480,7 @@ static int send_client_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptls_
 
     if (tls->client.using_early_data) {
         assert(!is_second_flight);
-        if ((ret = setup_traffic_protection(tls, 1, "c e traffic", 1, 0)) != 0)
+        if ((ret = setup_traffic_protection(tls, 1, "c e traffic", 1, 0, 0)) != 0)
             goto Exit;
         if ((ret = push_change_cipher_spec(tls, emitter)) != 0)
             goto Exit;
@@ -2795,7 +2796,7 @@ static int client_handle_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptl
 
     if ((ret = key_schedule_extract(tls->key_schedule, ecdh_secret)) != 0)
         goto Exit;
-    if ((ret = setup_traffic_protection(tls, 0, "s hs traffic", 2, 0)) != 0)
+    if ((ret = setup_traffic_protection(tls, 0, "s hs traffic", 2, 0, 0)) != 0)
         goto Exit;
     if (tls->client.using_early_data) {
         if ((tls->pending_handshake_secret = malloc(PTLS_MAX_DIGEST_SIZE)) == NULL) {
@@ -2808,7 +2809,7 @@ static int client_handle_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptl
             (ret = tls->ctx->update_traffic_key->cb(tls->ctx->update_traffic_key, tls, 1, 2, tls->pending_handshake_secret)) != 0)
             goto Exit;
     } else {
-        if ((ret = setup_traffic_protection(tls, 1, "c hs traffic", 2, 0)) != 0)
+        if ((ret = setup_traffic_protection(tls, 1, "c hs traffic", 2, 0, 0)) != 0)
             goto Exit;
     }
 
@@ -3373,7 +3374,7 @@ static int client_handle_finished(ptls_t *tls, ptls_message_emitter_t *emitter, 
     /* update traffic keys by using messages upto ServerFinished, but commission them after sending ClientFinished */
     if ((ret = key_schedule_extract(tls->key_schedule, ptls_iovec_init(NULL, 0))) != 0)
         goto Exit;
-    if ((ret = setup_traffic_protection(tls, 0, "s ap traffic", 3, 0)) != 0)
+    if ((ret = setup_traffic_protection(tls, 0, "s ap traffic", 3, 0, 0)) != 0)
         goto Exit;
     if ((ret = derive_secret(tls->key_schedule, send_secret, "c ap traffic")) != 0)
         goto Exit;
@@ -3407,7 +3408,7 @@ static int client_handle_finished(ptls_t *tls, ptls_message_emitter_t *emitter, 
     ret = send_finished(tls, emitter);
 
     memcpy(tls->traffic_protection.enc.secret, send_secret, sizeof(send_secret));
-    if ((ret = setup_traffic_protection(tls, 1, NULL, 3, 0)) != 0)
+    if ((ret = setup_traffic_protection(tls, 1, NULL, 3, 0, 0)) != 0)
         goto Exit;
 
     tls->state = PTLS_STATE_CLIENT_POST_HANDSHAKE;
@@ -4572,7 +4573,7 @@ static int server_handle_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptl
         }
         if ((ret = derive_exporter_secret(tls, 1)) != 0)
             goto Exit;
-        if ((ret = setup_traffic_protection(tls, 0, "c e traffic", 1, 0)) != 0)
+        if ((ret = setup_traffic_protection(tls, 0, "c e traffic", 1, 0, 0)) != 0)
             goto Exit;
     }
 
@@ -4631,7 +4632,7 @@ static int server_handle_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptl
     /* create protection contexts for the handshake */
     assert(tls->key_schedule->generation == 1);
     key_schedule_extract(tls->key_schedule, ecdh_secret);
-    if ((ret = setup_traffic_protection(tls, 1, "s hs traffic", 2, 0)) != 0)
+    if ((ret = setup_traffic_protection(tls, 1, "s hs traffic", 2, 0, 0)) != 0)
         goto Exit;
     if (tls->pending_handshake_secret != NULL) {
         if ((ret = derive_secret(tls->key_schedule, tls->pending_handshake_secret, "c hs traffic")) != 0)
@@ -4640,7 +4641,7 @@ static int server_handle_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptl
             (ret = tls->ctx->update_traffic_key->cb(tls->ctx->update_traffic_key, tls, 0, 2, tls->pending_handshake_secret)) != 0)
             goto Exit;
     } else {
-        if ((ret = setup_traffic_protection(tls, 0, "c hs traffic", 2, 0)) != 0)
+        if ((ret = setup_traffic_protection(tls, 0, "c hs traffic", 2, 0, 0)) != 0)
             goto Exit;
         if (ch->psk.early_data_indication)
             tls->server.early_data_skipped_bytes = 0;
@@ -4766,7 +4767,7 @@ static int server_finish_handshake(ptls_t *tls, ptls_message_emitter_t *emitter,
     assert(tls->key_schedule->generation == 2);
     if ((ret = key_schedule_extract(tls->key_schedule, ptls_iovec_init(NULL, 0))) != 0)
         goto Exit;
-    if ((ret = setup_traffic_protection(tls, 1, "s ap traffic", 3, 0)) != 0)
+    if ((ret = setup_traffic_protection(tls, 1, "s ap traffic", 3, 0, 0)) != 0)
         goto Exit;
     if ((ret = derive_secret(tls->key_schedule, tls->server.pending_traffic_secret, "c ap traffic")) != 0)
         goto Exit;
@@ -4827,7 +4828,7 @@ static int server_handle_finished(ptls_t *tls, ptls_iovec_t message)
 
     memcpy(tls->traffic_protection.dec.secret, tls->server.pending_traffic_secret, sizeof(tls->server.pending_traffic_secret));
     ptls_clear_memory(tls->server.pending_traffic_secret, sizeof(tls->server.pending_traffic_secret));
-    if ((ret = setup_traffic_protection(tls, 0, NULL, 3, 0)) != 0)
+    if ((ret = setup_traffic_protection(tls, 0, NULL, 3, 0, 0)) != 0)
         return ret;
 
     ptls__key_schedule_update_hash(tls->key_schedule, message.base, message.len, 0);
@@ -4847,7 +4848,7 @@ static int update_traffic_key(ptls_t *tls, int is_enc)
                                       "traffic upd", ptls_iovec_init(NULL, 0), NULL)) != 0)
         goto Exit;
     memcpy(tp->secret, secret, sizeof(secret));
-    ret = setup_traffic_protection(tls, is_enc, NULL, 3, 1);
+    ret = setup_traffic_protection(tls, is_enc, NULL, 3, 1, 0);
 
 Exit:
     ptls_clear_memory(secret, sizeof(secret));
@@ -5017,6 +5018,36 @@ ptls_t *ptls_server_new(ptls_context_t *ctx)
     return tls;
 }
 
+static int export_tls13_params(ptls_buffer_t *output, int is_server, int session_reused, ptls_cipher_suite_t *cipher,
+                               const void *client_random, const char *server_name, ptls_iovec_t negotiated_protocol,
+                               const void *enc_key, uint64_t enc_seq, const void *dec_key, uint64_t dec_seq)
+{
+    int ret;
+
+    ptls_buffer_push_block(output, 2, {
+        ptls_buffer_push(output, is_server);
+        ptls_buffer_push(output, session_reused);
+        ptls_buffer_push16(output, PTLS_PROTOCOL_VERSION_TLS13);
+        ptls_buffer_push16(output, cipher->id);
+        ptls_buffer_pushv(output, client_random, PTLS_HELLO_RANDOM_SIZE);
+        ptls_buffer_push_block(output, 2, {
+            size_t len = server_name != NULL ? strlen(server_name) : 0;
+            ptls_buffer_pushv(output, server_name, len);
+        });
+        ptls_buffer_push_block(output, 2, { ptls_buffer_pushv(output, negotiated_protocol.base, negotiated_protocol.len); });
+        ptls_buffer_push_block(output, 2, {
+            ptls_buffer_pushv(output, enc_key, cipher->hash->digest_size);
+            ptls_buffer_push64(output, enc_seq);
+            ptls_buffer_pushv(output, dec_key, cipher->hash->digest_size);
+            ptls_buffer_push64(output, dec_seq);
+        });
+        ptls_buffer_push_block(output, 2, {}); /* for future extensions */
+    });
+
+Exit:
+    return ret;
+}
+
 static int export_tls12_params(ptls_buffer_t *output, int is_server, int session_reused, ptls_cipher_suite_t *cipher,
                                const void *client_random, const char *server_name, ptls_iovec_t negotiated_protocol,
                                const void *enc_key, const void *enc_iv, uint64_t enc_seq, uint64_t enc_record_iv,
@@ -5094,17 +5125,21 @@ Exit:
 
 int ptls_export(ptls_t *tls, ptls_buffer_t *output)
 {
-    /* TODO add tls13 support */
-    if (!tls->traffic_protection.enc.tls12)
-        return PTLS_ERROR_LIBRARY;
-
     ptls_iovec_t negotiated_protocol =
         ptls_iovec_init(tls->negotiated_protocol, tls->negotiated_protocol != NULL ? strlen(tls->negotiated_protocol) : 0);
-    return export_tls12_params(output, tls->is_server, tls->is_psk_handshake, tls->cipher_suite, tls->client_random,
+    if (ptls_get_protocol_version(tls) == PTLS_PROTOCOL_VERSION_TLS13) {
+        if (tls->state != PTLS_STATE_SERVER_POST_HANDSHAKE)
+            return PTLS_ERROR_LIBRARY;
+        return export_tls13_params(output, tls->is_server, tls->is_psk_handshake, tls->cipher_suite, tls->client_random,
+                               tls->server_name, negotiated_protocol, tls->traffic_protection.enc.secret, tls->traffic_protection.enc.seq,
+                               tls->traffic_protection.dec.secret, tls->traffic_protection.dec.seq);
+    } else {
+        return export_tls12_params(output, tls->is_server, tls->is_psk_handshake, tls->cipher_suite, tls->client_random,
                                tls->server_name, negotiated_protocol, tls->traffic_protection.enc.secret,
                                tls->traffic_protection.enc.secret + PTLS_MAX_SECRET_SIZE, tls->traffic_protection.enc.seq,
                                tls->traffic_protection.enc.tls12_enc_record_iv, tls->traffic_protection.dec.secret,
                                tls->traffic_protection.dec.secret + PTLS_MAX_SECRET_SIZE, tls->traffic_protection.dec.seq);
+    }
 }
 
 static int build_tls12_traffic_protection(ptls_t *tls, int is_enc, const uint8_t **src, const uint8_t *const end)
@@ -5134,6 +5169,23 @@ static int build_tls12_traffic_protection(ptls_t *tls, int is_enc, const uint8_t
     return 0;
 }
 
+static int build_tls13_traffic_protection(ptls_t *tls, int is_enc, const uint8_t **src, const uint8_t *const end)
+{
+    struct st_ptls_traffic_protection_t *tp = is_enc ? &tls->traffic_protection.enc : &tls->traffic_protection.dec;
+
+    /* set properties */
+    memcpy(tp->secret, *src, tls->cipher_suite->hash->digest_size);
+    *src += tls->cipher_suite->hash->digest_size;
+    if (ptls_decode64(&tp->seq, src, end) != 0)
+        return PTLS_ALERT_DECODE_ERROR;
+
+    int skip_notify = is_enc ? 1 : 0;
+    if (setup_traffic_protection(tls, is_enc, NULL, 3, skip_notify, tp->seq) != 0)
+        return PTLS_ERROR_INCOMPATIBLE_KEY;
+
+    return 0;
+}
+
 int ptls_import(ptls_context_t *ctx, ptls_t **tls, ptls_iovec_t params)
 {
     const uint8_t *src = params.base, *const end = src + params.len;
@@ -5159,11 +5211,6 @@ int ptls_import(ptls_context_t *ctx, ptls_t **tls, ptls_iovec_t params)
             goto Exit;
         if ((ret = ptls_decode16(&csid, &src, end)) != 0)
             goto Exit;
-        (*tls)->cipher_suite = ptls_find_cipher_suite(ctx->tls12_cipher_suites, csid);
-        if ((*tls)->cipher_suite == NULL) {
-            ret = PTLS_ALERT_HANDSHAKE_FAILURE;
-            goto Exit;
-        }
         /* other version-independent stuff */
         if (end - src < PTLS_HELLO_RANDOM_SIZE) {
             ret = PTLS_ALERT_DECODE_ERROR;
@@ -5189,12 +5236,32 @@ int ptls_import(ptls_context_t *ctx, ptls_t **tls, ptls_iovec_t params)
         ptls_decode_open_block(src, end, 2, {
             switch (protocol_version) {
             case PTLS_PROTOCOL_VERSION_TLS12:
+                (*tls)->cipher_suite = ptls_find_cipher_suite(ctx->tls12_cipher_suites, csid);
+                if ((*tls)->cipher_suite == NULL) {
+                    ret = PTLS_ALERT_HANDSHAKE_FAILURE;
+                    goto Exit;
+                }
                 /* setup AEAD keys */
                 if ((ret = build_tls12_traffic_protection(*tls, 1, &src, end)) != 0)
                     goto Exit;
                 if ((ret = build_tls12_traffic_protection(*tls, 0, &src, end)) != 0)
                     goto Exit;
                 break;
+            case PTLS_PROTOCOL_VERSION_TLS13:
+                assert((*tls)->key_schedule == NULL);
+                (*tls)->cipher_suite = ptls_find_cipher_suite(ctx->cipher_suites, csid);
+                if ((*tls)->cipher_suite == NULL) {
+                    ret = PTLS_ALERT_HANDSHAKE_FAILURE;
+                    goto Exit;
+                }
+                /* setup AEAD keys */
+                if ((ret = build_tls13_traffic_protection(*tls, 1, &src, end)) != 0)
+                    goto Exit;
+                if ((ret = build_tls13_traffic_protection(*tls, 0, &src, end)) != 0)
+                    goto Exit;
+                (*tls)->key_schedule = key_schedule_new((*tls)->cipher_suite, (*tls)->ctx->cipher_suites, (*tls)->ech.aead != NULL);
+                (*tls)->state = PTLS_STATE_SERVER_POST_HANDSHAKE;
+            goto Exit;
             default:
                 ret = PTLS_ALERT_ILLEGAL_PARAMETER;
                 break;
@@ -5215,6 +5282,7 @@ Exit:
             *tls = NULL;
         }
     }
+    assert(ret == 0);
     return ret;
 }
 
@@ -6226,13 +6294,12 @@ ptls_aead_context_t *new_aead(ptls_aead_algorithm_t *aead, ptls_hash_algorithm_t
     struct {
         uint8_t key[PTLS_MAX_SECRET_SIZE];
         uint8_t iv[PTLS_MAX_IV_SIZE];
-    } key_iv;
+    } key_iv = {0};
     int ret;
 
     if ((ret = get_traffic_keys(aead, hash, key_iv.key, key_iv.iv, secret, hash_value, label_prefix)) != 0)
         goto Exit;
     ctx = ptls_aead_new_direct(aead, is_enc, key_iv.key, key_iv.iv);
-
 Exit:
     ptls_clear_memory(&key_iv, sizeof(key_iv));
     return ctx;

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -5131,14 +5131,15 @@ int ptls_export(ptls_t *tls, ptls_buffer_t *output)
         if (tls->state != PTLS_STATE_SERVER_POST_HANDSHAKE)
             return PTLS_ERROR_LIBRARY;
         return export_tls13_params(output, tls->is_server, tls->is_psk_handshake, tls->cipher_suite, tls->client_random,
-                               tls->server_name, negotiated_protocol, tls->traffic_protection.enc.secret, tls->traffic_protection.enc.seq,
-                               tls->traffic_protection.dec.secret, tls->traffic_protection.dec.seq);
+                                   tls->server_name, negotiated_protocol, tls->traffic_protection.enc.secret,
+                                   tls->traffic_protection.enc.seq, tls->traffic_protection.dec.secret,
+                                   tls->traffic_protection.dec.seq);
     } else {
         return export_tls12_params(output, tls->is_server, tls->is_psk_handshake, tls->cipher_suite, tls->client_random,
-                               tls->server_name, negotiated_protocol, tls->traffic_protection.enc.secret,
-                               tls->traffic_protection.enc.secret + PTLS_MAX_SECRET_SIZE, tls->traffic_protection.enc.seq,
-                               tls->traffic_protection.enc.tls12_enc_record_iv, tls->traffic_protection.dec.secret,
-                               tls->traffic_protection.dec.secret + PTLS_MAX_SECRET_SIZE, tls->traffic_protection.dec.seq);
+                                   tls->server_name, negotiated_protocol, tls->traffic_protection.enc.secret,
+                                   tls->traffic_protection.enc.secret + PTLS_MAX_SECRET_SIZE, tls->traffic_protection.enc.seq,
+                                   tls->traffic_protection.enc.tls12_enc_record_iv, tls->traffic_protection.dec.secret,
+                                   tls->traffic_protection.dec.secret + PTLS_MAX_SECRET_SIZE, tls->traffic_protection.dec.seq);
     }
 }
 
@@ -5261,7 +5262,7 @@ int ptls_import(ptls_context_t *ctx, ptls_t **tls, ptls_iovec_t params)
                     goto Exit;
                 (*tls)->key_schedule = key_schedule_new((*tls)->cipher_suite, (*tls)->ctx->cipher_suites, (*tls)->ech.aead != NULL);
                 (*tls)->state = PTLS_STATE_SERVER_POST_HANDSHAKE;
-            goto Exit;
+                goto Exit;
             default:
                 ret = PTLS_ALERT_ILLEGAL_PARAMETER;
                 break;

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -1630,9 +1630,8 @@ static int setup_traffic_protection(ptls_t *tls, int is_enc, const char *secret_
 
     ctx->epoch = epoch;
 
-    if (tls->key_schedule != NULL)
-        log_secret(tls, log_labels[ptls_is_server(tls) == is_enc][epoch],
-                   ptls_iovec_init(ctx->secret, tls->key_schedule->hashes[0].algo->digest_size));
+    log_secret(tls, log_labels[ptls_is_server(tls) == is_enc][epoch],
+               ptls_iovec_init(ctx->secret, tls->key_schedule->hashes[0].algo->digest_size));
 
     /* special path for applications having their own record layer */
     if (tls->ctx->update_traffic_key != NULL) {
@@ -5256,14 +5255,14 @@ int ptls_import(ptls_context_t *ctx, ptls_t **tls, ptls_iovec_t params)
                     goto Exit;
                 }
                 /* setup AEAD keys */
-                if ((ret = build_tls13_traffic_protection(*tls, 1, &src, end)) != 0)
-                    goto Exit;
-                if ((ret = build_tls13_traffic_protection(*tls, 0, &src, end)) != 0)
-                    goto Exit;
                 if (((*tls)->key_schedule = key_schedule_new((*tls)->cipher_suite, NULL, (*tls)->ech.aead != NULL)) == NULL) {
                     ret = PTLS_ERROR_NO_MEMORY;
                     goto Exit;
                 }
+                if ((ret = build_tls13_traffic_protection(*tls, 1, &src, end)) != 0)
+                    goto Exit;
+                if ((ret = build_tls13_traffic_protection(*tls, 0, &src, end)) != 0)
+                    goto Exit;
                 (*tls)->state = PTLS_STATE_SERVER_POST_HANDSHAKE;
                 goto Exit;
             default:

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -5179,8 +5179,7 @@ static int import_tls13_traffic_protection(ptls_t *tls, int is_enc, const uint8_
     if (ptls_decode64(&tp->seq, src, end) != 0)
         return PTLS_ALERT_DECODE_ERROR;
 
-    int skip_notify = is_enc ? 1 : 0;
-    if (setup_traffic_protection(tls, is_enc, NULL, 3, tp->seq, skip_notify) != 0)
+    if (setup_traffic_protection(tls, is_enc, NULL, 3, tp->seq, 0) != 0)
         return PTLS_ERROR_INCOMPATIBLE_KEY;
 
     return 0;

--- a/t/picotls.c
+++ b/t/picotls.c
@@ -1114,7 +1114,8 @@ static void test_handshake(ptls_iovec_t ticket, int mode, int expect_ticket, int
         ok(ptls_handshake_is_complete(server));
         decbuf.off = 0;
         cbuf.off = 0;
-        server = alloc_and_migrate_tls_context(original_server);
+        if (transfer_session)
+            server = alloc_and_migrate_tls_context(original_server);
 
         ret = ptls_send(server, &sbuf, resp, strlen(resp));
         ok(ret == 0);

--- a/t/picotls.c
+++ b/t/picotls.c
@@ -864,31 +864,29 @@ static int can_ech(ptls_context_t *ctx, int is_server)
     }
 }
 
-static void aead_keys_cmp(ptls_t *src, ptls_t *dst)
+static void check_clone(ptls_t *src, ptls_t *dest)
 {
-    ok(src->cipher_suite->hash->digest_size == dst->cipher_suite->hash->digest_size);
-    size_t digest_size = dst->cipher_suite->hash->digest_size;
-    ok(memcmp(src->traffic_protection.enc.secret, dst->traffic_protection.enc.secret, digest_size) == 0);
-    ok(memcmp(src->traffic_protection.dec.secret, dst->traffic_protection.dec.secret, digest_size) == 0);
+    ok(src->cipher_suite->hash->digest_size == dest->cipher_suite->hash->digest_size);
+    size_t digest_size = dest->cipher_suite->hash->digest_size;
+    ok(memcmp(src->traffic_protection.enc.secret, dest->traffic_protection.enc.secret, digest_size) == 0);
+    ok(memcmp(src->traffic_protection.dec.secret, dest->traffic_protection.dec.secret, digest_size) == 0);
     const unsigned enc_idx = 0;
     const unsigned dec_idx = 1;
-    struct st_keys {
+    struct {
         uint8_t key[PTLS_MAX_SECRET_SIZE];
         uint8_t iv[PTLS_MAX_IV_SIZE];
         uint64_t seq;
-    };
-    struct st_keys src_keys[2] = {0};
-    struct st_keys dst_keys[2] = {0};
+    } src_keys[2] = {0}, dest_keys[2] = {0};
     ok(ptls_get_traffic_keys(src, 1, src_keys[enc_idx].key, src_keys[enc_idx].iv, &src_keys[enc_idx].seq) == 0);
     ok(ptls_get_traffic_keys(src, 0, src_keys[dec_idx].key, src_keys[dec_idx].iv, &src_keys[dec_idx].seq) == 0);
-    ok(ptls_get_traffic_keys(dst, 1, dst_keys[enc_idx].key, dst_keys[enc_idx].iv, &dst_keys[enc_idx].seq) == 0);
-    ok(ptls_get_traffic_keys(dst, 0, dst_keys[dec_idx].key, dst_keys[dec_idx].iv, &dst_keys[dec_idx].seq) == 0);
-    ok(src_keys[enc_idx].seq == dst_keys[enc_idx].seq);
-    ok(src_keys[dec_idx].seq == dst_keys[dec_idx].seq);
-    ok(memcmp(src_keys[enc_idx].key, dst_keys[enc_idx].key, PTLS_MAX_SECRET_SIZE) == 0);
-    ok(memcmp(src_keys[dec_idx].key, dst_keys[dec_idx].key, PTLS_MAX_SECRET_SIZE) == 0);
-    ok(memcmp(src_keys[enc_idx].iv, dst_keys[enc_idx].iv, PTLS_MAX_IV_SIZE) == 0);
-    ok(memcmp(src_keys[dec_idx].iv, dst_keys[dec_idx].iv, PTLS_MAX_IV_SIZE) == 0);
+    ok(ptls_get_traffic_keys(dest, 1, dest_keys[enc_idx].key, dest_keys[enc_idx].iv, &dest_keys[enc_idx].seq) == 0);
+    ok(ptls_get_traffic_keys(dest, 0, dest_keys[dec_idx].key, dest_keys[dec_idx].iv, &dest_keys[dec_idx].seq) == 0);
+    ok(src_keys[enc_idx].seq == dest_keys[enc_idx].seq);
+    ok(src_keys[dec_idx].seq == dest_keys[dec_idx].seq);
+    ok(memcmp(src_keys[enc_idx].key, dest_keys[enc_idx].key, PTLS_MAX_SECRET_SIZE) == 0);
+    ok(memcmp(src_keys[dec_idx].key, dest_keys[dec_idx].key, PTLS_MAX_SECRET_SIZE) == 0);
+    ok(memcmp(src_keys[enc_idx].iv, dest_keys[enc_idx].iv, PTLS_MAX_IV_SIZE) == 0);
+    ok(memcmp(src_keys[dec_idx].iv, dest_keys[dec_idx].iv, PTLS_MAX_IV_SIZE) == 0);
 }
 
 static ptls_t *clone_tls(ptls_t *src)
@@ -903,7 +901,8 @@ static ptls_t *clone_tls(ptls_t *src)
     assert(r == 0);
     ptls_buffer_dispose(&sess_data);
 
-    aead_keys_cmp(src, dest);
+    check_clone(src, dest);
+
     return dest;
 }
 

--- a/t/picotls.c
+++ b/t/picotls.c
@@ -893,14 +893,16 @@ static void aead_keys_cmp(ptls_t *src, ptls_t *dst)
 
 static ptls_t *clone_tls(ptls_t *src)
 {
+    ptls_t *dest = NULL;
     ptls_buffer_t sess_data;
+
     ptls_buffer_init(&sess_data, "", 0);
     int r = ptls_export(src, &sess_data);
     assert(r == 0);
-    ptls_t *dest = NULL;
     r = ptls_import(ctx_peer, &dest, (ptls_iovec_t){.base = sess_data.base, .len = sess_data.off});
-
     assert(r == 0);
+    ptls_buffer_dispose(&sess_data);
+
     aead_keys_cmp(src, dest);
     return dest;
 }

--- a/t/picotls.c
+++ b/t/picotls.c
@@ -891,14 +891,14 @@ static void aead_keys_cmp(ptls_t *src, ptls_t *dst, const char **err)
     ok(memcmp(src_keys[dec_idx].iv, dst_keys[dec_idx].iv, PTLS_MAX_IV_SIZE) == 0);
 }
 
-static ptls_t *test_alloc_and_migrate_tls_context(ptls_t *prev_tls)
+static ptls_t *alloc_and_migrate_tls_context(ptls_t *prev_tls)
 {
     ptls_buffer_t sess_data;
     ptls_buffer_init(&sess_data, "", 0);
     int r = ptls_export(prev_tls, &sess_data);
     assert(r == 0);
     ptls_t *tls = NULL;
-    r = ptls_import(ctx_peer, &tls, (ptls_iovec_t){ .base = sess_data.base, .len = sess_data.off });
+    r = ptls_import(ctx_peer, &tls, (ptls_iovec_t){.base = sess_data.base, .len = sess_data.off});
 
     assert(r == 0);
     const char *err = NULL;
@@ -906,7 +906,8 @@ static ptls_t *test_alloc_and_migrate_tls_context(ptls_t *prev_tls)
     return tls;
 }
 
-static void test_handshake(ptls_iovec_t ticket, int mode, int expect_ticket, int check_ch, int require_client_authentication, int transfer_session)
+static void test_handshake(ptls_iovec_t ticket, int mode, int expect_ticket, int check_ch, int require_client_authentication,
+                           int transfer_session)
 {
     ptls_t *client, *server;
     ptls_handshake_properties_t client_hs_prop = {{{{NULL}, ticket}}}, server_hs_prop = {{{{NULL}}}};
@@ -1113,7 +1114,7 @@ static void test_handshake(ptls_iovec_t ticket, int mode, int expect_ticket, int
         ok(ptls_handshake_is_complete(server));
         decbuf.off = 0;
         cbuf.off = 0;
-        server = test_alloc_and_migrate_tls_context(original_server);
+        server = alloc_and_migrate_tls_context(original_server);
 
         ret = ptls_send(server, &sbuf, resp, strlen(resp));
         ok(ret == 0);
@@ -1348,7 +1349,8 @@ static void test_resumption_impl(int different_preferred_key_share, int require_
     ctx_peer->encrypt_ticket = &et;
     ctx->save_ticket = &st;
 
-    test_handshake(saved_ticket, different_preferred_key_share ? TEST_HANDSHAKE_2RTT : TEST_HANDSHAKE_1RTT, 1, 0, 0, transfer_session);
+    test_handshake(saved_ticket, different_preferred_key_share ? TEST_HANDSHAKE_2RTT : TEST_HANDSHAKE_1RTT, 1, 0, 0,
+                   transfer_session);
     ok(server_sc_callcnt == 1);
     ok(saved_ticket.base != NULL);
 

--- a/t/picotls.c
+++ b/t/picotls.c
@@ -864,7 +864,7 @@ static int can_ech(ptls_context_t *ctx, int is_server)
     }
 }
 
-static void aead_keys_cmp(ptls_t *src, ptls_t *dst, const char **err)
+static void aead_keys_cmp(ptls_t *src, ptls_t *dst)
 {
     ok(src->cipher_suite->hash->digest_size == dst->cipher_suite->hash->digest_size);
     size_t digest_size = dst->cipher_suite->hash->digest_size;
@@ -901,8 +901,7 @@ static ptls_t *alloc_and_migrate_tls_context(ptls_t *prev_tls)
     r = ptls_import(ctx_peer, &tls, (ptls_iovec_t){.base = sess_data.base, .len = sess_data.off});
 
     assert(r == 0);
-    const char *err = NULL;
-    aead_keys_cmp(prev_tls, tls, &err);
+    aead_keys_cmp(prev_tls, tls);
     return tls;
 }
 


### PR DESCRIPTION
This adds the ability to transfer the traffic secrets from one TLSv1.3  tls structure to another newly created one.
New helper functions are added to `t/picotls.c`:  `alloc_and_migrate_tls_context()` is a function that simulates the usage of import/export in different code paths and handshake types; `aead_keys_cmp()` compares secrets and keys (sequence numbers as well) to determine whether the transfer was correctly done.

@kazuho was in the loop as an active contributor, but we both agreed the PoC (private branch) code needed some cleanup--some of which already included in this PR.

One new thing form the PoC was adding an explicit call to `key_schedule_new()` to create a new `key_schedule` , so that key updates would work (tests that include key updates would work as well).