### PR TITLE
Fix out-of-bounds read in ASN.1 type-and-length parser

### DIFF
--- a/lib/asn1.c
+++ b/lib/asn1.c
@@ -183,6 +183,11 @@ size_t ptls_asn1_get_expected_type_and_length(const uint8_t *bytes, size_t bytes
 {
     int is_indefinite = 0;
 
+    if (byte_index >= bytes_max) {
+        *decode_error = PTLS_ERROR_INCORRECT_ASN1_SYNTAX;
+        return ptls_asn1_error_message("Unexpected end of input", bytes_max, byte_index, 0, log_ctx);
+    }
+
     /* Check that the expected type is present */
     if (bytes[byte_index] != expected_type) {
         byte_index = ptls_asn1_error_message("Unexpected type", bytes_max, byte_index, 0, log_ctx);

--- a/t/minicrypto.c
+++ b/t/minicrypto.c
@@ -28,6 +28,7 @@
 #include "../deps/picotest/picotest.h"
 #include "../lib/cifra.c"
 #include "../lib/uecc.c"
+#include "picotls/asn1.h"
 #include "test.h"
 
 static void test_secp256r1_key_exchange(void)
@@ -135,6 +136,26 @@ static void test_hrr(void)
     ptls_free(server);
 }
 
+static void test_asn1_empty_input(void)
+{
+    int decode_error = 0;
+    uint32_t length = 0;
+    size_t last_byte = 0;
+    uint8_t dummy = 0x30;
+
+    ptls_asn1_get_expected_type_and_length(&dummy, 0, 0, 0x30, &length, NULL, &last_byte, &decode_error, NULL);
+    ok(decode_error != 0);
+
+    decode_error = 0;
+    uint8_t buf[2] = {0x30, 0x00};
+    ptls_asn1_get_expected_type_and_length(buf, 2, 2, 0x30, &length, NULL, &last_byte, &decode_error, NULL);
+    ok(decode_error != 0);
+
+    decode_error = 0;
+    ptls_asn1_get_expected_type_and_length(buf, 1, 1, 0x04, &length, NULL, &last_byte, &decode_error, NULL);
+    ok(decode_error != 0);
+}
+
 DEFINE_FFX_AES128_ALGORITHMS(minicrypto);
 DEFINE_FFX_CHACHA20_ALGORITHMS(minicrypto);
 
@@ -161,6 +182,7 @@ int main(int argc, char **argv)
     ADD_FFX_CHACHA20_ALGORITHMS(minicrypto);
 
     subtest("picotls", test_picotls);
+    subtest("asn1-bounds", test_asn1_empty_input);
     subtest("hrr", test_hrr);
 
     return done_testing();


### PR DESCRIPTION
`ptls_asn1_get_expected_type_and_length()`, which is part of the public API, could read past the end of the input buffer.