### PR TITLE
Force serialization of `dtrace` `-G` invocations.

### DIFF
--- a/cmake/dtrace-utils.cmake
+++ b/cmake/dtrace-utils.cmake
@@ -32,7 +32,8 @@ FUNCTION (DEFINE_DTRACE_DEPENDENCIES d_file prefix)
     IF (DTRACE_USES_OBJFILE)
         ADD_CUSTOM_COMMAND(
             OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.o
-            COMMAND dtrace -o ${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.o -s ${d_file} -G
+            # /usr/bin/dtrace uses deterministic temporary files, do not let make parallelize
+            COMMAND flock /tmp/dtrace.lock dtrace -o ${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.o -s ${d_file} -G
             DEPENDS ${d_file})
         ADD_DEPENDENCIES(generate-${prefix}-probes ${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.o)
         SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_BINARY_DIR}/${prefix}-probes.o PROPERTIES GENERATED TRUE)


### PR DESCRIPTION
As of ubuntu focal (20.04), ` systemtap-sdt-dev` version `4.2-3ubuntu0.1`, the temporary files collide in a build with concurrency (`make` `-j`).

The description in the systemtap repo commit [0de9020c9](https://sourceware.org/git/?p=systemtap.git;a=commit;h=0de9020c970bceda73e32bbd169c12e7579f21ec) describes the problem.  From what I can tell, that commit introduced the version that we see on focal and it has the problem that we run into in a parallel build of h2o, because as the description mentions:

> Note: this still leaves open a race in the case of 2 dtrace processes with identical input/output paths.

`dtrace` does not take all that long to run, the impact that serializing all `dtrace` command invocations has on the build time is imperceptible.

The eventual fix in [05c8fa6a5](https://sourceware.org/git/?p=systemtap.git;a=commit;h=05c8fa6a54b78e87c2513f52641d1bba10852994) seems to be a better fix because it looks like it checks for collisions, though I have not tested that version.