### PR TITLE
mbedtls: ED25519 algorithm mapping rejects imported keys

### DIFF
--- a/lib/mbedtls_sign.c
+++ b/lib/mbedtls_sign.c
@@ -403,6 +403,7 @@ int ptls_mbedtls_set_available_schemes(ptls_mbedtls_sign_certificate_t *signer)
         }
         break;
     case PSA_ALG_ED25519PH:
+    case PSA_ALG_PURE_EDDSA:
         signer->schemes = ed25519_signature_schemes;
         break;
     default:


### PR DESCRIPTION
Imported PKCS8 Ed25519 private keys are assigned `PSA_ALG_PURE_EDDSA` during load, but scheme selection only recognizes `PSA_ALG_ED25519PH` for Ed25519.

As a result, Ed25519 keys are rejected instead of being exposed as usable signing certificates.