### PR TITLE
optionally emit conn_id if supplied, to help cross-layer tracing

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -1466,6 +1466,9 @@ typedef struct st_ptls_log_getsni_t {
             break;                                                                                                                 \
         PTLS_LOG__DO_LOG(picotls, name, conn_state, ptls_log_getsni_ptls(_tls), 1, {                                               \
             PTLS_LOG_ELEMENT_PTR(tls, _tls);                                                                                       \
+            if (conn_state->conn_id != 0) {                                                                                        \
+                PTLS_LOG_ELEMENT_UNSIGNED(conn_id, conn_state->conn_id);                                                           \
+            }                                                                                                                      \
             do {                                                                                                                   \
                 block                                                                                                              \
             } while (0);                                                                                                           \
@@ -1550,6 +1553,10 @@ typedef struct st_ptls_log_conn_state_t {
      * represents the peer address using ipv6; ipv4 addresses are stored using the mapped form (::ffff:192.0.2.1)
      */
     uint8_t address[16];
+    /**
+     * application-supplied identifier; emitted as `conn_id` if set to a non-zero value
+     */
+    uint64_t conn_id;
     struct st_ptls_log_state_t state;
 } ptls_log_conn_state_t;
 
@@ -1577,9 +1584,10 @@ extern struct st_ptls_log_t {
 } ptls_log;
 
 /**
- * initializes a ptls_log_conn_state_t
+ * initializes a ptls_log_conn_state_t. `conn_id` and `peeraddr` (of type struct sockaddr) are optional; pass 0 and NULL
+ * respectively when unavailable.
  */
-void ptls_log_init_conn_state(ptls_log_conn_state_t *state, void (*random_bytes)(void *, size_t));
+void ptls_log_init_conn_state(ptls_log_conn_state_t *state, void (*random_bytes)(void *, size_t), uint64_t conn_id, void *peeraddr);
 /**
  * forces recalculation of the log state (should be called when SNI is determined)
  */

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -5203,7 +5203,7 @@ static ptls_t *new_instance(ptls_context_t *ctx, int is_server)
     if (ptls_log_conn_state_override != NULL) {
         tls->log_state = *ptls_log_conn_state_override;
     } else {
-        ptls_log_init_conn_state(&tls->log_state, ctx->random_bytes);
+        ptls_log_init_conn_state(&tls->log_state, ctx->random_bytes, 0, NULL);
     }
 #endif
 
@@ -7196,15 +7196,29 @@ int ptls_log__do_write_end(struct st_ptls_log_point_t *point, struct st_ptls_log
 
 #endif
 
-void ptls_log_init_conn_state(ptls_log_conn_state_t *state, void (*random_bytes)(void *, size_t))
+void ptls_log_init_conn_state(ptls_log_conn_state_t *state, void (*random_bytes)(void *, size_t), uint64_t conn_id, void *_peeraddr)
 {
+    struct sockaddr *peeraddr = _peeraddr;
     uint32_t r;
     random_bytes(&r, sizeof(r));
 
     *state = (ptls_log_conn_state_t){
         .random_ = (float)r / ((uint64_t)UINT32_MAX + 1), /* [0..1), so that any(r) < sample_ratio where sample_ratio is [0..1] */
         .address = {0}, /* inaddr6_any */
+        .conn_id = conn_id,
     };
+    if (peeraddr != NULL) {
+        switch (peeraddr->sa_family) {
+        case AF_INET: /* store as v6-mapped v4 address */
+            ptls_build_v4_mapped_v6_address(state->address, &((struct sockaddr_in *)peeraddr)->sin_addr);
+            break;
+        case AF_INET6:
+            memcpy(state->address, ((struct sockaddr_in6 *)peeraddr)->sin6_addr.s6_addr, sizeof(state->address));
+            break;
+        default:
+            break;
+        }
+    }
 }
 
 size_t ptls_log_num_lost(void)


### PR DESCRIPTION
Log points now emit "conn_id", if supplied from the layers above.

To facilitate such use and reduce code duplication, `prls_log_init_state` has been extended to accept optional parameters.