### PR TITLE
Reject undersized ciphertext in bcrypt AEAD decrypt

### DIFF
--- a/lib/ptlsbcrypt.c
+++ b/lib/ptlsbcrypt.c
@@ -448,8 +448,13 @@ static size_t ptls_bcrypt_aead_do_decrypt(struct st_ptls_aead_context_t *_ctx, v
 {
     struct ptls_bcrypt_aead_context_t *ctx = (struct ptls_bcrypt_aead_context_t *)_ctx;
     ULONG cbResult;
-    size_t textLen = inlen - ctx->super.algo->tag_size;
+    size_t textLen;
     NTSTATUS ret;
+
+    if (inlen < ctx->super.algo->tag_size) {
+        return SIZE_MAX;
+    }
+    textLen = inlen - ctx->super.algo->tag_size;
 
     /* Build the IV for this decryption */
     ptls_aead__build_iv(ctx->super.algo, ctx->bctx.iv, ctx->bctx.iv_static, seq);


### PR DESCRIPTION
ptls_bcrypt_aead_do_decrypt subtracted the tag size from inlen without first checking that inlen is large enough.

When inlen is smaller than the tag, the size_t subtraction wraps, producing a bogus textLen and an out-of-bounds tag pointer that get forwarded to BCryptDecrypt.