### PR TITLE
Minor fix to headers sequence

### DIFF
--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -32,9 +32,9 @@
 #include <errno.h>
 #include <pthread.h>
 #include <unistd.h>
+#include <sys/socket.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>
-#include <sys/socket.h>
 #include <sys/time.h>
 #include <sys/types.h>
 #endif


### PR DESCRIPTION
This is a trivial change on top of https://github.com/h2o/picotls/commit/bbcdbe6dc31ec5d4b72a7beece4daf58098bad42

Older macOS requires `<sys/socket.h>` to come before other related headers.