### PR TITLE
fix three client-side ECH bugs (grease 0-RTT, HRR/SH, NULL configs)

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -1123,8 +1123,9 @@ typedef struct st_ptls_handshake_properties_t {
              */
             struct {
                 /**
-                 * Config offered by server e.g., by HTTPS RR. If config.base is non-NULL but config.len is zero, a grease ECH will
-                 * be sent, assuming that X25519-SHA256 KEM and SHA256-AES-128-GCM HPKE cipher is available.
+                 * An ECH config offered by server e.g., by HTTPS RR. If config.len is zero and .base is non-NULL, a grease ECH will
+                 * be sent, assuming that X25519-SHA256 KEM and SHA256-AES-128-GCM HPKE cipher is available. If .base is also NULL,
+                 * ECH will not be used at all, even if the context provided the ECH ciphers.
                  */
                 ptls_iovec_t configs;
                 /**

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -1177,7 +1177,6 @@ static void client_setup_ech_grease(struct st_ptls_ech_t *ech, void (*random_byt
                                     ptls_hpke_cipher_suite_t **ciphers, const char *sni_name)
 {
     static const size_t x25519_key_size = 32;
-    uint8_t random_secret[PTLS_AES128_KEY_SIZE + PTLS_AES_IV_SIZE];
 
     /* pick up X25519, AES-128-GCM or bail out */
     for (size_t i = 0; kems[i] != NULL; ++i) {
@@ -1194,10 +1193,6 @@ static void client_setup_ech_grease(struct st_ptls_ech_t *ech, void (*random_byt
     }
     if (ech->kem == NULL || ech->cipher == NULL)
         goto Fail;
-
-    /* aead is generated from random */
-    random_bytes(random_secret, sizeof(random_secret));
-    ech->aead = ptls_aead_new_direct(ech->cipher->aead, 1, random_secret, random_secret + PTLS_AES128_KEY_SIZE);
 
     /* `enc` is random bytes */
     if ((ech->client.enc.base = malloc(x25519_key_size)) == NULL)
@@ -2341,6 +2336,68 @@ Exit:
     return ret;
 }
 
+static int build_grease_ech_extension(ptls_context_t *ctx, struct st_ptls_ech_t *ech, ptls_iovec_t *dst,
+                                      ptls_handshake_properties_t *properties, const void *client_random,
+                                      ptls_key_exchange_context_t *key_share_ctx, const char *sni_name,
+                                      ptls_iovec_t legacy_session_id, ptls_iovec_t psk_secret, ptls_iovec_t psk_identity,
+                                      uint32_t obfuscated_ticket_age, size_t psk_binder_size, ptls_iovec_t *cookie,
+                                      int using_early_data)
+{
+    ptls_buffer_t chbuf, extbuf;
+    int ret;
+
+    *dst = ptls_iovec_init(NULL, 0);
+    ptls_buffer_init(&chbuf, "", 0);
+    ptls_buffer_init(&extbuf, "", 0);
+
+    if ((ret = encode_client_hello(ctx, &chbuf, ENCODE_CH_MODE_INNER, 0, properties, client_random, key_share_ctx, sni_name,
+                                   legacy_session_id, ech, NULL, ptls_iovec_init(NULL, 0), psk_secret, psk_identity,
+                                   obfuscated_ticket_age, psk_binder_size, cookie, using_early_data)) != 0)
+        goto Exit;
+
+    { /* pad as if this were EncodedClientHelloInner */
+        size_t padding_len;
+        if (sni_name != NULL) {
+            padding_len = strlen(sni_name);
+            if (padding_len < ech->client.max_name_length)
+                padding_len = ech->client.max_name_length;
+        } else {
+            padding_len = ech->client.max_name_length + 9;
+        }
+        size_t final_len = chbuf.off - PTLS_HANDSHAKE_HEADER_SIZE + padding_len;
+        final_len = (final_len + 31) / 32 * 32;
+        padding_len = final_len - (chbuf.off - PTLS_HANDSHAKE_HEADER_SIZE);
+        if (padding_len != 0) {
+            if ((ret = ptls_buffer_reserve(&chbuf, padding_len)) != 0)
+                goto Exit;
+            memset(chbuf.base + chbuf.off, 0, padding_len);
+            chbuf.off += padding_len;
+        }
+    }
+
+    size_t payload_len = chbuf.off - PTLS_HANDSHAKE_HEADER_SIZE + ech->cipher->aead->tag_size;
+    ptls_buffer_push(&extbuf, PTLS_ECH_CLIENT_HELLO_TYPE_OUTER);
+    ptls_buffer_push16(&extbuf, ech->cipher->id.kdf);
+    ptls_buffer_push16(&extbuf, ech->cipher->id.aead);
+    ptls_buffer_push(&extbuf, ech->config_id);
+    ptls_buffer_push_block(&extbuf, 2, { ptls_buffer_pushv(&extbuf, ech->client.enc.base, ech->client.enc.len); });
+    ptls_buffer_push_block(&extbuf, 2, {
+        if ((ret = ptls_buffer_reserve(&extbuf, payload_len)) != 0)
+            goto Exit;
+        ctx->random_bytes(extbuf.base + extbuf.off, payload_len);
+        extbuf.off += payload_len;
+    });
+
+    *dst = ptls_iovec_init(extbuf.base, extbuf.off);
+    extbuf = (ptls_buffer_t){0};
+    ret = 0;
+
+Exit:
+    ptls_buffer_dispose(&chbuf);
+    ptls_buffer_dispose(&extbuf);
+    return ret;
+}
+
 static int send_client_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptls_handshake_properties_t *properties,
                              ptls_iovec_t *cookie)
 {
@@ -2375,6 +2432,7 @@ static int send_client_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptls_
                 /* zero-length config indicates ECH greasing */
                 client_setup_ech_grease(&tls->ech, tls->ctx->random_bytes, tls->ctx->ech.client.kems, tls->ctx->ech.client.ciphers,
                                         sni_name);
+                tls->ech.offered_grease = 1;
             }
         }
     }
@@ -2456,6 +2514,14 @@ static int send_client_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptls_
             goto Exit;
         }
         if ((ret = key_schedule_extract(tls->key_schedule, psk.secret)) != 0)
+            goto Exit;
+    }
+
+    if (tls->ech.offered_grease && !is_second_flight && tls->ech.client.first_ech.base == NULL) {
+        if ((ret = build_grease_ech_extension(tls->ctx, &tls->ech, &tls->ech.client.first_ech, properties, tls->client_random,
+                                              tls->client.key_share_ctx, sni_name, tls->client.legacy_session_id, psk.secret,
+                                              psk.identity, obfuscated_ticket_age, tls->key_schedule->hashes[0].algo->digest_size,
+                                              cookie, tls->client.using_early_data)) != 0)
             goto Exit;
     }
 
@@ -2541,11 +2607,7 @@ static int send_client_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptls_
             memcpy(tls->ech.client.first_ech.base,
                    emitter->buf->base + ech_size_offset - outer_ech_header_size(tls->ech.client.enc.len), len);
             tls->ech.client.first_ech.len = len;
-            if (properties->client.ech.configs.len != 0) {
-                tls->ech.offered = 1;
-            } else {
-                tls->ech.offered_grease = 1;
-            }
+            tls->ech.offered = 1;
         }
         /* update hash */
         ptls__key_schedule_update_hash(tls->key_schedule, emitter->buf->base + mess_start, emitter->buf->off - mess_start, 1);
@@ -3003,8 +3065,16 @@ static int client_handle_encrypted_extensions(ptls_t *tls, ptls_iovec_t message,
             src = end;
             break;
         case PTLS_EXTENSION_TYPE_ENCRYPTED_CLIENT_HELLO: {
+            if (tls->ech.offered_grease) {
+                /* GREASE clients ignore retry_configs after verifying the syntax. */
+                struct st_decoded_ech_config_t decoded;
+                if ((ret = client_decode_ech_config_list(tls->ctx, &decoded, ptls_iovec_init(src, end - src))) != 0)
+                    goto Exit;
+                src = end;
+                break;
+            }
             /* accept retry_configs only if we offered ECH but rejected */
-            if (!((tls->ech.offered || tls->ech.offered_grease) && !ptls_is_ech_handshake(tls, NULL, NULL, NULL))) {
+            if (!(tls->ech.offered && !ptls_is_ech_handshake(tls, NULL, NULL, NULL))) {
                 ret = PTLS_ALERT_UNSUPPORTED_EXTENSION;
                 goto Exit;
             }

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -1177,6 +1177,7 @@ static void client_setup_ech_grease(struct st_ptls_ech_t *ech, void (*random_byt
                                     ptls_hpke_cipher_suite_t **ciphers, const char *sni_name)
 {
     static const size_t x25519_key_size = 32;
+    uint8_t random_secret[PTLS_AES128_KEY_SIZE + PTLS_AES_IV_SIZE];
 
     /* pick up X25519, AES-128-GCM or bail out */
     for (size_t i = 0; kems[i] != NULL; ++i) {
@@ -1195,11 +1196,8 @@ static void client_setup_ech_grease(struct st_ptls_ech_t *ech, void (*random_byt
         goto Fail;
 
     /* aead is generated from random */
-    {
-        uint8_t random_secret[PTLS_AES128_KEY_SIZE + PTLS_AES_IV_SIZE];
-        random_bytes(random_secret, sizeof(random_secret));
-        ech->aead = ptls_aead_new_direct(ech->cipher->aead, 1, random_secret, random_secret + PTLS_AES128_KEY_SIZE);
-    }
+    random_bytes(random_secret, sizeof(random_secret));
+    ech->aead = ptls_aead_new_direct(ech->cipher->aead, 1, random_secret, random_secret + PTLS_AES128_KEY_SIZE);
 
     /* `enc` is random bytes */
     if ((ech->client.enc.base = malloc(x25519_key_size)) == NULL)
@@ -3037,25 +3035,19 @@ static int client_handle_encrypted_extensions(ptls_t *tls, ptls_iovec_t message,
             src = end;
             break;
         case PTLS_EXTENSION_TYPE_ENCRYPTED_CLIENT_HELLO: {
-            if (tls->ech.offered_grease) {
-                /* GREASE clients ignore retry_configs after verifying the syntax. */
-                struct st_decoded_ech_config_t decoded;
-                if ((ret = client_decode_ech_config_list(tls->ctx, &decoded, ptls_iovec_init(src, end - src))) != 0)
-                    goto Exit;
-                src = end;
-                break;
-            }
-            /* accept retry_configs only if we offered ECH but rejected */
-            if (!(tls->ech.offered && !ptls_is_ech_handshake(tls, NULL, NULL, NULL))) {
+            /* accept retry_configs only if we offered ECH (or grease) but rejected */
+            if (!((tls->ech.offered || tls->ech.offered_grease) && !ptls_is_ech_handshake(tls, NULL, NULL, NULL))) {
                 ret = PTLS_ALERT_UNSUPPORTED_EXTENSION;
                 goto Exit;
             }
-            /* parse retry_config, and if it is applicable, provide that to the application */
+            /* parse retry_config, and if it is applicable, provide that to the application (grease clients just verify syntax) */
             struct st_decoded_ech_config_t decoded;
             if ((ret = client_decode_ech_config_list(tls->ctx, &decoded, ptls_iovec_init(src, end - src))) != 0)
                 goto Exit;
-            if (decoded.kem != NULL && decoded.cipher != NULL && properties != NULL &&
-                properties->client.ech.retry_configs != NULL) {
+            if (tls->ech.offered_grease) {
+                /* GREASE clients ignore retry_configs after verifying the syntax */
+            } else if (decoded.kem != NULL && decoded.cipher != NULL && properties != NULL &&
+                       properties->client.ech.retry_configs != NULL) {
                 if ((properties->client.ech.retry_configs->base = malloc(end - src)) == NULL) {
                     ret = PTLS_ERROR_NO_MEMORY;
                     goto Exit;

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -180,9 +180,16 @@ struct st_decoded_ech_config_t {
  * Properties for ECH. Iff ECH is used and not rejected, `aead` is non-NULL.
  */
 struct st_ptls_ech_t {
-    uint8_t offered : 1;
-    uint8_t offered_grease : 1;
-    uint8_t accepted : 1;
+    /**
+     * ECH state for this connection. `OFFERED` and `ACCEPTED` are used on both client and server; `GREASE` is client-only (server
+     * cannot distinguish GREASE from a config mismatch, both are simply ECH that fails to decrypt).
+     */
+    enum en_ptls_ech_state_t {
+        PTLS_ECH_STATE_NONE = 0,
+        PTLS_ECH_STATE_OFFERED,
+        PTLS_ECH_STATE_ACCEPTED,
+        PTLS_ECH_STATE_GREASE
+    } state;
     uint8_t config_id;
     ptls_hpke_kem_t *kem;
     ptls_hpke_cipher_suite_t *cipher;
@@ -2305,7 +2312,7 @@ static int encode_client_hello(ptls_context_t *ctx, ptls_buffer_t *sendbuf, enum
                 buffer_push_extension(sendbuf, PTLS_EXTENSION_TYPE_PRE_SHARED_KEY, {
                     ptls_buffer_push_block(sendbuf, 2, {
                         ptls_buffer_push_block(sendbuf, 2, {
-                            if (mode == ENCODE_CH_MODE_OUTER && !ech->offered_grease) {
+                            if (mode == ENCODE_CH_MODE_OUTER && ech->state != PTLS_ECH_STATE_GREASE) {
                                 if ((ret = ptls_buffer_reserve(sendbuf, psk_identity.len)) != 0)
                                     goto Exit;
                                 ctx->random_bytes(sendbuf->base + sendbuf->off, psk_identity.len);
@@ -2315,7 +2322,7 @@ static int encode_client_hello(ptls_context_t *ctx, ptls_buffer_t *sendbuf, enum
                             }
                         });
                         uint32_t age;
-                        if (mode == ENCODE_CH_MODE_OUTER && !ech->offered_grease) {
+                        if (mode == ENCODE_CH_MODE_OUTER && ech->state != PTLS_ECH_STATE_GREASE) {
                             ctx->random_bytes(&age, sizeof(age));
                         } else {
                             age = obfuscated_ticket_age;
@@ -2397,7 +2404,7 @@ static int send_client_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptls_
                 /* zero-length config indicates ECH greasing */
                 client_setup_ech_grease(&tls->ech, tls->ctx->random_bytes, tls->ctx->ech.client.kems, tls->ctx->ech.client.ciphers,
                                         sni_name);
-                tls->ech.offered_grease = 1;
+                tls->ech.state = PTLS_ECH_STATE_GREASE;
             }
         }
     }
@@ -2561,10 +2568,10 @@ static int send_client_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptls_
             memcpy(tls->ech.client.first_ech.base,
                    emitter->buf->base + ech_size_offset - outer_ech_header_size(tls->ech.client.enc.len), len);
             tls->ech.client.first_ech.len = len;
-            if (!tls->ech.offered_grease)
-                tls->ech.offered = 1;
+            if (tls->ech.state != PTLS_ECH_STATE_GREASE)
+                tls->ech.state = PTLS_ECH_STATE_OFFERED;
         }
-        if (tls->ech.offered_grease) {
+        if (tls->ech.state == PTLS_ECH_STATE_GREASE) {
             /* For grease ECH, the server sees the outer CH. Discard the inner state and adopt the outer, then compute the PSK
              * binder over the outer CH using the standard flow. */
             for (size_t i = 0; i < tls->key_schedule->num_hashes; ++i) {
@@ -2723,7 +2730,7 @@ static int decode_server_hello(ptls_t *tls, struct st_ptls_server_hello_t *sh, c
                               break;
                           case PTLS_EXTENSION_TYPE_ENCRYPTED_CLIENT_HELLO:
                               assert(sh->is_retry_request);
-                              if (!(tls->ech.offered || tls->ech.offered_grease)) {
+                              if (tls->ech.state == PTLS_ECH_STATE_NONE) {
                                   ret = PTLS_ALERT_UNSUPPORTED_EXTENSION;
                                   goto Exit;
                               }
@@ -2824,9 +2831,11 @@ static int client_ech_select_hello(ptls_t *tls, ptls_iovec_t message, size_t con
         if ((ret = ech_calc_confirmation(tls->key_schedule, confirm_hash_expected, tls->ech.inner_client_random, label, message)) !=
             0)
             goto Exit;
-        tls->ech.accepted = ptls_mem_equal(confirm_hash_delivered, confirm_hash_expected, sizeof(confirm_hash_delivered));
+        tls->ech.state = ptls_mem_equal(confirm_hash_delivered, confirm_hash_expected, sizeof(confirm_hash_delivered))
+                             ? PTLS_ECH_STATE_ACCEPTED
+                             : PTLS_ECH_STATE_OFFERED;
         memcpy(message.base + confirm_hash_off, confirm_hash_delivered, sizeof(confirm_hash_delivered));
-        if (tls->ech.accepted)
+        if (tls->ech.state == PTLS_ECH_STATE_ACCEPTED)
             goto Exit;
     }
 
@@ -2836,8 +2845,8 @@ static int client_ech_select_hello(ptls_t *tls, ptls_iovec_t message, size_t con
     key_schedule_select_outer(tls->key_schedule);
 
 Exit:
-    PTLS_PROBE(ECH_SELECTION, tls, !!tls->ech.accepted);
-    PTLS_LOG_CONN(ech_selection, tls, { PTLS_LOG_ELEMENT_BOOL(is_ech, tls->ech.accepted); });
+    PTLS_PROBE(ECH_SELECTION, tls, tls->ech.state == PTLS_ECH_STATE_ACCEPTED);
+    PTLS_LOG_CONN(ech_selection, tls, { PTLS_LOG_ELEMENT_BOOL(is_ech, tls->ech.state == PTLS_ECH_STATE_ACCEPTED); });
     ptls_clear_memory(confirm_hash_expected, sizeof(confirm_hash_expected));
     return ret;
 }
@@ -2863,11 +2872,9 @@ static int client_handle_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptl
         key_schedule_transform_post_ch1hash(tls->key_schedule);
         if (tls->ech.aead != NULL) {
             size_t confirm_hash_off = 0;
-            if (tls->ech.offered) {
+            if (tls->ech.state != PTLS_ECH_STATE_GREASE) {
                 if (sh.retry_request.ech != NULL)
                     confirm_hash_off = sh.retry_request.ech - message.base;
-            } else {
-                assert(tls->ech.offered_grease);
             }
             if ((ret = client_ech_select_hello(tls, message, confirm_hash_off, ECH_CONFIRMATION_HRR)) != 0)
                 goto Exit;
@@ -2883,11 +2890,9 @@ static int client_handle_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptl
     /* check if ECH is accepted */
     if (tls->ech.aead != NULL) {
         size_t confirm_hash_off = 0;
-        if (tls->ech.offered) {
+        if (tls->ech.state != PTLS_ECH_STATE_GREASE) {
             confirm_hash_off =
                 PTLS_HANDSHAKE_HEADER_SIZE + 2 /* legacy_version */ + PTLS_HELLO_RANDOM_SIZE - PTLS_ECH_CONFIRM_LENGTH;
-        } else {
-            assert(tls->ech.offered_grease);
         }
         if ((ret = client_ech_select_hello(tls, message, confirm_hash_off, ECH_CONFIRMATION_SERVER_HELLO)) != 0)
             goto Exit;
@@ -3036,7 +3041,7 @@ static int client_handle_encrypted_extensions(ptls_t *tls, ptls_iovec_t message,
             break;
         case PTLS_EXTENSION_TYPE_ENCRYPTED_CLIENT_HELLO: {
             /* accept retry_configs only if we offered ECH (or grease) but rejected */
-            if (!((tls->ech.offered || tls->ech.offered_grease) && !ptls_is_ech_handshake(tls, NULL, NULL, NULL))) {
+            if (!(tls->ech.state == PTLS_ECH_STATE_OFFERED || tls->ech.state == PTLS_ECH_STATE_GREASE)) {
                 ret = PTLS_ALERT_UNSUPPORTED_EXTENSION;
                 goto Exit;
             }
@@ -3044,7 +3049,7 @@ static int client_handle_encrypted_extensions(ptls_t *tls, ptls_iovec_t message,
             struct st_decoded_ech_config_t decoded;
             if ((ret = client_decode_ech_config_list(tls->ctx, &decoded, ptls_iovec_init(src, end - src))) != 0)
                 goto Exit;
-            if (tls->ech.offered_grease) {
+            if (tls->ech.state == PTLS_ECH_STATE_GREASE) {
                 /* GREASE clients ignore retry_configs after verifying the syntax */
             } else if (decoded.kem != NULL && decoded.cipher != NULL && properties != NULL &&
                        properties->client.ech.retry_configs != NULL) {
@@ -3315,7 +3320,7 @@ static int handle_certificate(ptls_t *tls, const uint8_t *src, const uint8_t *en
     if (tls->ctx->verify_certificate != NULL) {
         const char *server_name = NULL;
         if (!ptls_is_server(tls)) {
-            if (tls->ech.offered && !ptls_is_ech_handshake(tls, NULL, NULL, NULL)) {
+            if (tls->ech.state == PTLS_ECH_STATE_OFFERED) {
                 server_name = tls->ech.client.public_name;
             } else {
                 server_name = tls->server_name;
@@ -3486,7 +3491,7 @@ static int server_handle_certificate_verify(ptls_t *tls, ptls_iovec_t message)
 static int client_handle_finished(ptls_t *tls, ptls_message_emitter_t *emitter, ptls_iovec_t message)
 {
     uint8_t send_secret[PTLS_MAX_DIGEST_SIZE];
-    int alert_ech_required = tls->ech.offered && !ptls_is_ech_handshake(tls, NULL, NULL, NULL), ret;
+    int alert_ech_required = tls->ech.state == PTLS_ECH_STATE_OFFERED, ret;
 
     if ((ret = verify_finished(tls, message)) != 0)
         goto Exit;
@@ -4431,7 +4436,7 @@ static int server_handle_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptl
             goto Exit;
         }
         if (!is_second_flight)
-            tls->ech.offered = 1;
+            tls->ech.state = PTLS_ECH_STATE_OFFERED;
         /* obtain AEAD context for opening inner CH */
         if (!is_second_flight && ch->ech.payload.base != NULL && tls->ctx->ech.server.create_opener != NULL) {
             if ((tls->ech.aead = tls->ctx->ech.server.create_opener->cb(
@@ -4454,7 +4459,7 @@ static int server_handle_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptl
             memset(ech.ch_outer_aad + (ch->ech.payload.base - (message.base + PTLS_HANDSHAKE_HEADER_SIZE)), 0, ch->ech.payload.len);
             if (ptls_aead_decrypt(tls->ech.aead, ech.encoded_ch_inner, ch->ech.payload.base, ch->ech.payload.len, is_second_flight,
                                   ech.ch_outer_aad, message.len - PTLS_HANDSHAKE_HEADER_SIZE) != SIZE_MAX) {
-                tls->ech.accepted = 1;
+                tls->ech.state = PTLS_ECH_STATE_ACCEPTED;
                 /* successfully decrypted EncodedCHInner, build CHInner */
                 if ((ret = rebuild_ch_inner(&ech.ch_inner, ech.encoded_ch_inner,
                                             ech.encoded_ch_inner + ch->ech.payload.len - tls->ech.aead->algo->tag_size, ch,
@@ -4482,7 +4487,7 @@ static int server_handle_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptl
                 tls->ech.aead = NULL;
             }
         }
-    } else if (tls->ech.offered) {
+    } else if (tls->ech.state != PTLS_ECH_STATE_NONE) {
         assert(is_second_flight);
         ret = PTLS_ALERT_ILLEGAL_PARAMETER;
         goto Exit;
@@ -4856,7 +4861,7 @@ static int server_handle_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptl
             if (tls->pending_handshake_secret != NULL)
                 buffer_push_extension(sendbuf, PTLS_EXTENSION_TYPE_EARLY_DATA, {});
             /* send ECH retry_configs, if ECH was offered by rejected, even though we (the server) could have accepted ECH */
-            if (tls->ech.offered && !ptls_is_ech_handshake(tls, NULL, NULL, NULL) && tls->ctx->ech.server.create_opener != NULL &&
+            if (tls->ech.state == PTLS_ECH_STATE_OFFERED && tls->ctx->ech.server.create_opener != NULL &&
                 tls->ctx->ech.server.retry_configs.len != 0)
                 buffer_push_extension(sendbuf, PTLS_EXTENSION_TYPE_ENCRYPTED_CLIENT_HELLO, {
                     ptls_buffer_pushv(sendbuf, tls->ctx->ech.server.retry_configs.base, tls->ctx->ech.server.retry_configs.len);
@@ -5622,7 +5627,7 @@ int ptls_is_psk_handshake(ptls_t *tls)
 
 int ptls_is_ech_handshake(ptls_t *tls, uint8_t *config_id, ptls_hpke_kem_t **kem, ptls_hpke_cipher_suite_t **cipher)
 {
-    if (tls->ech.accepted) {
+    if (tls->ech.state == PTLS_ECH_STATE_ACCEPTED) {
         if (config_id != NULL)
             *config_id = tls->ech.config_id;
         if (kem != NULL)

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -2831,12 +2831,16 @@ static int client_ech_select_hello(ptls_t *tls, ptls_iovec_t message, size_t con
         if ((ret = ech_calc_confirmation(tls->key_schedule, confirm_hash_expected, tls->ech.inner_client_random, label, message)) !=
             0)
             goto Exit;
-        tls->ech.state = ptls_mem_equal(confirm_hash_delivered, confirm_hash_expected, sizeof(confirm_hash_delivered))
-                             ? PTLS_ECH_STATE_ACCEPTED
-                             : PTLS_ECH_STATE_OFFERED;
+        int accepted = ptls_mem_equal(confirm_hash_delivered, confirm_hash_expected, sizeof(confirm_hash_delivered));
         memcpy(message.base + confirm_hash_off, confirm_hash_delivered, sizeof(confirm_hash_delivered));
-        if (tls->ech.state == PTLS_ECH_STATE_ACCEPTED)
+        if (accepted) {
+            tls->ech.state = PTLS_ECH_STATE_ACCEPTED;
             goto Exit;
+        } else if (tls->ech.state == PTLS_ECH_STATE_ACCEPTED) {
+            /* Per RFC 9849 Section 6.1.5: if HRR confirmed ECH acceptance, ServerHello MUST also confirm it. */
+            ret = PTLS_ALERT_ILLEGAL_PARAMETER;
+            goto Exit;
+        }
     }
 
     /* dispose ECH AEAD state to indicate rejection, adopting outer CH for the rest of the handshake */

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -2400,8 +2400,8 @@ static int send_client_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptls_
                     if ((ret = client_setup_ech(&tls->ech, &decoded, tls->ctx->random_bytes)) != 0)
                         goto Exit;
                 }
-            } else {
-                /* zero-length config indicates ECH greasing */
+            } else if (properties->client.ech.configs.base != NULL) {
+                /* zero-length config with non-NULL base indicates ECH greasing; NULL base means no ECH */
                 client_setup_ech_grease(&tls->ech, tls->ctx->random_bytes, tls->ctx->ech.client.kems, tls->ctx->ech.client.ciphers,
                                         sni_name);
                 tls->ech.state = PTLS_ECH_STATE_GREASE;

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -1194,6 +1194,13 @@ static void client_setup_ech_grease(struct st_ptls_ech_t *ech, void (*random_byt
     if (ech->kem == NULL || ech->cipher == NULL)
         goto Fail;
 
+    /* aead is generated from random */
+    {
+        uint8_t random_secret[PTLS_AES128_KEY_SIZE + PTLS_AES_IV_SIZE];
+        random_bytes(random_secret, sizeof(random_secret));
+        ech->aead = ptls_aead_new_direct(ech->cipher->aead, 1, random_secret, random_secret + PTLS_AES128_KEY_SIZE);
+    }
+
     /* `enc` is random bytes */
     if ((ech->client.enc.base = malloc(x25519_key_size)) == NULL)
         goto Fail;
@@ -2300,7 +2307,7 @@ static int encode_client_hello(ptls_context_t *ctx, ptls_buffer_t *sendbuf, enum
                 buffer_push_extension(sendbuf, PTLS_EXTENSION_TYPE_PRE_SHARED_KEY, {
                     ptls_buffer_push_block(sendbuf, 2, {
                         ptls_buffer_push_block(sendbuf, 2, {
-                            if (mode == ENCODE_CH_MODE_OUTER) {
+                            if (mode == ENCODE_CH_MODE_OUTER && !ech->offered_grease) {
                                 if ((ret = ptls_buffer_reserve(sendbuf, psk_identity.len)) != 0)
                                     goto Exit;
                                 ctx->random_bytes(sendbuf->base + sendbuf->off, psk_identity.len);
@@ -2310,7 +2317,7 @@ static int encode_client_hello(ptls_context_t *ctx, ptls_buffer_t *sendbuf, enum
                             }
                         });
                         uint32_t age;
-                        if (mode == ENCODE_CH_MODE_OUTER) {
+                        if (mode == ENCODE_CH_MODE_OUTER && !ech->offered_grease) {
                             ctx->random_bytes(&age, sizeof(age));
                         } else {
                             age = obfuscated_ticket_age;
@@ -2333,68 +2340,6 @@ static int encode_client_hello(ptls_context_t *ctx, ptls_buffer_t *sendbuf, enum
     });
 
 Exit:
-    return ret;
-}
-
-static int build_grease_ech_extension(ptls_context_t *ctx, struct st_ptls_ech_t *ech, ptls_iovec_t *dst,
-                                      ptls_handshake_properties_t *properties, const void *client_random,
-                                      ptls_key_exchange_context_t *key_share_ctx, const char *sni_name,
-                                      ptls_iovec_t legacy_session_id, ptls_iovec_t psk_secret, ptls_iovec_t psk_identity,
-                                      uint32_t obfuscated_ticket_age, size_t psk_binder_size, ptls_iovec_t *cookie,
-                                      int using_early_data)
-{
-    ptls_buffer_t chbuf, extbuf;
-    int ret;
-
-    *dst = ptls_iovec_init(NULL, 0);
-    ptls_buffer_init(&chbuf, "", 0);
-    ptls_buffer_init(&extbuf, "", 0);
-
-    if ((ret = encode_client_hello(ctx, &chbuf, ENCODE_CH_MODE_INNER, 0, properties, client_random, key_share_ctx, sni_name,
-                                   legacy_session_id, ech, NULL, ptls_iovec_init(NULL, 0), psk_secret, psk_identity,
-                                   obfuscated_ticket_age, psk_binder_size, cookie, using_early_data)) != 0)
-        goto Exit;
-
-    { /* pad as if this were EncodedClientHelloInner */
-        size_t padding_len;
-        if (sni_name != NULL) {
-            padding_len = strlen(sni_name);
-            if (padding_len < ech->client.max_name_length)
-                padding_len = ech->client.max_name_length;
-        } else {
-            padding_len = ech->client.max_name_length + 9;
-        }
-        size_t final_len = chbuf.off - PTLS_HANDSHAKE_HEADER_SIZE + padding_len;
-        final_len = (final_len + 31) / 32 * 32;
-        padding_len = final_len - (chbuf.off - PTLS_HANDSHAKE_HEADER_SIZE);
-        if (padding_len != 0) {
-            if ((ret = ptls_buffer_reserve(&chbuf, padding_len)) != 0)
-                goto Exit;
-            memset(chbuf.base + chbuf.off, 0, padding_len);
-            chbuf.off += padding_len;
-        }
-    }
-
-    size_t payload_len = chbuf.off - PTLS_HANDSHAKE_HEADER_SIZE + ech->cipher->aead->tag_size;
-    ptls_buffer_push(&extbuf, PTLS_ECH_CLIENT_HELLO_TYPE_OUTER);
-    ptls_buffer_push16(&extbuf, ech->cipher->id.kdf);
-    ptls_buffer_push16(&extbuf, ech->cipher->id.aead);
-    ptls_buffer_push(&extbuf, ech->config_id);
-    ptls_buffer_push_block(&extbuf, 2, { ptls_buffer_pushv(&extbuf, ech->client.enc.base, ech->client.enc.len); });
-    ptls_buffer_push_block(&extbuf, 2, {
-        if ((ret = ptls_buffer_reserve(&extbuf, payload_len)) != 0)
-            goto Exit;
-        ctx->random_bytes(extbuf.base + extbuf.off, payload_len);
-        extbuf.off += payload_len;
-    });
-
-    *dst = ptls_iovec_init(extbuf.base, extbuf.off);
-    extbuf = (ptls_buffer_t){0};
-    ret = 0;
-
-Exit:
-    ptls_buffer_dispose(&chbuf);
-    ptls_buffer_dispose(&extbuf);
     return ret;
 }
 
@@ -2517,14 +2462,6 @@ static int send_client_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptls_
             goto Exit;
     }
 
-    if (tls->ech.offered_grease && !is_second_flight && tls->ech.client.first_ech.base == NULL) {
-        if ((ret = build_grease_ech_extension(tls->ctx, &tls->ech, &tls->ech.client.first_ech, properties, tls->client_random,
-                                              tls->client.key_share_ctx, sni_name, tls->client.legacy_session_id, psk.secret,
-                                              psk.identity, obfuscated_ticket_age, tls->key_schedule->hashes[0].algo->digest_size,
-                                              cookie, tls->client.using_early_data)) != 0)
-            goto Exit;
-    }
-
     /* start generating CH */
     if ((ret = emitter->begin_message(emitter)) != 0)
         goto Exit;
@@ -2607,10 +2544,34 @@ static int send_client_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptls_
             memcpy(tls->ech.client.first_ech.base,
                    emitter->buf->base + ech_size_offset - outer_ech_header_size(tls->ech.client.enc.len), len);
             tls->ech.client.first_ech.len = len;
-            tls->ech.offered = 1;
+            if (!tls->ech.offered_grease)
+                tls->ech.offered = 1;
         }
-        /* update hash */
-        ptls__key_schedule_update_hash(tls->key_schedule, emitter->buf->base + mess_start, emitter->buf->off - mess_start, 1);
+        if (tls->ech.offered_grease) {
+            /* For grease ECH, the server sees the outer CH. Discard the inner state and adopt the outer, then compute the PSK
+             * binder over the outer CH using the standard flow. */
+            for (size_t i = 0; i < tls->key_schedule->num_hashes; ++i) {
+                tls->key_schedule->hashes[i].ctx->final(tls->key_schedule->hashes[i].ctx, NULL, PTLS_HASH_FINAL_MODE_FREE);
+                tls->key_schedule->hashes[i].ctx = tls->key_schedule->hashes[i].ctx_outer;
+                tls->key_schedule->hashes[i].ctx_outer = NULL;
+            }
+            ptls_aead_free(tls->ech.aead);
+            tls->ech.aead = NULL;
+            if (psk.secret.base != NULL) {
+                size_t psk_binder_off = emitter->buf->off - (3 + tls->key_schedule->hashes[0].algo->digest_size);
+                ptls__key_schedule_update_hash(tls->key_schedule, emitter->buf->base + mess_start, psk_binder_off - mess_start, 0);
+                if ((ret = calc_verify_data(emitter->buf->base + psk_binder_off + 3, tls->key_schedule, binder_key)) != 0)
+                    goto Exit;
+                ptls__key_schedule_update_hash(tls->key_schedule, emitter->buf->base + psk_binder_off,
+                                               emitter->buf->off - psk_binder_off, 0);
+            } else {
+                ptls__key_schedule_update_hash(tls->key_schedule, emitter->buf->base + mess_start, emitter->buf->off - mess_start,
+                                               0);
+            }
+        } else {
+            /* update outer hash */
+            ptls__key_schedule_update_hash(tls->key_schedule, emitter->buf->base + mess_start, emitter->buf->off - mess_start, 1);
+        }
     }
 
     /* commit CH to the record layer */

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -2343,6 +2343,28 @@ Exit:
     return ret;
 }
 
+/**
+ * Feeds the CH message into the hash, computing the PSK binder if necessary. `binder_key` must be derived before calling this
+ * function.
+ */
+static int update_ch_hash_and_binder(ptls_key_schedule_t *ks, uint8_t *ch, size_t ch_start, size_t ch_end, int has_psk,
+                                     uint8_t *binder_key, int is_outer)
+{
+    int ret = 0;
+    size_t hash_off = ch_start;
+
+    if (has_psk) {
+        size_t psk_binder_off = ch_end - (3 + ks->hashes[0].algo->digest_size);
+        ptls__key_schedule_update_hash(ks, ch + hash_off, psk_binder_off - hash_off, is_outer);
+        hash_off = psk_binder_off;
+        if ((ret = calc_verify_data(ch + psk_binder_off + 3, ks, binder_key)) != 0)
+            return ret;
+    }
+    ptls__key_schedule_update_hash(ks, ch + hash_off, ch_end - hash_off, is_outer);
+
+    return ret;
+}
+
 static int send_client_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptls_handshake_properties_t *properties,
                              ptls_iovec_t *cookie)
 {
@@ -2353,7 +2375,7 @@ static int send_client_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptls_
     } psk = {{NULL}};
     uint32_t obfuscated_ticket_age = 0;
     const char *sni_name = NULL;
-    size_t mess_start, msghash_off;
+    size_t mess_start;
     uint8_t binder_key[PTLS_MAX_DIGEST_SIZE];
     ptls_buffer_t encoded_ch_inner;
     int ret, is_second_flight = tls->key_schedule != NULL;
@@ -2465,7 +2487,7 @@ static int send_client_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptls_
     /* start generating CH */
     if ((ret = emitter->begin_message(emitter)) != 0)
         goto Exit;
-    mess_start = msghash_off = emitter->buf->off;
+    mess_start = emitter->buf->off;
 
     /* generate true (inner) CH */
     if ((ret = encode_client_hello(tls->ctx, emitter->buf, ENCODE_CH_MODE_INNER, is_second_flight, properties,
@@ -2477,15 +2499,12 @@ static int send_client_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptls_
 
     /* update the message hash, filling in the PSK binder HMAC if necessary */
     if (psk.secret.base != NULL) {
-        size_t psk_binder_off = emitter->buf->off - (3 + tls->key_schedule->hashes[0].algo->digest_size);
         if ((ret = derive_secret_with_empty_digest(tls->key_schedule, binder_key, psk.label)) != 0)
             goto Exit;
-        ptls__key_schedule_update_hash(tls->key_schedule, emitter->buf->base + msghash_off, psk_binder_off - msghash_off, 0);
-        msghash_off = psk_binder_off;
-        if ((ret = calc_verify_data(emitter->buf->base + psk_binder_off + 3, tls->key_schedule, binder_key)) != 0)
-            goto Exit;
     }
-    ptls__key_schedule_update_hash(tls->key_schedule, emitter->buf->base + msghash_off, emitter->buf->off - msghash_off, 0);
+    if ((ret = update_ch_hash_and_binder(tls->key_schedule, emitter->buf->base, mess_start, emitter->buf->off,
+                                         psk.secret.base != NULL, binder_key, 0)) != 0)
+        goto Exit;
 
     /* ECH */
     if (tls->ech.aead != NULL) {
@@ -2557,17 +2576,9 @@ static int send_client_hello(ptls_t *tls, ptls_message_emitter_t *emitter, ptls_
             }
             ptls_aead_free(tls->ech.aead);
             tls->ech.aead = NULL;
-            if (psk.secret.base != NULL) {
-                size_t psk_binder_off = emitter->buf->off - (3 + tls->key_schedule->hashes[0].algo->digest_size);
-                ptls__key_schedule_update_hash(tls->key_schedule, emitter->buf->base + mess_start, psk_binder_off - mess_start, 0);
-                if ((ret = calc_verify_data(emitter->buf->base + psk_binder_off + 3, tls->key_schedule, binder_key)) != 0)
-                    goto Exit;
-                ptls__key_schedule_update_hash(tls->key_schedule, emitter->buf->base + psk_binder_off,
-                                               emitter->buf->off - psk_binder_off, 0);
-            } else {
-                ptls__key_schedule_update_hash(tls->key_schedule, emitter->buf->base + mess_start, emitter->buf->off - mess_start,
-                                               0);
-            }
+            if ((ret = update_ch_hash_and_binder(tls->key_schedule, emitter->buf->base, mess_start, emitter->buf->off,
+                                                     psk.secret.base != NULL, binder_key, 0)) != 0)
+                goto Exit;
         } else {
             /* update outer hash */
             ptls__key_schedule_update_hash(tls->key_schedule, emitter->buf->base + mess_start, emitter->buf->off - mess_start, 1);

--- a/t/picotls.c
+++ b/t/picotls.c
@@ -1635,6 +1635,69 @@ static void test_ech_config_mismatch(void)
     free(retry_configs.base);
 }
 
+/* Per RFC 9849 §6.1.5, if the HRR confirmed ECH acceptance, the ServerHello MUST also confirm it. Here we force HRR, let the
+ * server accept ECH in the HRR, then flip the ECH confirmation bits in the SH and check that the client aborts with
+ * illegal_parameter. */
+static void test_ech_hrr_accept_sh_reject(void)
+{
+    ptls_t *client, *server;
+    ptls_buffer_t cbuf, sbuf;
+    size_t consumed;
+    int ret;
+    ptls_handshake_properties_t client_hs_prop = {
+        .client = {
+            .ech.configs = ptls_iovec_init(ECH_CONFIG_LIST, sizeof(ECH_CONFIG_LIST) - 1),
+            .negotiate_before_key_exchange = 1, /* force HRR */
+        }};
+
+    client = ptls_new(ctx, 0);
+    ptls_set_server_name(client, "test.example.com", 0);
+    server = ptls_new(ctx_peer, 1);
+    ptls_buffer_init(&cbuf, "", 0);
+    ptls_buffer_init(&sbuf, "", 0);
+
+    /* CH1 */
+    ret = ptls_handshake(client, &cbuf, NULL, NULL, &client_hs_prop);
+    ok(ret == PTLS_ERROR_IN_PROGRESS);
+
+    /* CH1 -> HRR */
+    consumed = cbuf.off;
+    ret = ptls_handshake(server, &sbuf, cbuf.base, &consumed, NULL);
+    ok(ret == PTLS_ERROR_IN_PROGRESS);
+    ok(cbuf.off == consumed);
+    cbuf.off = 0;
+
+    /* HRR -> CH2 (client transitions to ECH_STATE_ACCEPTED via HRR confirmation) */
+    consumed = sbuf.off;
+    ret = ptls_handshake(client, &cbuf, sbuf.base, &consumed, &client_hs_prop);
+    ok(ret == PTLS_ERROR_IN_PROGRESS);
+    ok(sbuf.off == consumed);
+    sbuf.off = 0;
+
+    /* CH2 -> SH + ... */
+    consumed = cbuf.off;
+    ret = ptls_handshake(server, &sbuf, cbuf.base, &consumed, NULL);
+    ok(ret == 0);
+    ok(cbuf.off == consumed);
+    cbuf.off = 0;
+
+    /* Corrupt last 8 bytes of SH.random (the ECH confirmation signal). SH record layout:
+     * [5 record hdr][1 hs_type=0x02][3 hs len][2 legacy_ver][32 random]... -> bytes 35..42 */
+    ok(sbuf.off >= 43 && sbuf.base[0] == 0x16 && sbuf.base[5] == 0x02);
+    for (size_t i = 35; i < 43; ++i)
+        sbuf.base[i] ^= 0xff;
+
+    /* Corrupted SH -> client MUST abort with illegal_parameter. */
+    consumed = sbuf.off;
+    ret = ptls_handshake(client, &cbuf, sbuf.base, &consumed, &client_hs_prop);
+    ok(ret == PTLS_ALERT_ILLEGAL_PARAMETER);
+
+    ptls_free(client);
+    ptls_free(server);
+    ptls_buffer_dispose(&cbuf);
+    ptls_buffer_dispose(&sbuf);
+}
+
 static void do_test_pre_shared_key(int mode)
 {
     ptls_context_t ctx_client = *ctx;
@@ -2147,6 +2210,7 @@ static void test_all_handshakes(void)
             test_client_ech_configs = ptls_iovec_init(ECH_CONFIG_LIST, sizeof(ECH_CONFIG_LIST) - 1);
         }
         subtest("ech-config-mismatch", test_ech_config_mismatch);
+        subtest("ech-hrr-accept-sh-reject", test_ech_hrr_accept_sh_reject);
         test_client_ech_configs = ptls_iovec_init(NULL, 0);
     }
 

--- a/t/picotls.c
+++ b/t/picotls.c
@@ -846,7 +846,11 @@ enum test_ech_mode {
     TEST_ECH_GREASE
 };
 
-static enum test_ech_mode test_client_ech_mode = TEST_ECH_REAL;
+/**
+ * Sentinel value for `ctx->ech.client.ciphers` indicating grease mode. `get_test_ech_mode` recognizes this pointer and returns
+ * `TEST_ECH_GREASE`. Contains a single cipher entry sufficient for `client_setup_ech_grease`.
+ */
+static ptls_hpke_cipher_suite_t *grease_ciphers[2];
 
 enum {
     TEST_HANDSHAKE_1RTT,
@@ -870,7 +874,9 @@ static enum test_ech_mode get_test_ech_mode(ptls_context_t *ctx, int is_server)
     } else {
         if (ctx->ech.client.ciphers == NULL)
             return TEST_ECH_NONE;
-        return test_client_ech_mode;
+        if (ctx->ech.client.ciphers == grease_ciphers)
+            return TEST_ECH_GREASE;
+        return TEST_ECH_REAL;
     }
 }
 
@@ -1432,16 +1438,21 @@ static void test_resumption(int different_preferred_key_share, int require_clien
 static void test_grease_resumption(void)
 {
     ptls_ech_create_opener_t *orig_create_opener = ctx_peer->ech.server.create_opener;
+    ptls_hpke_cipher_suite_t **orig_ciphers = ctx->ech.client.ciphers;
 
     if (get_test_ech_mode(ctx, 0) == TEST_ECH_NONE)
         return;
 
+    /* populate grease_ciphers (once) with a single entry from the real list */
+    if (grease_ciphers[0] == NULL)
+        grease_ciphers[0] = orig_ciphers[0];
+
     ctx_peer->ech.server.create_opener = NULL;
-    test_client_ech_mode = TEST_ECH_GREASE;
+    ctx->ech.client.ciphers = grease_ciphers;
 
     test_resumption(0, 0);
 
-    test_client_ech_mode = TEST_ECH_REAL;
+    ctx->ech.client.ciphers = orig_ciphers;
     ctx_peer->ech.server.create_opener = orig_create_opener;
 }
 

--- a/t/picotls.c
+++ b/t/picotls.c
@@ -840,6 +840,14 @@ static int save_client_hello(ptls_on_client_hello_t *self, ptls_t *tls, ptls_on_
     return 0;
 }
 
+enum test_ech_mode {
+    TEST_ECH_NONE,
+    TEST_ECH_REAL,
+    TEST_ECH_GREASE
+};
+
+static enum test_ech_mode test_client_ech_mode = TEST_ECH_REAL;
+
 enum {
     TEST_HANDSHAKE_1RTT,
     TEST_HANDSHAKE_2RTT,
@@ -855,12 +863,14 @@ static int on_extension_cb(ptls_on_extension_t *self, ptls_t *tls, uint8_t hstyp
     return 0;
 }
 
-static int can_ech(ptls_context_t *ctx, int is_server)
+static enum test_ech_mode get_test_ech_mode(ptls_context_t *ctx, int is_server)
 {
     if (is_server) {
-        return ctx->ech.server.create_opener != NULL;
+        return ctx->ech.server.create_opener != NULL ? TEST_ECH_REAL : TEST_ECH_NONE;
     } else {
-        return ctx->ech.client.ciphers != NULL;
+        if (ctx->ech.client.ciphers == NULL)
+            return TEST_ECH_NONE;
+        return test_client_ech_mode;
     }
 }
 
@@ -940,9 +950,17 @@ static void test_handshake(ptls_iovec_t ticket, int mode, int expect_ticket, int
         ptls_set_server_name(client, "test.example.com", 0);
     }
 
-    if (can_ech(ctx, 0)) {
+    switch (get_test_ech_mode(ctx, 0)) {
+    case TEST_ECH_REAL:
         ptls_set_server_name(client, "test.example.com", 0);
         client_hs_prop.client.ech.configs = ptls_iovec_init(ECH_CONFIG_LIST, sizeof(ECH_CONFIG_LIST) - 1);
+        break;
+    case TEST_ECH_GREASE:
+        ptls_set_server_name(client, "test.example.com", 0);
+        client_hs_prop.client.ech.configs = ptls_iovec_init("", 0);
+        break;
+    default:
+        break;
     }
 
     static ptls_on_extension_t cb = {on_extension_cb};
@@ -1016,7 +1034,7 @@ static void test_handshake(ptls_iovec_t ticket, int mode, int expect_ticket, int
     ok(sbuf.off != 0);
     if (check_ch) {
         ok(ptls_get_server_name(server) != NULL);
-        if (can_ech(ctx, 0) && !can_ech(ctx_peer, 1)) {
+        if (get_test_ech_mode(ctx, 0) != TEST_ECH_NONE && get_test_ech_mode(ctx_peer, 1) == TEST_ECH_NONE) {
             /* server should be using CHouter.sni that includes the public name of the ECH extension */
             ok(strcmp(ptls_get_server_name(server), "example.com") == 0);
         } else {
@@ -1174,7 +1192,7 @@ static void test_handshake(ptls_iovec_t ticket, int mode, int expect_ticket, int
     }
 
     /* original_server is used for the server-side checks because handshake data is never migrated */
-    if (can_ech(ctx_peer, 1) && can_ech(ctx, 0)) {
+    if (get_test_ech_mode(ctx_peer, 1) != TEST_ECH_NONE && get_test_ech_mode(ctx, 0) == TEST_ECH_REAL) {
         ok(ptls_is_ech_handshake(client, NULL, NULL, NULL));
         ok(ptls_is_ech_handshake(original_server, NULL, NULL, NULL));
     } else {
@@ -1409,6 +1427,24 @@ static void test_resumption(int different_preferred_key_share, int require_clien
     subtest("basic", test_resumption_impl, different_preferred_key_share, require_client_authentication, 0, 0);
     subtest("transfer-session", test_resumption_impl, different_preferred_key_share, require_client_authentication, 0, 1);
     subtest("ticket-request", test_resumption_impl, different_preferred_key_share, require_client_authentication, 1, 0);
+}
+
+static void test_grease_resumption(void)
+{
+    ptls_ech_create_opener_t *orig_create_opener = ctx_peer->ech.server.create_opener;
+
+    if (get_test_ech_mode(ctx, 0) == TEST_ECH_NONE)
+        return;
+
+    ctx_peer->ech.server.create_opener = NULL;
+    test_client_ech_mode = TEST_ECH_GREASE;
+
+    subtest("basic", test_resumption_impl, 0, 0, 0, 0);
+    subtest("transfer-session", test_resumption_impl, 0, 0, 0, 1);
+    subtest("ticket-request", test_resumption_impl, 0, 0, 1, 0);
+
+    test_client_ech_mode = TEST_ECH_REAL;
+    ctx_peer->ech.server.create_opener = orig_create_opener;
 }
 
 static void test_async_sign_certificate(void)
@@ -2088,15 +2124,17 @@ static void test_all_handshakes_core(void)
     subtest("full-handshake+client-auth", test_full_handshake_with_client_authentication);
     subtest("hrr-handshake", test_hrr_handshake);
     /* resumption does not work when the client offers ECH but the server does not recognize that */
-    if (!(can_ech(ctx, 0) && !can_ech(ctx_peer, 1))) {
+    if (!(get_test_ech_mode(ctx, 0) != TEST_ECH_NONE && get_test_ech_mode(ctx_peer, 1) == TEST_ECH_NONE)) {
         subtest("resumption", test_resumption, 0, 0);
         if (ctx != ctx_peer)
             subtest("resumption-different-preferred-key-share", test_resumption, 1, 0);
         subtest("resumption-with-client-authentication", test_resumption, 0, 1);
     }
+    if (get_test_ech_mode(ctx, 0) != TEST_ECH_NONE)
+        subtest("resumption-with-grease", test_grease_resumption);
     subtest("async-sign-certificate", test_async_sign_certificate);
     subtest("enforce-retry-stateful", test_enforce_retry_stateful);
-    if (!(can_ech(ctx_peer, 1) && can_ech(ctx, 0))) {
+    if (!(get_test_ech_mode(ctx_peer, 1) != TEST_ECH_NONE && get_test_ech_mode(ctx, 0) != TEST_ECH_NONE)) {
         subtest("hrr-stateless-handshake", test_hrr_stateless_handshake);
         subtest("enforce-retry-stateless", test_enforce_retry_stateless);
         subtest("stateless-hrr-aad-change", test_stateless_hrr_aad_change);
@@ -2130,7 +2168,7 @@ static void test_all_handshakes(void)
     ctx_peer->ech.server.create_opener = orig_ech.create_opener;
     ctx->ech.client.ciphers = orig_ech.client_ciphers;
 
-    if (can_ech(ctx_peer, 1) && can_ech(ctx, 0)) {
+    if (get_test_ech_mode(ctx_peer, 1) != TEST_ECH_NONE && get_test_ech_mode(ctx, 0) != TEST_ECH_NONE) {
         subtest("ech", test_all_handshakes_core);
         if (ctx != ctx_peer) {
             ctx->ech.client.ciphers = NULL;

--- a/t/picotls.c
+++ b/t/picotls.c
@@ -1439,9 +1439,7 @@ static void test_grease_resumption(void)
     ctx_peer->ech.server.create_opener = NULL;
     test_client_ech_mode = TEST_ECH_GREASE;
 
-    subtest("basic", test_resumption_impl, 0, 0, 0, 0);
-    subtest("transfer-session", test_resumption_impl, 0, 0, 0, 1);
-    subtest("ticket-request", test_resumption_impl, 0, 0, 1, 0);
+    test_resumption(0, 0);
 
     test_client_ech_mode = TEST_ECH_REAL;
     ctx_peer->ech.server.create_opener = orig_create_opener;

--- a/t/picotls.c
+++ b/t/picotls.c
@@ -840,17 +840,10 @@ static int save_client_hello(ptls_on_client_hello_t *self, ptls_t *tls, ptls_on_
     return 0;
 }
 
-enum test_ech_mode {
-    TEST_ECH_NONE,
-    TEST_ECH_REAL,
-    TEST_ECH_GREASE
-};
-
 /**
- * Sentinel value for `ctx->ech.client.ciphers` indicating grease mode. `get_test_ech_mode` recognizes this pointer and returns
- * `TEST_ECH_GREASE`. Contains a single cipher entry sufficient for `client_setup_ech_grease`.
+ * What ECH configs the client should send. `base == NULL` means no ECH, `len == 0` means grease, `len > 0` means real ECH.
  */
-static ptls_hpke_cipher_suite_t *grease_ciphers[2];
+static ptls_iovec_t test_client_ech_configs = {NULL};
 
 enum {
     TEST_HANDSHAKE_1RTT,
@@ -865,19 +858,6 @@ static int on_extension_cb(ptls_on_extension_t *self, ptls_t *tls, uint8_t hstyp
 {
     assert(extdata.base);
     return 0;
-}
-
-static enum test_ech_mode get_test_ech_mode(ptls_context_t *ctx, int is_server)
-{
-    if (is_server) {
-        return ctx->ech.server.create_opener != NULL ? TEST_ECH_REAL : TEST_ECH_NONE;
-    } else {
-        if (ctx->ech.client.ciphers == NULL)
-            return TEST_ECH_NONE;
-        if (ctx->ech.client.ciphers == grease_ciphers)
-            return TEST_ECH_GREASE;
-        return TEST_ECH_REAL;
-    }
 }
 
 static void check_clone(ptls_t *src, ptls_t *dest)
@@ -956,17 +936,9 @@ static void test_handshake(ptls_iovec_t ticket, int mode, int expect_ticket, int
         ptls_set_server_name(client, "test.example.com", 0);
     }
 
-    switch (get_test_ech_mode(ctx, 0)) {
-    case TEST_ECH_REAL:
+    if (test_client_ech_configs.base != NULL) {
         ptls_set_server_name(client, "test.example.com", 0);
-        client_hs_prop.client.ech.configs = ptls_iovec_init(ECH_CONFIG_LIST, sizeof(ECH_CONFIG_LIST) - 1);
-        break;
-    case TEST_ECH_GREASE:
-        ptls_set_server_name(client, "test.example.com", 0);
-        client_hs_prop.client.ech.configs = ptls_iovec_init("", 0);
-        break;
-    default:
-        break;
+        client_hs_prop.client.ech.configs = test_client_ech_configs;
     }
 
     static ptls_on_extension_t cb = {on_extension_cb};
@@ -1040,7 +1012,7 @@ static void test_handshake(ptls_iovec_t ticket, int mode, int expect_ticket, int
     ok(sbuf.off != 0);
     if (check_ch) {
         ok(ptls_get_server_name(server) != NULL);
-        if (get_test_ech_mode(ctx, 0) != TEST_ECH_NONE && get_test_ech_mode(ctx_peer, 1) == TEST_ECH_NONE) {
+        if (test_client_ech_configs.base != NULL && ctx_peer->ech.server.create_opener == NULL) {
             /* server should be using CHouter.sni that includes the public name of the ECH extension */
             ok(strcmp(ptls_get_server_name(server), "example.com") == 0);
         } else {
@@ -1198,7 +1170,7 @@ static void test_handshake(ptls_iovec_t ticket, int mode, int expect_ticket, int
     }
 
     /* original_server is used for the server-side checks because handshake data is never migrated */
-    if (get_test_ech_mode(ctx_peer, 1) != TEST_ECH_NONE && get_test_ech_mode(ctx, 0) == TEST_ECH_REAL) {
+    if (ctx_peer->ech.server.create_opener != NULL && test_client_ech_configs.len > 0) {
         ok(ptls_is_ech_handshake(client, NULL, NULL, NULL));
         ok(ptls_is_ech_handshake(original_server, NULL, NULL, NULL));
     } else {
@@ -1438,21 +1410,14 @@ static void test_resumption(int different_preferred_key_share, int require_clien
 static void test_grease_resumption(void)
 {
     ptls_ech_create_opener_t *orig_create_opener = ctx_peer->ech.server.create_opener;
-    ptls_hpke_cipher_suite_t **orig_ciphers = ctx->ech.client.ciphers;
-
-    if (get_test_ech_mode(ctx, 0) == TEST_ECH_NONE)
-        return;
-
-    /* populate grease_ciphers (once) with a single entry from the real list */
-    if (grease_ciphers[0] == NULL)
-        grease_ciphers[0] = orig_ciphers[0];
+    ptls_iovec_t orig_configs = test_client_ech_configs;
 
     ctx_peer->ech.server.create_opener = NULL;
-    ctx->ech.client.ciphers = grease_ciphers;
+    test_client_ech_configs = ptls_iovec_init("", 0);
 
     test_resumption(0, 0);
 
-    ctx->ech.client.ciphers = orig_ciphers;
+    test_client_ech_configs = orig_configs;
     ctx_peer->ech.server.create_opener = orig_create_opener;
 }
 
@@ -2133,17 +2098,17 @@ static void test_all_handshakes_core(void)
     subtest("full-handshake+client-auth", test_full_handshake_with_client_authentication);
     subtest("hrr-handshake", test_hrr_handshake);
     /* resumption does not work when the client offers ECH but the server does not recognize that */
-    if (!(get_test_ech_mode(ctx, 0) != TEST_ECH_NONE && get_test_ech_mode(ctx_peer, 1) == TEST_ECH_NONE)) {
+    if (!(test_client_ech_configs.base != NULL && ctx_peer->ech.server.create_opener == NULL)) {
         subtest("resumption", test_resumption, 0, 0);
         if (ctx != ctx_peer)
             subtest("resumption-different-preferred-key-share", test_resumption, 1, 0);
         subtest("resumption-with-client-authentication", test_resumption, 0, 1);
     }
-    if (get_test_ech_mode(ctx, 0) != TEST_ECH_NONE)
+    if (test_client_ech_configs.base != NULL)
         subtest("resumption-with-grease", test_grease_resumption);
     subtest("async-sign-certificate", test_async_sign_certificate);
     subtest("enforce-retry-stateful", test_enforce_retry_stateful);
-    if (!(get_test_ech_mode(ctx_peer, 1) != TEST_ECH_NONE && get_test_ech_mode(ctx, 0) != TEST_ECH_NONE)) {
+    if (!(ctx_peer->ech.server.create_opener != NULL && test_client_ech_configs.base != NULL)) {
         subtest("hrr-stateless-handshake", test_hrr_stateless_handshake);
         subtest("enforce-retry-stateless", test_enforce_retry_stateless);
         subtest("stateless-hrr-aad-change", test_stateless_hrr_aad_change);
@@ -2165,26 +2130,24 @@ static void test_all_handshakes(void)
         ctx->sign_certificate = &client_sc;
     }
 
-    struct {
-        ptls_ech_create_opener_t *create_opener;
-        ptls_hpke_cipher_suite_t **client_ciphers;
-    } orig_ech = {ctx_peer->ech.server.create_opener, ctx->ech.client.ciphers};
+    ptls_ech_create_opener_t *orig_create_opener = ctx_peer->ech.server.create_opener;
+    int client_supports_ech = ctx->ech.client.ciphers != NULL;
 
     /* first run tests wo. ECH */
     ctx_peer->ech.server.create_opener = NULL;
-    ctx->ech.client.ciphers = NULL;
     subtest("no-ech", test_all_handshakes_core);
-    ctx_peer->ech.server.create_opener = orig_ech.create_opener;
-    ctx->ech.client.ciphers = orig_ech.client_ciphers;
+    ctx_peer->ech.server.create_opener = orig_create_opener;
 
-    if (get_test_ech_mode(ctx_peer, 1) != TEST_ECH_NONE && get_test_ech_mode(ctx, 0) != TEST_ECH_NONE) {
+    if (orig_create_opener != NULL && client_supports_ech) {
+        test_client_ech_configs = ptls_iovec_init(ECH_CONFIG_LIST, sizeof(ECH_CONFIG_LIST) - 1);
         subtest("ech", test_all_handshakes_core);
         if (ctx != ctx_peer) {
-            ctx->ech.client.ciphers = NULL;
+            test_client_ech_configs = ptls_iovec_init(NULL, 0);
             subtest("ech (server-only)", test_all_handshakes_core);
-            ctx->ech.client.ciphers = orig_ech.client_ciphers;
+            test_client_ech_configs = ptls_iovec_init(ECH_CONFIG_LIST, sizeof(ECH_CONFIG_LIST) - 1);
         }
         subtest("ech-config-mismatch", test_ech_config_mismatch);
+        test_client_ech_configs = ptls_iovec_init(NULL, 0);
     }
 
     ctx_peer->sign_certificate = sc_orig;

--- a/t/picotls.c
+++ b/t/picotls.c
@@ -1698,6 +1698,52 @@ static void test_ech_hrr_accept_sh_reject(void)
     ptls_buffer_dispose(&sbuf);
 }
 
+static int ech_ext_seen_in_ch;
+static int observe_ech_extension(ptls_on_extension_t *self, ptls_t *tls, uint8_t hstype, uint16_t exttype, ptls_iovec_t extdata)
+{
+    /* PTLS_EXTENSION_TYPE_ENCRYPTED_CLIENT_HELLO is 0xfe0d (not exposed in picotls.h). */
+    if (hstype == PTLS_HANDSHAKE_TYPE_CLIENT_HELLO && exttype == 0xfe0d)
+        ech_ext_seen_in_ch = 1;
+    return 0;
+}
+
+/* When handshake_properties is supplied with client.ech.configs = {NULL, 0}, the client must NOT send an ECH extension
+ * (neither real ECH nor grease), even when the context has ECH ciphers configured. This matches what picotls.h documents. */
+static void test_ech_null_configs_no_ech(void)
+{
+    ptls_t *client, *server;
+    ptls_buffer_t cbuf, sbuf;
+    size_t consumed;
+    int ret;
+    ptls_handshake_properties_t client_hs_prop = {{{{NULL}}}}; /* configs.base == NULL */
+    ptls_on_extension_t observer = {observe_ech_extension};
+    ptls_on_extension_t *orig_observer = ctx_peer->on_extension;
+
+    ech_ext_seen_in_ch = 0;
+    ctx_peer->on_extension = &observer;
+
+    client = ptls_new(ctx, 0);
+    ptls_set_server_name(client, "test.example.com", 0);
+    server = ptls_new(ctx_peer, 1);
+    ptls_buffer_init(&cbuf, "", 0);
+    ptls_buffer_init(&sbuf, "", 0);
+
+    ret = ptls_handshake(client, &cbuf, NULL, NULL, &client_hs_prop);
+    ok(ret == PTLS_ERROR_IN_PROGRESS);
+
+    consumed = cbuf.off;
+    ret = ptls_handshake(server, &sbuf, cbuf.base, &consumed, NULL);
+    /* server should progress (either still in handshake or complete); what matters is that it observed no ECH ext */
+    ok(ret == PTLS_ERROR_IN_PROGRESS || ret == 0);
+    ok(!ech_ext_seen_in_ch);
+
+    ctx_peer->on_extension = orig_observer;
+    ptls_free(client);
+    ptls_free(server);
+    ptls_buffer_dispose(&cbuf);
+    ptls_buffer_dispose(&sbuf);
+}
+
 static void do_test_pre_shared_key(int mode)
 {
     ptls_context_t ctx_client = *ctx;
@@ -2211,6 +2257,7 @@ static void test_all_handshakes(void)
         }
         subtest("ech-config-mismatch", test_ech_config_mismatch);
         subtest("ech-hrr-accept-sh-reject", test_ech_hrr_accept_sh_reject);
+        subtest("ech-null-configs-no-ech", test_ech_null_configs_no_ech);
         test_client_ech_configs = ptls_iovec_init(NULL, 0);
     }
 


### PR DESCRIPTION
## Summary
Three client-side ECH bugs, each with a regression test:

1. GREASE ECH prevented 0-RTT session resumption against non-ECH servers.
2. Per RFC 9849 §6.1.5, a HelloRetryRequest that confirmed ECH followed by a
   ServerHello that does not confirm must abort with `illegal_parameter`;
   picotls silently fell back to the outer ClientHello.
3. `handshake_properties.client.ech.configs = {NULL, 0}` should disable ECH
   (as `picotls.h` documents), but the client was still sending GREASE.

## Details
- **grease 0-RTT, closes #576**: GREASE reused the real-ECH inner/outer
  PSK path, randomizing the outer PSK identity/binder and breaking resumption.
  Refactored to send a normal resumption-capable ClientHello with a dummy but
  syntactically valid ECH extension, matching RFC 9849 §6.2.1.
- **HRR/SH consistency**: `client_ech_select_hello` demoted the post-HRR
  `ACCEPTED` state back to `OFFERED` on an SH confirmation mismatch. It now
  aborts with `PTLS_ALERT_ILLEGAL_PARAMETER`.
- **NULL configs**: the grease branch triggered on `configs.len == 0`
  regardless of `.base`. Added the missing `configs.base != NULL` gate so the
  default zero-initialized `handshake_properties` does not force GREASE.

Plus internal cleanup: the three ECH bit fields collapsed into a single state
enum, test-harness config handling simplified, and binder computation
deduplicated.

## Validation
`build/default/test-openssl.t` — all 17 subtests pass. Each fix has a
dedicated regression test that fails without its corresponding code change.

Closes #576.