### PR TITLE
Fix build error due to undefined variables

### DIFF
--- a/include/picotls/openssl.h
+++ b/include/picotls/openssl.h
@@ -33,17 +33,18 @@ extern "C" {
 #include <openssl/opensslconf.h>
 #include "../picotls.h"
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
-#if !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305)
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305)
 #define PTLS_OPENSSL_HAVE_CHACHA20_POLY1305 1
-#endif
+#else
+#define PTLS_OPENSSL_HAVE_CHACHA20_POLY1305 0
 #endif
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100010L && !defined(LIBRESSL_VERSION_NUMBER)
-#if !defined(OPENSSL_NO_ASYNC)
+#if OPENSSL_VERSION_NUMBER >= 0x10100010L && !defined(LIBRESSL_VERSION_NUMBER) && \
+    !defined(OPENSSL_NO_ASYNC)
 #include <openssl/async.h>
 #define PTLS_OPENSSL_HAVE_ASYNC 1
-#endif
+#else
+#define PTLS_OPENSSL_HAVE_ASYNC 0
 #endif
 
 extern ptls_key_exchange_algorithm_t ptls_openssl_secp256r1;
@@ -64,11 +65,16 @@ extern ptls_key_exchange_algorithm_t ptls_openssl_secp521r1;
 #define PTLS_OPENSSL_HAVE_X25519 1
 #define PTLS_OPENSSL_HAS_X25519 1 /* deprecated; use HAVE_ */
 extern ptls_key_exchange_algorithm_t ptls_openssl_x25519;
+#else
+#define PTLS_OPENSSL_HAVE_X25519 0
+#define PTLS_OPENSSL_HAS_X25519 0 /* deprecated; use HAVE_ */
 #endif
 
 /* when boringssl is used, existence of libdecrepit is assumed */
 #if !defined(OPENSSL_NO_BF) || defined(OPENSSL_IS_BORINGSSL)
 #define PTLS_OPENSSL_HAVE_BF 1
+#else
+#define PTLS_OPENSSL_HAVE_BF 0
 #endif
 
 extern ptls_key_exchange_algorithm_t *ptls_openssl_key_exchanges[];


### PR DESCRIPTION
When buidling LibreSSL + picotls with `-Wundef` option, the build fails due to the following error.

```
2024-06-16T05:50:37.9131759Z In file included from /home/runner/work/ngtcp2/ngtcp2/ngtcp2-1.6.0-DEV/crypto/picotls/picotls.c:36:
2024-06-16T05:50:37.9134332Z /home/runner/work/ngtcp2/ngtcp2/picotls-libressl/include/picotls/openssl.h:91:5: error: 'PTLS_OPENSSL_HAVE_CHACHA20_POLY1305' is not defined, evaluates to 0 [-Werror,-Wundef]
2024-06-16T05:50:37.9136125Z #if PTLS_OPENSSL_HAVE_CHACHA20_POLY1305
2024-06-16T05:50:37.9136719Z     ^
2024-06-16T05:50:37.9138515Z /home/runner/work/ngtcp2/ngtcp2/picotls-libressl/include/picotls/openssl.h:108:5: error: 'PTLS_OPENSSL_HAVE_CHACHA20_POLY1305' is not defined, evaluates to 0 [-Werror,-Wundef]
2024-06-16T05:50:37.9140294Z #if PTLS_OPENSSL_HAVE_CHACHA20_POLY1305
2024-06-16T05:50:37.9141272Z     ^
2024-06-16T05:50:37.9143043Z /home/runner/work/ngtcp2/ngtcp2/picotls-libressl/include/picotls/openssl.h:119:5: error: 'PTLS_OPENSSL_HAVE_X25519' is not defined, evaluates to 0 [-Werror,-Wundef]
2024-06-16T05:50:37.9144740Z #if PTLS_OPENSSL_HAVE_X25519
2024-06-16T05:50:37.9145253Z     ^
2024-06-16T05:50:37.9147028Z /home/runner/work/ngtcp2/ngtcp2/picotls-libressl/include/picotls/openssl.h:127:5: error: 'PTLS_OPENSSL_HAVE_CHACHA20_POLY1305' is not defined, evaluates to 0 [-Werror,-Wundef]
2024-06-16T05:50:37.9148787Z #if PTLS_OPENSSL_HAVE_CHACHA20_POLY1305
2024-06-16T05:50:37.9149365Z     ^
2024-06-16T05:50:37.9221836Z 4 errors generated.
2024-06-16T05:50:37.9278275Z make[2]: *** [crypto/picotls/CMakeFiles/ngtcp2_crypto_picotls_static.dir/build.make:76: crypto/picotls/CMakeFiles/ngtcp2_crypto_picotls_static.dir/picotls.c.o] Error 1
2024-06-16T05:50:37.9280880Z make[1]: *** [CMakeFiles/Makefile2:553: crypto/picotls/CMakeFiles/ngtcp2_crypto_picotls_static.dir/all] Error 2
```

This patch fixes them.
