### PR TITLE
[codex] fix TLS 1.3 CCS and cert alert codes

### DIFF
--- a/lib/openssl.c
+++ b/lib/openssl.c
@@ -1930,6 +1930,12 @@ static int verify_cert_chain(X509_STORE *store, X509 *cert, STACK_OF(X509) * cha
             break;
         case X509_V_ERR_HOSTNAME_MISMATCH:
         case X509_V_ERR_INVALID_CA:
+#ifdef X509_V_ERR_CA_MD_TOO_WEAK
+        case X509_V_ERR_CA_MD_TOO_WEAK:
+#endif
+#ifdef X509_V_ERR_UNSUPPORTED_SIGNATURE_ALGORITHM
+        case X509_V_ERR_UNSUPPORTED_SIGNATURE_ALGORITHM:
+#endif
             ret = PTLS_ALERT_BAD_CERTIFICATE;
             break;
         default:

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -5874,9 +5874,9 @@ static int handle_input(ptls_t *tls, ptls_message_emitter_t *emitter, ptls_buffe
     if (rec.type == PTLS_CONTENT_TYPE_CHANGE_CIPHER_SPEC) {
         if (tls->state < PTLS_STATE_POST_HANDSHAKE_MIN) {
             if (!(rec.length == 1 && rec.fragment[0] == 0x01))
-                return PTLS_ALERT_ILLEGAL_PARAMETER;
+                return PTLS_ALERT_UNEXPECTED_MESSAGE;
         } else {
-            return PTLS_ALERT_HANDSHAKE_FAILURE;
+            return PTLS_ALERT_UNEXPECTED_MESSAGE;
         }
         ret = PTLS_ERROR_IN_PROGRESS;
         goto NextRecord;


### PR DESCRIPTION
## Summary
Fix two TLS 1.3 alert-mapping issues:
- return `unexpected_message` for invalid plaintext `change_cipher_spec` records and for plaintext CCS received after the peer's Finished message
- map MD5-related certificate verification failures to `bad_certificate` when OpenSSL exposes `X509_V_ERR_CA_MD_TOO_WEAK` or `X509_V_ERR_UNSUPPORTED_SIGNATURE_ALGORITHM`

## Why
RFC 8446 Appendix D.4 requires `unexpected_message` for the plaintext CCS cases.
RFC 8446 Section 4.4.2.4 requires `bad_certificate` when validation would require an MD5-based signature algorithm.

## Compatibility
The certificate-error additions are guarded so the OpenSSL backend continues to build across picotls's older OpenSSL and LibreSSL matrix.

## Validation
Not run, per request.
