### PR TITLE
Revert change to reject zero-length SNI

### DIFF
--- a/include/picotls.h
+++ b/include/picotls.h
@@ -2050,7 +2050,7 @@ inline void ptls_buffer_init(ptls_buffer_t *buf, void *smallbuf, size_t smallbuf
 inline void ptls_buffer_dispose(ptls_buffer_t *buf)
 {
     ptls_buffer__release_memory(buf);
-    *buf = (ptls_buffer_t){NULL, 0, 0, 0, 0};
+    memset(buf, 0, sizeof(*buf));
 }
 
 inline uint8_t *ptls_encode_quicint(uint8_t *p, uint64_t v)

--- a/include/picotls.h
+++ b/include/picotls.h
@@ -1423,7 +1423,8 @@ typedef struct st_ptls_log_getsni_t {
     }                                                                                                                              \
     static inline ptls_log_getsni_t ptls_log_getsni_##suffix(type arg)                                                             \
     {                                                                                                                              \
-        return (ptls_log_getsni_t){ptls_log_getsni_cb_##suffix, arg};                                                              \
+        ptls_log_getsni_t ret = {ptls_log_getsni_cb_##suffix, arg};                                                                \
+        return ret;                                                                                                                \
     }
 
 #if PTLS_HAVE_LOG

--- a/lib/picotls.c
+++ b/lib/picotls.c
@@ -3606,10 +3606,9 @@ static int client_hello_decode_server_name(ptls_iovec_t *name, const uint8_t **s
             ptls_decode_open_block(*src, end, 2, {
                 switch (type) {
                 case PTLS_SERVER_NAME_TYPE_HOSTNAME:
-                    if (end - *src == 0) {
-                        ret = PTLS_ALERT_DECODE_ERROR;
-                        goto Exit;
-                    }
+                    /* Twingate: upstream (h2o/picotls #603) rejects a zero-length HostName per RFC 6066. Our clients have always
+                     * sent an empty SNI for direct connections, so treat it as "no SNI" as picotls did before #603; rejecting it
+                     * breaks every already-deployed client. */
                     if (memchr(*src, '\0', end - *src) != 0) {
                         ret = PTLS_ALERT_ILLEGAL_PARAMETER;
                         goto Exit;

--- a/picotlsvs/picotls/wincompat.h
+++ b/picotlsvs/picotls/wincompat.h
@@ -2,7 +2,8 @@
 #define WINCOMPAT_H
 
 #include <stdint.h>
-#define ssize_t int
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
 #include <Winsock2.h>
 #include <ws2tcpip.h>
 #include <malloc.h>


### PR DESCRIPTION
The following PR enforces the RFC rule to reject zero-length SNI:
https://github.com/h2o/picotls/pull/603

However, this would break backwards compatibility if one side still sends such a field.