### PR TITLE
[cli] server sends EE with retry_configs

### DIFF
--- a/t/cli.c
+++ b/t/cli.c
@@ -649,6 +649,7 @@ int main(int argc, char **argv)
         }
 #endif
         setup_session_cache(&ctx);
+        ech_setup_retry_configs(&ctx);
     } else {
         /* client */
         if (use_early_data) {

--- a/t/util.h
+++ b/t/util.h
@@ -266,6 +266,11 @@ static struct {
     } retry;
 } ech;
 
+static void ech_setup_retry_configs(ptls_context_t *ctx) {
+    ctx->ech.server.retry_configs.base = ech.config_list.base;
+    ctx->ech.server.retry_configs.len = ech.config_list.len;
+}
+
 static ptls_aead_context_t *ech_create_opener(ptls_ech_create_opener_t *self, ptls_hpke_kem_t **kem,
                                               ptls_hpke_cipher_suite_t **cipher, ptls_t *tls, uint8_t config_id,
                                               ptls_hpke_cipher_suite_id_t cipher_id, ptls_iovec_t enc, ptls_iovec_t info_prefix)


### PR DESCRIPTION
Hi!
This PR would the cli enable to send EE with retry_configs when the server is configured with -E echconfiglist file.

Now, the cli sends EE with empty retry_configs if the server rejects ECH. The cli has -E option, so this PR uses it. 
Thanks.