### PR TITLE
Fix error propagation in TLS 1.2 receive path

### DIFF
--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -6008,7 +6008,7 @@ static int handle_input_tls12(ptls_t *tls, ptls_buffer_t *decryptbuf, const void
 Exit:
     ptls_buffer_dispose(&tls->recvbuf.rec);
     ptls_clear_memory(aad, sizeof(aad));
-    return 0;
+    return ret;
 }
 
 static void init_record_message_emitter(ptls_t *tls, struct st_ptls_record_message_emitter_t *emitter, ptls_buffer_t *sendbuf)


### PR DESCRIPTION
handle_input_tls12 unconditionally returned 0, silently discarding AEAD decryption failures, bad MAC errors, and other fatal conditions on imported/resumed TLS 1.2 connections.

Callers of ptls_receive had no way to observe that a record failed authentication.