### PR TITLE
sampling-based tracing through Unix sockets

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -34,8 +34,10 @@ extern "C" {
 #include <inttypes.h>
 #include <string.h>
 #include <sys/types.h>
+#ifndef _WINDOWS
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#endif
 
 #if __GNUC__ >= 3
 #define PTLS_LIKELY(x) __builtin_expect(!!(x), 1)

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -1612,8 +1612,6 @@ static uint32_t ptls_log_conn_maybe_active(ptls_log_conn_state_t *conn, const ch
  * Returns the number of log events that were unable to be emitted.
  */
 size_t ptls_log_num_lost(void);
-
-#if PTLS_HAVE_LOG
 /**
  * Registers an fd to the logger. A registered fd is automatically closed and removed when it is closed by the peer.
  * @param sample_ratio  sampling ratio between 0 and 1
@@ -1623,7 +1621,6 @@ size_t ptls_log_num_lost(void);
  * @param addresses     list of IPv4/v6 addresses to log, using the same form as points
  */
 int ptls_log_add_fd(int fd, float sample_ratio, const char *points, const char *snis, const char *addresses, int appdata);
-#endif
 
 void ptls_log__recalc_point(int caller_locked, struct st_ptls_log_point_t *point);
 void ptls_log__recalc_conn(int caller_locked, struct st_ptls_log_conn_state_t *conn, const char *(*get_sni)(void *),

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -1421,10 +1421,10 @@ uint64_t ptls_decode_quicint(const uint8_t **src, const uint8_t *end);
 
 #define PTLS_LOG(module, name, block)                                                                                              \
     do {                                                                                                                           \
-        PTLS_LOG_DEFINE_POINT(module, name);                                                                                       \
-        if (ptls_log__active_connections(&logpoint) == 0)                                                                          \
+        PTLS_LOG_DEFINE_POINT(module, name, logpoint);                                                                             \
+        if (ptls_log_point_maybe_active(&logpoint) == 0)                                                                           \
             break;                                                                                                                 \
-        PTLS_LOG__DO_LOG((module), (type), (block));                                                                               \
+        PTLS_LOG__DO_LOG(module, name, NULL, NULL, NULL, {block});                                                                 \
     } while (0)
 
 #define PTLS_LOG_CONN(name, tls, block)                                                                                            \

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -2004,6 +2004,8 @@ static void ptls_hash_clone_memcpy(void *dst, const void *src, size_t size);
 
 inline uint32_t ptls_log_point_maybe_active(struct st_ptls_log_point_t *point)
 {
+    if (!PTLS_HAVE_LOG)
+        return 0;
     if (PTLS_UNLIKELY(point->state.generation != ptls_log._generation))
         ptls_log__recalc_point(0, point);
     return point->state.active_conns;
@@ -2016,6 +2018,8 @@ inline void ptls_log_recalc_conn_state(ptls_log_conn_state_t *state)
 
 inline uint32_t ptls_log_conn_maybe_active(ptls_log_conn_state_t *conn, const char *(*get_sni)(void *), void *get_sni_arg)
 {
+    if (!PTLS_HAVE_LOG)
+        return 0;
     if (PTLS_UNLIKELY(conn->state.generation != ptls_log._generation))
         ptls_log__recalc_conn(0, conn, get_sni, get_sni_arg);
     return conn->state.active_conns;

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -1397,13 +1397,13 @@ uint64_t ptls_decode_quicint(const uint8_t **src, const uint8_t *end);
         ptls_decode_assert_block_close((src), end);                                                                                \
     } while (0)
 
-#define PTLS_LOG__DO_LOG(module, name, conn_state, get_sni, get_sni_arg, block)                                                    \
+#define PTLS_LOG__DO_LOG(module, name, conn_state, get_sni, get_sni_arg, add_time, block)                                          \
     do {                                                                                                                           \
         int ptlslog_skip = 0, ptlslog_include_appdata = 0;                                                                         \
         do {                                                                                                                       \
             char smallbuf[128];                                                                                                    \
             ptls_buffer_t ptlslogbuf;                                                                                              \
-            ptls_log__do_write_start(&logpoint, &ptlslogbuf, smallbuf, sizeof(smallbuf));                                          \
+            ptls_log__do_write_start(&logpoint, &ptlslogbuf, smallbuf, sizeof(smallbuf), (add_time));                              \
             do {                                                                                                                   \
                 block                                                                                                              \
             } while (0);                                                                                                           \
@@ -1420,7 +1420,7 @@ uint64_t ptls_decode_quicint(const uint8_t **src, const uint8_t *end);
         PTLS_LOG_DEFINE_POINT(module, name, logpoint);                                                                             \
         if (ptls_log_point_maybe_active(&logpoint) == 0)                                                                           \
             break;                                                                                                                 \
-        PTLS_LOG__DO_LOG(module, name, NULL, NULL, NULL, {block});                                                                 \
+        PTLS_LOG__DO_LOG(module, name, NULL, NULL, NULL, 1, {block});                                                              \
     } while (0)
 
 #define PTLS_LOG_CONN(name, tls, block)                                                                                            \
@@ -1434,7 +1434,7 @@ uint64_t ptls_decode_quicint(const uint8_t **src, const uint8_t *end);
         active &= ptls_log_conn_maybe_active(conn_state, (const char *(*)(void *))ptls_get_server_name, _tls);                     \
         if (active == 0)                                                                                                           \
             break;                                                                                                                 \
-        PTLS_LOG__DO_LOG(picotls, name, conn_state, (const char *(*)(void *))ptls_get_server_name, _tls, {                         \
+        PTLS_LOG__DO_LOG(picotls, name, conn_state, (const char *(*)(void *))ptls_get_server_name, _tls, 1, {                      \
             PTLS_LOG_ELEMENT_PTR(tls, _tls);                                                                                       \
             do {                                                                                                                   \
                 block                                                                                                              \
@@ -1636,7 +1636,8 @@ int ptls_log__do_push_signed32(ptls_buffer_t *buf, int32_t v);
 int ptls_log__do_push_signed64(ptls_buffer_t *buf, int64_t v);
 int ptls_log__do_push_unsigned32(ptls_buffer_t *buf, uint32_t v);
 int ptls_log__do_push_unsigned64(ptls_buffer_t *buf, uint64_t v);
-void ptls_log__do_write_start(struct st_ptls_log_point_t *point, ptls_buffer_t *buf, void *smallbuf, size_t smallbufsize);
+void ptls_log__do_write_start(struct st_ptls_log_point_t *point, ptls_buffer_t *buf, void *smallbuf, size_t smallbufsize,
+                              int add_time);
 int ptls_log__do_write_end(struct st_ptls_log_point_t *point, struct st_ptls_log_conn_state_t *conn, const char *(*get_sni)(void *),
                            void *get_sni_arg, ptls_buffer_t *buf, int includes_appdata);
 

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -1989,7 +1989,7 @@ char *ptls_jsonescape(char *buf, const char *s, size_t len);
 /**
  * builds a v4-mapped address (i.e., ::ffff:192.0.2.1)
  */
-static void ptls_build_v4_mapped_v6_address(struct in6_addr *v6, const struct in_addr *v4);
+void ptls_build_v4_mapped_v6_address(struct in6_addr *v6, const struct in_addr *v4);
 
 /**
  * the default get_time callback
@@ -2168,12 +2168,6 @@ inline size_t ptls_aead_decrypt(ptls_aead_context_t *ctx, void *output, const vo
                                 const void *aad, size_t aadlen)
 {
     return ctx->do_decrypt(ctx, output, input, inlen, seq, aad, aadlen);
-}
-
-inline void ptls_build_v4_mapped_v6_address(struct in6_addr *v6, const struct in_addr *v4)
-{
-    *v6 = (struct in6_addr){.s6_addr[10] = 0xff, .s6_addr[11] = 0xff};
-    memcpy(&v6->s6_addr[12], &v4->s_addr, 4);
 }
 
 inline void ptls_hash_clone_memcpy(void *dst, const void *src, size_t size)

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -1983,7 +1983,7 @@ char *ptls_jsonescape(char *buf, const char *s, size_t len);
 /**
  * builds a v4-mapped address (i.e., ::ffff:192.0.2.1)
  */
-static void ptls_build_mapped_v4_address(struct in6_addr *v6, const struct in_addr *v4);
+static void ptls_build_v4_mapped_v6_address(struct in6_addr *v6, const struct in_addr *v4);
 
 /**
  * the default get_time callback
@@ -2160,7 +2160,7 @@ inline size_t ptls_aead_decrypt(ptls_aead_context_t *ctx, void *output, const vo
     return ctx->do_decrypt(ctx, output, input, inlen, seq, aad, aadlen);
 }
 
-inline void ptls_build_mapped_v4_address(struct in6_addr *v6, const struct in_addr *v4)
+inline void ptls_build_v4_mapped_v6_address(struct in6_addr *v6, const struct in_addr *v4)
 {
     *v6 = (struct in6_addr){.s6_addr[10] = 0xff, .s6_addr[11] = 0xff};
     memcpy(&v6->s6_addr[12], &v4->s_addr, 4);

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -68,7 +68,14 @@ extern "C" {
 #define PTLS_THREADLOCAL __declspec(thread)
 #else
 #define PTLS_THREADLOCAL __thread
+#endif
+
+#ifndef PTLS_HAVE_LOG
+#ifdef _WINDOWS
+#define PTLS_HAVE_LOG 0
+#else
 #define PTLS_HAVE_LOG 1
+#endif
 #endif
 
 #ifndef PTLS_FUZZ_HANDSHAKE

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -7125,7 +7125,7 @@ void ptls_log__do_write_start(struct st_ptls_log_point_t *point, ptls_buffer_t *
         pthread_mutex_lock(&mutex);
         if (tid.len == 0) {
 #if defined(__linux__)
-            sprintf(tid.buf, ",\"tid\":%" PRId64, (int64_t)syscall(SYS_gettid));
+            int l = sprintf(tid.buf, ",\"tid\":%" PRId64, (int64_t)syscall(SYS_gettid));
 #elif defined(__APPLE__)
             uint64_t t = 0;
             (void)pthread_threadid_np(NULL, &t);

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -273,10 +273,12 @@ struct st_ptls_t {
     unsigned send_change_cipher_spec : 1;
     unsigned needs_key_update : 1;
     unsigned key_update_send_request : 1;
+#if PTLS_HAVE_LOG
     /**
      * see ptls_log
      */
     ptls_log_conn_state_t log_state;
+#endif
     struct {
         uint32_t active_conns;
         uint32_t generation;
@@ -5140,11 +5142,15 @@ static ptls_t *new_instance(ptls_context_t *ctx, int is_server)
     *tls = (ptls_t){ctx};
     tls->is_server = is_server;
     tls->send_change_cipher_spec = ctx->send_change_cipher_spec;
+
+#if PTLS_HAVE_LOG
     if (ptls_log_conn_state_override != NULL) {
         tls->log_state = *ptls_log_conn_state_override;
     } else {
         ptls_log_init_conn_state(&tls->log_state, ctx->random_bytes);
     }
+#endif
+
     return tls;
 }
 
@@ -5592,7 +5598,11 @@ void **ptls_get_data_ptr(ptls_t *tls)
 
 ptls_log_conn_state_t *ptls_get_log_state(ptls_t *tls)
 {
+#if PTLS_HAVE_LOG
     return &tls->log_state;
+#else
+    return &ptls_log.dummy_conn_state;
+#endif
 }
 
 static int handle_client_handshake_message(ptls_t *tls, ptls_message_emitter_t *emitter, ptls_iovec_t message, int is_end_of_record,

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -6901,6 +6901,9 @@ static void close_log_fd(size_t slot)
 
 static char *duplicate_stringlist(const char *input)
 {
+    if (input == NULL)
+        return strdup("");
+
     char *result;
     const char *in_tail;
 
@@ -7035,14 +7038,14 @@ int ptls_log_add_fd(int fd, float sample_ratio, const char *_points, const char 
     }
     {
         size_t num_addresses = 0;
-        for (const char *input = _addresses; *input != '\0'; input += strlen(input) + 1)
+        for (const char *input = _addresses; input != NULL && *input != '\0'; input += strlen(input) + 1)
             ++num_addresses;
         if ((addresses = malloc(sizeof(*addresses) * (num_addresses + 1))) == NULL) {
             ret = PTLS_ERROR_NO_MEMORY;
             goto Exit;
         }
         size_t index = 0;
-        for (const char *input = _addresses; *input != '\0'; input += strlen(input) + 1) {
+        for (const char *input = _addresses; input != NULL && *input != '\0'; input += strlen(input) + 1) {
             /* note: for consistency to the handling of points, erroneous input is ignored. V4 addresses will use the mapped form
              * (::ffff:192.0.2.1) */
             if (!inet_pton(AF_INET6, input, &addresses[index])) {

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -7105,39 +7105,53 @@ Exit:
 #endif
 }
 
-void ptls_log__do_write_start(struct st_ptls_log_point_t *point, ptls_buffer_t *buf, void *smallbuf, size_t smallbufsize)
+void ptls_log__do_write_start(struct st_ptls_log_point_t *point, ptls_buffer_t *buf, void *smallbuf, size_t smallbufsize,
+                              int add_time)
 {
 #if defined(__linux__) || defined(__APPLE__)
     static PTLS_THREADLOCAL char tid[sizeof(",\"tid\":-9223372036854775808")];
-    static PTLS_THREADLOCAL int tid_ready;
-    if (!tid_ready) {
+    static PTLS_THREADLOCAL size_t tid_len;
+    if (tid_len == 0) {
         static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
         pthread_mutex_lock(&mutex);
-        if (!tid_ready) {
+        if (tid_len == 0) {
 #if defined(__linux__)
             sprintf(tid, ",\"tid\":%" PRId64, (int64_t)syscall(SYS_gettid));
 #elif defined(__APPLE__)
             uint64_t t = 0;
             (void)pthread_threadid_np(NULL, &t);
-            sprintf(tid, ",\"tid\":%" PRIu64, t);
+            int l = sprintf(tid, ",\"tid\":%" PRIu64, t);
 #else
 #error "unexpected platform"
 #endif
             __sync_synchronize();
-            tid_ready = 1;
+            tid_len = (size_t)l;
         }
         pthread_mutex_unlock(&mutex);
     }
 #else
-    const char *tid = "";
+    const char *tid = NULL;
+    const size_t tid_len = 0;
 #endif
     const char *colon_at = strchr(point->name, ':');
 
     ptls_buffer_init(buf, smallbuf, smallbufsize);
 
-    int written = snprintf((char *)buf->base, buf->capacity, "{\"module\":\"%.*s\",\"type\":\"%s\"%s",
-                           (int)(colon_at - point->name), point->name, colon_at + 1, tid);
+    int written = snprintf((char *)buf->base, buf->capacity, "{\"module\":\"%.*s\",\"type\":\"%s\"", (int)(colon_at - point->name),
+                           point->name, colon_at + 1);
+    if (tid != NULL) {
+        assert(written > 0 && written + tid_len < buf->capacity);
+        memcpy((char *)buf->base + written, tid, tid_len + 1);
+        written += tid_len;
+    }
+    if (add_time != 0) {
+        struct timeval tv;
+        gettimeofday(&tv, NULL);
+        written += snprintf((char *)buf->base + written, buf->capacity - written, ",\"time\":%" PRIu64,
+                            (uint64_t)tv.tv_sec * 1000 + tv.tv_usec / 1000);
+    }
     assert(written > 0 && written < buf->capacity && "caller MUST provide smallbuf suffient to emit the prefix");
+
     buf->off = (size_t)written;
 }
 

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -34,6 +34,9 @@
 #include <arpa/inet.h>
 #include <sys/time.h>
 #endif
+#ifdef __linux__
+#include <sys/syscall.h>
+#endif
 #include "picotls.h"
 #if PICOTLS_USE_DTRACE
 #include "picotls-probes.h"

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -7013,8 +7013,7 @@ void ptls_log__recalc_conn(int caller_locked, struct st_ptls_log_conn_state_t *c
         const char *sni = get_sni != NULL ? get_sni(get_sni_arg) : NULL;
         for (size_t slot = 0; slot < PTLS_ELEMENTSOF(logctx.conns); ++slot) {
             if (logctx.conns[slot].points != NULL && conn->random_ < logctx.conns[slot].sample_ratio &&
-                is_in_stringlist(logctx.conns[slot].snis, sni) &&
-                is_in_addresslist(logctx.conns[slot].addresses, &conn->address)) {
+                is_in_stringlist(logctx.conns[slot].snis, sni) && is_in_addresslist(logctx.conns[slot].addresses, &conn->address)) {
                 new_active |= (uint32_t)1 << slot;
             }
         }

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -6987,7 +6987,7 @@ void ptls_log__recalc_point(int caller_locked, struct st_ptls_log_point_t *point
         uint32_t new_active = 0;
         for (size_t slot = 0; slot < PTLS_ELEMENTSOF(logctx.conns); ++slot)
             if (logctx.conns[slot].points != NULL && is_in_stringlist(logctx.conns[slot].points, point->name))
-                new_active = (uint32_t)1 << slot;
+                new_active |= (uint32_t)1 << slot;
         point->state.active_conns = new_active;
         point->state.generation = ptls_log._generation;
     }
@@ -7012,7 +7012,7 @@ void ptls_log__recalc_conn(int caller_locked, struct st_ptls_log_conn_state_t *c
             if (logctx.conns[slot].points != NULL && conn->random_ < logctx.conns[slot].sample_ratio &&
                 is_in_stringlist(logctx.conns[slot].snis, sni) &&
                 is_in_addresslist(logctx.conns[slot].addresses, &conn->address)) {
-                new_active = (uint32_t)1 << slot;
+                new_active |= (uint32_t)1 << slot;
             }
         }
         conn->state.active_conns = new_active;

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -6765,6 +6765,12 @@ char *ptls_jsonescape(char *buf, const char *unsafe_str, size_t len)
     return dst;
 }
 
+void ptls_build_v4_mapped_v6_address(struct in6_addr *v6, const struct in_addr *v4)
+{
+    *v6 = (struct in6_addr){.s6_addr[10] = 0xff, .s6_addr[11] = 0xff};
+    memcpy(&v6->s6_addr[12], &v4->s_addr, 4);
+}
+
 int ptls_log__do_pushv(ptls_buffer_t *buf, const void *p, size_t l)
 {
     if (ptls_buffer_reserve(buf, l) != 0)

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -104,18 +104,15 @@ static const char ech_info_prefix[8] = "tls ech";
 #endif
 
 #if PICOTLS_USE_DTRACE
-#define PTLS_SHOULD_PROBE(LABEL, tls) (PTLS_UNLIKELY(PICOTLS_##LABEL##_ENABLED()) && !(tls)->skip_tracing)
 #define PTLS_PROBE0(LABEL, tls)                                                                                                    \
     do {                                                                                                                           \
-        ptls_t *_tls = (tls);                                                                                                      \
-        if (PTLS_SHOULD_PROBE(LABEL, _tls))                                                                                        \
-            PICOTLS_##LABEL(_tls);                                                                                                 \
+        if (PTLS_UNLIKELY(PICOTLS_##LABEL##_ENABLED()))                                                                            \
+            PICOTLS_##LABEL(tls);                                                                                                  \
     } while (0)
 #define PTLS_PROBE(LABEL, tls, ...)                                                                                                \
     do {                                                                                                                           \
-        ptls_t *_tls = (tls);                                                                                                      \
-        if (PTLS_SHOULD_PROBE(LABEL, _tls))                                                                                        \
-            PICOTLS_##LABEL(_tls, __VA_ARGS__);                                                                                    \
+        if (PTLS_UNLIKELY(PICOTLS_##LABEL##_ENABLED()))                                                                            \
+            PICOTLS_##LABEL((tls), __VA_ARGS__);                                                                                   \
     } while (0)
 #else
 #define PTLS_PROBE0(LABEL, tls)

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -7027,7 +7027,7 @@ int ptls_log_add_fd(int fd, float sample_ratio, const char *_points, const char 
                 struct in_addr v4;
                 if (!inet_pton(AF_INET, input, &v4))
                     continue;
-                ptls_build_mapped_v4_address(&addresses[index], &v4);
+                ptls_build_v4_mapped_v6_address(&addresses[index], &v4);
             }
             if (memcmp(&addresses[index], &in6addr_any, sizeof(struct in6_addr)) == 0)
                 continue;

--- a/t/cli.c
+++ b/t/cli.c
@@ -74,7 +74,7 @@ static void setup_ptlslog(const char *fn)
         fprintf(stderr, "failed to open file:%s:%s\n", fn, strerror(errno));
         exit(1);
     }
-    ptls_log_add_fd(fd);
+    ptls_log_add_fd(fd, 1., NULL, NULL, NULL, 1);
 }
 
 static int handle_connection(int sockfd, ptls_context_t *ctx, const char *server_name, const char *input_file,

--- a/t/cli.c
+++ b/t/cli.c
@@ -75,6 +75,7 @@ static void setup_ptlslog(const char *fn)
         exit(1);
     }
     ptls_log_add_fd(fd, 1., NULL, NULL, NULL, 1);
+    ptls_log.may_include_appdata = 1;
 }
 
 static int handle_connection(int sockfd, ptls_context_t *ctx, const char *server_name, const char *input_file,


### PR DESCRIPTION
This PR expands the support for sampling-based tracing through Unix sockets.

Connections to be traced can be selected based on the combination of the following criteria:
* sampling ratio - a `float` between 0 and 1
* any number of SNIs
* any number of client IP addresses
* if or not to include application data

Unlike the old USDT-based scheme (as has been provided by h2olog), the new interface allows each logger to specify different criteria. Up to 32 loggers are supported.

As we transition from using USDT to Unix sockets, sampling support is removed from the USDT side. Otherwise, USDT probes are retained as-is, as they are considered valuable properties when debugging the system as a whole with picotls or h2o being part of the system.