### PR TITLE
Refine key exchange comments and fix typo

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -345,7 +345,7 @@ typedef struct st_ptls_key_exchange_context_t {
     ptls_iovec_t pubkey;
     /**
      * This function can be used for deriving a shared secret or for destroying the context.
-     * When `secret` is non-NULL, this callback derives the shared secret using the public key of the context and the peer key being
+     * When `secret` is non-NULL, this callback derives the shared secret using the private key of the context and the peer key being
      * given, and sets the value in `secret`. The memory pointed to by `secret->base` must be freed by the caller by calling `free`.
      * When `release` is set, the callee frees resources allocated to the context and set *keyex to NULL.
      */
@@ -366,9 +366,9 @@ typedef const struct st_ptls_key_exchange_algorithm_t {
      */
     int (*create)(const struct st_ptls_key_exchange_algorithm_t *algo, ptls_key_exchange_context_t **ctx);
     /**
-     * Implements synchronous key exchange. Called when receiving a ServerHello.
-     * Given a public key provided by the peer (`peerkey`), this callback returns a empheral public key (`pubkey`) and a secret
-     * (`secret) `derived from the two public keys.
+     * Implements synchronous key exchange. Called when ServerHello is generated.
+     * Given a public key provided by the peer (`peerkey`), this callback generates an ephemeral private and public key, and returns
+     * the public key (`pubkey`) and a secret (`secret`) derived from the peerkey and private key.
      */
     int (*exchange)(const struct st_ptls_key_exchange_algorithm_t *algo, ptls_iovec_t *pubkey, ptls_iovec_t *secret,
                     ptls_iovec_t peerkey);

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -434,14 +434,14 @@ static int x9_62_key_exchange(EC_GROUP *group, ptls_iovec_t *pubkey, ptls_iovec_
         goto Exit;
     }
 
-    /* calc secret */
+    /* allocate space for secret */
     secret->len = (EC_GROUP_get_degree(group) + 7) / 8;
     if ((secret->base = malloc(secret->len)) == NULL) {
         ret = PTLS_ERROR_NO_MEMORY;
         goto Exit;
     }
 
-    /* ecdh! */
+    /* calc secret */
     if (ECDH_compute_key(secret->base, secret->len, peer_point, privkey, NULL) <= 0) {
         ret = PTLS_ALERT_HANDSHAKE_FAILURE; /* ??? */
         goto Exit;

--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -201,7 +201,7 @@ void ptls_openssl_random_bytes(void *buf, size_t len)
     }
 }
 
-static EC_KEY *ecdh_gerenate_key(EC_GROUP *group)
+static EC_KEY *ecdh_generate_key(EC_GROUP *group)
 {
     EC_KEY *key;
 
@@ -362,7 +362,7 @@ static int x9_62_create_key_exchange(ptls_key_exchange_algorithm_t *algo, ptls_k
     }
     if ((ret = x9_62_create_context(algo, &ctx)) != 0)
         goto Exit;
-    if ((ctx->privkey = ecdh_gerenate_key(group)) == NULL) {
+    if ((ctx->privkey = ecdh_generate_key(group)) == NULL) {
         ret = PTLS_ERROR_LIBRARY;
         goto Exit;
     }
@@ -423,7 +423,7 @@ static int x9_62_key_exchange(EC_GROUP *group, ptls_iovec_t *pubkey, ptls_iovec_
     }
 
     /* create private key */
-    if ((privkey = ecdh_gerenate_key(group)) == NULL) {
+    if ((privkey = ecdh_generate_key(group)) == NULL) {
         ret = PTLS_ERROR_NO_MEMORY;
         goto Exit;
     }


### PR DESCRIPTION
Improve key exchange comments and fix typo in method name `ecdh_generate_key`.