### PR TITLE
drop macOS/openssl1.1 from the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,6 @@ jobs:
         include:
           - name: "macOS / OpenSSL 3.x"
             openssl: openssl@3
-          - name: "macOS / OpenSSL 1.1.x"
-            openssl: openssl@1.1
           - name: "macOS / LibreSSL"
             openssl: libressl
 


### PR DESCRIPTION
The cask no longer exists on homebrew.