### PR TITLE
in case of external PSK mode, clients need not provide `properties`

### DIFF
--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -2383,7 +2383,7 @@ static int send_client_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptls_
                 }
             }
             assert(tls->cipher_suite != NULL && "no compatible cipher-suite provided that matches psk.hash");
-            if (properties->client.max_early_data_size != NULL) {
+            if (properties != NULL && properties->client.max_early_data_size != NULL) {
                 tls->client.using_early_data = 1;
                 *properties->client.max_early_data_size = SIZE_MAX;
             }


### PR DESCRIPTION
Cherry-pick from https://github.com/h2o/h2o/pull/3424.