### PR TITLE
Allow LibreSSL to use ChaCha20-Poly1305

### DIFF
--- a/include/picotls/openssl.h
+++ b/include/picotls/openssl.h
@@ -33,7 +33,7 @@ extern "C" {
 #include <openssl/opensslconf.h>
 #include "../picotls.h"
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 #if !defined(OPENSSL_NO_CHACHA) && !defined(OPENSSL_NO_POLY1305)
 #define PTLS_OPENSSL_HAVE_CHACHA20_POLY1305 1
 #endif


### PR DESCRIPTION
Although ChaCha20-Poly1305 was excluded long time ago fd180162a4f6eac509e172cd381983ef22d8fd5d for LibreSSL, it is already available as per the [ChangeLog](https://github.com/libressl/portable/blob/46ddd6b184d211b56d8813069f62cb5e0ba32a1d/ChangeLog#L2570).

This patch allows LibreSSL to use ChaCha20-Poly1305.