### PR TITLE
Allow LibreSSL to use X25519

### DIFF
--- a/include/picotls/openssl.h
+++ b/include/picotls/openssl.h
@@ -61,7 +61,7 @@ extern ptls_key_exchange_algorithm_t ptls_openssl_secp521r1;
 #ifdef EVP_PKEY_ED25519
 #define PTLS_OPENSSL_HAVE_ED25519 1
 #endif
-#if defined(NID_X25519) && !defined(LIBRESSL_VERSION_NUMBER)
+#if defined(NID_X25519)
 #define PTLS_OPENSSL_HAVE_X25519 1
 #define PTLS_OPENSSL_HAS_X25519 1 /* deprecated; use HAVE_ */
 extern ptls_key_exchange_algorithm_t ptls_openssl_x25519;


### PR DESCRIPTION
As LibreSSL already supports X25519 ([changelog](https://github.com/libressl/portable/blob/master/ChangeLog)). Also NID_X25519 variable is also [defined](https://github.com/libressl/openbsd/blob/9d394c7780687b920ba0b1d0c64ec49d7a5a1772/src/lib/libcrypto/evp/evp.h#L120).
Hence, this patch allows LibreSSL to use X25519.