### PR TITLE
Add the `u` option to the getopt arg to parse

### DIFF
--- a/t/cli.c
+++ b/t/cli.c
@@ -456,7 +456,7 @@ int main(int argc, char **argv)
     int family = 0;
     const char *raw_pub_key_file = NULL, *cert_location = NULL;
 
-    while ((ch = getopt(argc, argv, "46abBC:c:i:Ij:k:nN:es:Sr:p:P:E:K:l:y:vV:h")) != -1) {
+    while ((ch = getopt(argc, argv, "46abBC:c:i:Ij:k:nN:es:Sr:p:P:E:K:l:uy:vV:h")) != -1) {
         switch (ch) {
         case '4':
             family = AF_INET;


### PR DESCRIPTION
As reported by https://github.com/h2o/picotls/issues/521, the args of `getopt()` misses `u`
and so it does not parse the `-u` option even though it is implemented.

This patch parses the `-u` option via `getopt`.

Fix https://github.com/h2o/picotls/issues/521