### PR TITLE
when peer verification is off, accept RSA-PSS-RSAE-SHA384 / ECDSA-SECP384R1-SHA384

### DIFF
--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -1979,7 +1979,8 @@ Exit:
 static int push_signature_algorithms(ptls_verify_certificate_t *vc, ptls_buffer_t *sendbuf)
 {
     /* The list sent when verify callback is not registered */
-    static const uint16_t default_algos[] = {PTLS_SIGNATURE_RSA_PSS_RSAE_SHA256, PTLS_SIGNATURE_ECDSA_SECP256R1_SHA256,
+    static const uint16_t default_algos[] = {PTLS_SIGNATURE_RSA_PSS_RSAE_SHA384, PTLS_SIGNATURE_RSA_PSS_RSAE_SHA256,
+                                             PTLS_SIGNATURE_ECDSA_SECP384R1_SHA384, PTLS_SIGNATURE_ECDSA_SECP256R1_SHA256,
                                              PTLS_SIGNATURE_RSA_PKCS1_SHA256, PTLS_SIGNATURE_RSA_PKCS1_SHA1, UINT16_MAX};
     int ret;
 


### PR DESCRIPTION
The purpose of skipping verification is to test transport interoperability; there is no reason to not include ones used in practice.