### PR TITLE
send_certificate_verify: remove invalid assert in client mode

### DIFF
--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -3188,7 +3188,6 @@ static int send_certificate_verify(ptls_t *tls, ptls_message_emitter_t *emitter,
                 }
                 goto Exit;
             }
-            assert(tls->server.async_job == NULL);
             sendbuf->base[algo_off] = (uint8_t)(algo >> 8);
             sendbuf->base[algo_off + 1] = (uint8_t)algo;
         });


### PR DESCRIPTION
The function send_certificate_verify is used both in client and server mode. When it is used in client mode, the server part of the union in struct st_ptls_t is not supposed to be read. Moreover the client part is larger than the server part, e.g. on x86_64:

  sizeof(st_ptls_t.client): 120
  sizeof(st_ptls_t.server):  80

It means that server.async_job may not be NULL when calling the function in client mode.